### PR TITLE
Fix errors that can occur with partial data

### DIFF
--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -454,16 +454,17 @@ class Ticker():
         try:
             data = _pd.read_html(_requests.get(url=url, proxies=proxy).text)[0]
         except ValueError:
-            return None
+            return lambda : None
         if kind == 'sustainability':
             data['Significant Involvement'] = data[
                 'Significant Involvement'] != 'No'
-            return data
+            return lambda : data
 
         data.columns = [''] + list(data[:1].values[0][1:])
         data.set_index('', inplace=True)
         for col in data.columns:
             data[col] = _np.where(data[col] == '-', _np.nan, data[col])
+        if len(data.columns) < 2: return lambda : None
         idx = data[data[data.columns[0]] == data[data.columns[1]]].index
         data.loc[idx] = '-'
         return data[1:]

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -454,17 +454,17 @@ class Ticker():
         try:
             data = _pd.read_html(_requests.get(url=url, proxies=proxy).text)[0]
         except ValueError:
-            return lambda : None
+            return None
         if kind == 'sustainability':
             data['Significant Involvement'] = data[
                 'Significant Involvement'] != 'No'
-            return lambda : data
+            return data
 
         data.columns = [''] + list(data[:1].values[0][1:])
         data.set_index('', inplace=True)
         for col in data.columns:
             data[col] = _np.where(data[col] == '-', _np.nan, data[col])
-        if len(data.columns) < 2: return lambda : None
+        if len(data.columns) < 2: return None
         idx = data[data[data.columns[0]] == data[data.columns[1]]].index
         data.loc[idx] = '-'
         return data[1:]


### PR DESCRIPTION
Tested and working.

Try in current version (stock with no cash flow, financial or balance sheet data which is in the S&P500!):
tick = yf.Ticker('ABMD')
tick.cashflow()

Before, it will crash since it returns only the description column, and no data but there is still a table.

tick = yf.Ticker('VTI')
tick.cashflow()

will test the case for an ETF which has no table and gives ValueError.  These are 2 very common and easy to reproduce error scenarios (this latter one fixed in previous PR).