### PR TITLE
easyfix for financials url

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -351,7 +351,8 @@ class TickerBase():
             pass
 
         # get fundamentals
-        data = utils.get_json(url+'/financials', proxy)
+        url = "{}/{}/financials".format(self._scrape_url, self.ticker)
+        data = utils.get_json(url, proxy)
 
         # generic patterns
         for key in (


### PR DESCRIPTION
fix financials url (previous url variable refers to the 'holders' url - it should not be reused here)