### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,10 +93,10 @@ ticker data in amore Pythonic way:
     msft.quarterly_financials
 
     # show major holders
-    stock.major_holders
+    msft.major_holders
 
     # show institutional holders
-    stock.institutional_holders
+    msft.institutional_holders
 
     # show balance heet
     msft.balance_sheet


### PR DESCRIPTION
stock.major_holders and stock.institutional_holders are aligned with the pattern in the content, such as msft.xxxx