### PR TITLE
Fix empty esgScores

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -261,7 +261,7 @@ class TickerBase():
 
         # sustainability
         d = {}
-        if data['esgScores']:
+        if data.get('esgScores'):
             for item in data['esgScores']:
                 if not isinstance(data['esgScores'][item], dict):
                     d[item] = data['esgScores'][item]

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -261,7 +261,7 @@ class TickerBase():
 
         # sustainability
         d = {}
-        if 'esgScores' in data:
+        if data['esgScores']:
             for item in data['esgScores']:
                 if not isinstance(data['esgScores'][item], dict):
                     d[item] = data['esgScores'][item]


### PR DESCRIPTION
Fix for a bug I've noticed when you try to get info of a ticker without ESG scores

To reproduce using the latest version:
```python
import yfinance as yf
ebro = yf.Ticker('EBRO.MC')
ebro.info
```

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/alex-dev/.venv/<hidden>/lib/python3.8/site-packages/yfinance/ticker.py", line 122, in info
    return self.get_info()
  File "/Users/alex-dev/.venv/<hidden>/lib/python3.8/site-packages/yfinance/base.py", line 360, in get_info
    self._get_fundamentals(proxy)
  File "/Users/alex-dev/.venv/<hidden>/lib/python3.8/site-packages/yfinance/base.py", line 265, in _get_fundamentals
    for item in data['esgScores']:
TypeError: 'NoneType' object is not iterable
```