### PR TITLE
Download should throw an exception in case if any download task fails

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -91,8 +91,9 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
                                    back_adjust=back_adjust,
                                    progress=(progress and i > 0), proxy=proxy,
                                    rounding=rounding)
-        while len(shared._DFS) < len(tickers):
-            _time.sleep(0.01)
+        _multitasking.wait_for_tasks(sleep=0.01)
+        if len(shared._DFS) < len(tickers):
+            raise Exception("Failed to download tickers: %s" % (", ".join(set(tickers) - set(shared._DFS))))
 
     # download synchronously
     else:


### PR DESCRIPTION
Hi,

There is a problem with download code. If thread/process fails for some reason (net error/parse exception) the below code will never exit and spin in endless loop. `multitasking` lib have no mechanic to pass those exceptions outside (maybe it's a good idea to add such ability) so not-so-bad approach is to wait for all tasks completion and assert for result.

It's a dispute if exception should be thrown or result for whole ticker should be ignored as earlier, but the reason why I decided to thrown exception is because the nature of failure - we know nothing about real data availability so it's better to terminate whole process.

Node: this code relies on pr https://github.com/ranaroussi/multitasking/pull/16