### PR TITLE
holders length not always 2 (i.e. Ford stock)

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,13 +283,14 @@ class TickerBase():
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
         self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
-        if 'Date Reported' in self._institutional_holders:
-            self._institutional_holders['Date Reported'] = _pd.to_datetime(
-                self._institutional_holders['Date Reported'])
-        if '% Out' in self._institutional_holders:
-            self._institutional_holders['% Out'] = self._institutional_holders[
-                '% Out'].str.replace('%', '').astype(float)/100
+        if len(holders) > 1:
+            self._institutional_holders = holders[1]
+            if 'Date Reported' in self._institutional_holders:
+                self._institutional_holders['Date Reported'] = _pd.to_datetime(
+                    self._institutional_holders['Date Reported'])
+            if '% Out' in self._institutional_holders:
+                self._institutional_holders['% Out'] = self._institutional_holders[
+                    '% Out'].str.replace('%', '').astype(float)/100
 
         # sustainability
         d = {}


### PR DESCRIPTION
Yahoo Finance doesn't always provide "Top Institutional Holders" data, an example of this would be Ford stock ($F). This results in a "list index out of range" error when calling ".info" on a stock like Ford.
To fix this issue a small if statement was added to check if the stock does have the "Top Institutional Holders" data.