### PR TITLE
Add sustainability data/error handling for ETF/MF

### DIFF
--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -446,14 +446,14 @@ class Ticker():
 
         url = '%s/%s/%s' % (self._scrape_url, self.ticker, kind)
         data = _pd.read_html(_requests.get(url=url, proxies=proxy).text)[0]
+        if kind == 'sustainability': return data
 
         data.columns = [''] + list(data[:1].values[0][1:])
         data.set_index('', inplace=True)
         for col in data.columns:
             data[col] = _np.where(data[col] == '-', _np.nan, data[col])
-        if len(data.columns) != 1:
-          idx = data[data[data.columns[0]] == data[data.columns[1]]].index
-          data.loc[idx] = '-'
+        idx = data[data[data.columns[0]] == data[data.columns[1]]].index
+        data.loc[idx] = '-'
         return data[1:]
 
     def get_financials(self, proxy=None):

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -445,7 +445,8 @@ class Ticker():
         """
 
         url = '%s/%s/%s' % (self._scrape_url, self.ticker, kind)
-        data = _pd.read_html(_requests.get(url=url, proxies=proxy).text)[0]
+        try: data = _pd.read_html(_requests.get(url=url, proxies=proxy).text)[0]
+        except ValueError: return None
         if kind == 'sustainability': return data
 
         data.columns = [''] + list(data[:1].values[0][1:])

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -109,6 +109,7 @@ class Ticker():
         self._financials = None
         self._balance_sheet = None
         self._cashflow = None
+        self._sustainability = None
         self._scrape_url = 'https://finance.yahoo.com/quote'
         self._expirations = {}
 
@@ -450,9 +451,9 @@ class Ticker():
         data.set_index('', inplace=True)
         for col in data.columns:
             data[col] = _np.where(data[col] == '-', _np.nan, data[col])
-
-        idx = data[data[data.columns[0]] == data[data.columns[1]]].index
-        data.loc[idx] = '-'
+        if len(data.columns) != 1:
+          idx = data[data[data.columns[0]] == data[data.columns[1]]].index
+          data.loc[idx] = '-'
         return data[1:]
 
     def get_financials(self, proxy=None):
@@ -472,6 +473,12 @@ class Ticker():
             self._cashflow = self._get_fundamentals(
                 'cash-flow', proxy)
         return self._cashflow
+
+    def get_sustainability(self, proxy=None):
+        if self._sustainability is None:
+            self._sustainability = self._get_fundamentals(
+                'sustainability', proxy)
+        return self._sustainability
 
     # ------------------------
 
@@ -503,6 +510,9 @@ class Ticker():
     def cashflow(self):
         return self.get_cashflow()
 
+    @property
+    def sustainability(self):
+        return self.get_sustainability()
 
 @_multitasking.task
 def _download_one_threaded(ticker, start=None, end=None, auto_adjust=False,


### PR DESCRIPTION
New addition for sustainability data - very straightforward table to collect, however, as it has only a simple table with yes/no values, it should not try to deal with the extra numeric columns so a small fix is needed there which will make the get_fundamentals do less work as the table requires no processing.

Also mutual funds and ETFs have no financials, cash flow or balance sheet but it will cause an error to be thrown which is not gracefully handled such as by returning None or an empty list.

Note that pandas will require dependencies for (pip install) html5lib and BeautifulSoup4 before it throws this error since no HTML table is present.  Alternative is to from lxml import html, and use xpath('//table') == [] but try except seems more appropriate and less explicit dependencies (though 2 implicit ones as mentioned).

Other places where invalid tickers are specified should be checked.

The new ESG data also is handled by the change.  esgPopulated in the ticker info unfortunately is always false right now despite the data often being present.