### PR TITLE
Suppress print error kwarg in def history

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -98,10 +98,10 @@ class TickerBase():
                 (default data is returned as non-localized dates)
             **kwargs: dict
                 debug: bool
-                    Optional. If passed as False, will suppress 
+                    Optional. If passed as False, will suppress
                     error message printing to console.
         """
-
+        
         if start or period is None or period.lower() == "max":
             if start is None:
                 start = -2208988800
@@ -147,7 +147,7 @@ class TickerBase():
 
         # Work with errors
         debug_mode = True
-        if "debug" in kwargs and type(kwargs["debug"]) == bool:
+        if "debug" in kwargs and isinstance(kwargs["debug"], bool):
             debug_mode = kwargs["debug"]
 
         err_msg = "No data found for this date range, symbol may be delisted"
@@ -155,7 +155,7 @@ class TickerBase():
             err_msg = data["chart"]["error"]["description"]
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode == True:
+            if "many" not in kwargs and debug_mode is True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -163,7 +163,7 @@ class TickerBase():
                 not data["chart"]["result"]:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode == True:
+            if "many" not in kwargs and debug_mode is True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -173,7 +173,7 @@ class TickerBase():
         except Exception:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode == True:
+            if "many" not in kwargs and debug_mode is True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -96,6 +96,10 @@ class TickerBase():
             tz: str
                 Optional timezone locale for dates.
                 (default data is returned as non-localized dates)
+            **kwargs: dict
+                debug: bool
+                    Optional. If passed as False, will suppress 
+                    error message printing to console.
         """
 
         if start or period is None or period.lower() == "max":
@@ -142,12 +146,16 @@ class TickerBase():
         data = data.json()
 
         # Work with errors
+        debug_mode = True
+        if "debug" in kwargs and type(kwargs["debug"]) == bool:
+            debug_mode = kwargs["debug"]
+
         err_msg = "No data found for this date range, symbol may be delisted"
         if "chart" in data and data["chart"]["error"]:
             err_msg = data["chart"]["error"]["description"]
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs:
+            if "many" not in kwargs and debug_mode == True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -155,7 +163,7 @@ class TickerBase():
                 not data["chart"]["result"]:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs:
+            if "many" not in kwargs and debug_mode == True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -165,7 +173,7 @@ class TickerBase():
         except Exception:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs:
+            if "many" not in kwargs and debug_mode == True:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -101,7 +101,7 @@ class TickerBase():
                     Optional. If passed as False, will suppress
                     error message printing to console.
         """
-        
+
         if start or period is None or period.lower() == "max":
             if start is None:
                 start = -2208988800


### PR DESCRIPTION
This edit makes it possible to optionally suppress printing error messages to the console
in the history function by passing a named parameter "debug" in the **kwargs dict as False.

I made this to handle errors myself and prevent them from jamming up my console, because 
I'm using the console to pass data between two different programming languages and 
I can't have unintended messages flying around there. 

Thought that maybe others would also find this error message suppression feature useful.