### PR TITLE
Change rounding default in Ticker.history

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -75,7 +75,7 @@ class TickerBase():
     def history(self, period="1mo", interval="1d",
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False,
-                proxy=None, rounding=True, tz=None, **kwargs):
+                proxy=None, rounding=False, tz=None, **kwargs):
         """
         :Parameters:
             period : str


### PR DESCRIPTION
Rounding was described in comments as having a default of False, but the definition of the function has rounding set to True. Default in function definition was changed to False to stay consistent with comments