### PR TITLE
Add lxml package to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas>=0.24
 numpy>=1.15
 requests>=2.21
 multitasking>=0.0.7
+lxml>=4.5.0


### PR DESCRIPTION
When I  installed this via pip, it complained that lxml wasn't found.