### PR TITLE
Fixes the scrape URL for financial data

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -351,7 +351,8 @@ class TickerBase():
             pass
 
         # get fundamentals
-        data = utils.get_json(url+'/financials', proxy)
+        financials_url = "{}/{}/financials".format(self._scrape_url, self.ticker)
+        data = utils.get_json(financials_url, proxy)
 
         # generic patterns
         for key in (


### PR DESCRIPTION
Hi,

Thanks for the helpful library!

The `url` variable holds the value `https://finance.yahoo.com/quote/TICKER/holders` as set in line [283](https://github.com/ranaroussi/yfinance/blob/master/yfinance/base.py#L283). So the result of line [354](https://github.com/ranaroussi/yfinance/blob/master/yfinance/base.py#L354) is `https://finance.yahoo.com/quote/TICKER/holders/financials` which is incorrect. The code before the changes was not retrieving all the following properties as a result of the incorrect URL:

* `self._cashflow`
* `self._balancesheet`
* `self._financials`
* `self._earnings`

All of the above are retrieved fine after the small change to the URL. Let me know what you think please.

Cheers,
Mo