### PR TITLE
Bugfix, add _expirations to base

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -48,6 +48,7 @@ class TickerBase():
         self._sustainability = None
         self._recommendations = None
         self._calendar = None
+        self._expirations = {}
 
         self._earnings = {
             "yearly": utils.empty_df(),


### PR DESCRIPTION
new commits today seemed to break example code,
code run from colab, versions at the bottom

```
import yfinance as yf
yf.__version__
msft = yf.Ticker("MSFT")
# get stock info
msft.info
# get historical market data
hist = msft.history(period="max")
# show actions (dividends, splits)
msft.actions
# show dividends
msft.dividends
# show splits
msft.splits
# show financials
msft.financials
msft.quarterly_financials
# show balance heet
msft.balance_sheet
msft.quarterly_balance_sheet
# show cashflow
msft.cashflow
msft.quarterly_cashflow
# show earnings
msft.earnings
msft.quarterly_earnings
# show sustainability
msft.sustainability
# show analysts recommendations
msft.recommendations
# show next event (earnings, etc)
msft.calendar
# show options expirations
msft.options
```
```
/usr/local/lib/python3.6/dist-packages/pandas/core/ops/__init__.py:1115: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  result = method(y)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-b6cf2c10b4fb> in <module>()
     42 
     43 # show options expirations
---> 44 msft.options

/usr/local/lib/python3.6/dist-packages/yfinance/ticker.py in options(self)
    176     @property
    177     def options(self):
--> 178         if not self._expirations:
    179             self._download_options()
    180         return tuple(self._expirations.keys())

AttributeError: 'Ticker' object has no attribute '_expirations'
```

Requirement already up-to-date: yfinance in /usr/local/lib/python3.6/dist-packages (0.1.46)
Requirement already satisfied, skipping upgrade: requests>=2.20 in /usr/local/lib/python3.6/dist-packages (from yfinance) (2.21.0)
Requirement already satisfied, skipping upgrade: multitasking>=0.0.7 in /usr/local/lib/python3.6/dist-packages (from yfinance) (0.0.9)
Requirement already satisfied, skipping upgrade: numpy>=1.15 in /usr/local/lib/python3.6/dist-packages (from yfinance) (1.17.3)
Requirement already satisfied, skipping upgrade: pandas>=0.24 in /usr/local/lib/python3.6/dist-packages (from yfinance) (0.25.2)
Requirement already satisfied, skipping upgrade: certifi>=2017.4.17 in /usr/local/lib/python3.6/dist-packages (from requests>=2.20->yfinance) (2019.9.11)
Requirement already satisfied, skipping upgrade: idna<2.9,>=2.5 in /usr/local/lib/python3.6/dist-packages (from requests>=2.20->yfinance) (2.8)
Requirement already satisfied, skipping upgrade: chardet<3.1.0,>=3.0.2 in /usr/local/lib/python3.6/dist-packages (from requests>=2.20->yfinance) (3.0.4)
Requirement already satisfied, skipping upgrade: urllib3<1.25,>=1.21.1 in /usr/local/lib/python3.6/dist-packages (from requests>=2.20->yfinance) (1.24.3)
Requirement already satisfied, skipping upgrade: python-dateutil>=2.6.1 in /usr/local/lib/python3.6/dist-packages (from pandas>=0.24->yfinance) (2.6.1)
Requirement already satisfied, skipping upgrade: pytz>=2017.2 in /usr/local/lib/python3.6/dist-packages (from pandas>=0.24->yfinance) (2018.9)
Requirement already satisfied, skipping upgrade: six>=1.5 in /usr/local/lib/python3.6/dist-packages (from python-dateutil>=2.6.1->pandas>=0.24->yfinance) (1.12.0)