### PR TITLE
Load 'financialData' into info.

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -310,7 +310,7 @@ class TickerBase():
         # info (be nice to python 2)
         self._info = {}
         items = ['summaryProfile', 'summaryDetail', 'quoteType',
-                 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
+                 'defaultKeyStatistics', 'assetProfile', 'financialData']
         for item in items:
             if isinstance(data.get(item), dict):
                 self._info.update(data[item])


### PR DESCRIPTION
Hi, I just think it will be nice to include `financialData` in `info` since it contains things like `currentPrice`, `totalDebt` and `DebtToEquity`. Also btw, it seems like its fetching from `summaryDetail` twice.