### PR TITLE
Fix pandas ValueError for lists in Ticker.info() method

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -263,7 +263,7 @@ class TickerBase():
         d = {}
         if isinstance(data.get('esgScores'), dict):
             for item in data['esgScores']:
-                if not isinstance(data['esgScores'][item], dict):
+                if not isinstance(data['esgScores'][item], (dict, list)):
                     d[item] = data['esgScores'][item]
 
             s = _pd.DataFrame(index=[0], data=d)[-1:].T


### PR DESCRIPTION
I saw that the ticker.info() method results in a Pandas DataFrame error for ticker symbols with list return values longer than 1 (e.g., AAPL returning a 'relatedControversy' key with a list of three values):
https://gist.github.com/liencis/df85238dba2b153f116053bde054a33d

Here I extended the existing filter for nested dictionaries on line 266 of base.py to also filter for the nested lists causing the errors:
https://gist.github.com/liencis/ccd378c095bdfc0212b6ac39a32cc926