### PR TITLE
fix index error when calling ticker's info

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -282,6 +282,10 @@ class TickerBase():
         # holders
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
+        
+        if isinstance(holders, list) and len(holders) == 1 and isinstance(holders[0], _pd.DataFrame):
+            holders = holders[0]
+            
         self._major_holders = holders[0]
         self._institutional_holders = holders[1]
         if 'Date Reported' in self._institutional_holders:


### PR DESCRIPTION
if the holders returned is a list of data frame, we should extract it before using it, otherwise there will be a index error
