### PR TITLE
Add test script for release quality case coverage

### DIFF
--- a/yfinance/test.py
+++ b/yfinance/test.py
@@ -1,0 +1,15 @@
+#sanity check for most common library uses all working
+def test_yfinance():
+  #stock Microsoft, ETF Russell 2000 Growth,
+  #mutual fund Vanguard 500 Index fund,
+  #index S&P500, currency BitCoin-US Dollars
+  for x in ['MSFT', 'IWO', 'VFINX', '^GSPC', 'BTC-USD']:
+    tick = yf.Ticker(x)
+    #always should have info and history for valid symbols
+    assert(tick.info != None and tick.info != {})
+    assert(len(tick.history(period="max", rounding=True)) != 0)
+    #following should always gracefully handled, no crashes
+    tick.cashflow
+    tick.balance_sheet
+    tick.financials
+    tick.sustainability


### PR DESCRIPTION
This can be added as a sanity check post-install for making sure the library is working installed correctly with its dependencies, designed to get code coverage in mainstream cases.  It can and should be expanded for code coverage and perhaps other types.