### PR TITLE
Time zone conversion error in ticker option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
     - master
 
 notifications:
+  slack: tradologics:HcnS6XusfcuS02waQPCG18oc
   webhooks:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always


### PR DESCRIPTION
Previous conversion of datetime column to other time zone did not work. Also maybe consider defaulting to America/New_York. As that is what is used by default for stocks.