### PR TITLE
Add more data to info object

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -278,6 +278,7 @@ class TickerBase():
         # info (be nice to python 2)
         self._info = data['summaryProfile']
         self._info.update(data['summaryDetail'])
+        self._info.update(data['quoteType'])
         if isinstance(data['defaultKeyStatistics'], dict):
             self._info.update(data['defaultKeyStatistics'])
         elif 'assetProfile' in data and isinstance(data['assetProfile'], dict):


### PR DESCRIPTION
Currently there is no way to get the name of the stock or the market in which it operates. I've added to `Ticker.info` all properties from the `quoteType` object returned by Yahoo.

Here is an example of the `quoteType`.
```
{
  "exchange": "NMS",
  "shortName": "Tesla, Inc.",
  "longName": "Tesla, Inc.",
  "exchangeTimezoneName": "America/New_York",
  "exchangeTimezoneShortName": "EDT",
  "isEsgPopulated": True,
  "gmtOffSetMilliseconds": "-14400000",
  "underlyingSymbol": None,
  "quoteType": "EQUITY",
  "symbol": "TSLA",
  "underlyingExchangeSymbol": None,
  "headSymbol": None,
  "messageBoardId": "finmb_27444752",
  "uuid": "ec367bc4-f92c-397c-ac81-bf7b43cffaf7",
  "market": "us_market"
}
```