### PR TITLE
Fix default rounding issue

### DIFF
--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -277,7 +277,7 @@ class Ticker():
 
     def history(self, period="1mo", interval="1d",
                 start=None, end=None, prepost=False, actions=True,
-                auto_adjust=True, proxy=None, rounding=False):
+                auto_adjust=True, proxy=None, rounding=True):
         """
         :Parameters:
             period : str


### PR DESCRIPTION
Fix #105, default rounding to False is not ideal as generally expectation is correct price data.  Though this is a matter of opinion, it certainly seems from use cases that this is a poor default especially given the margin of error in the floats returned.