### PR TITLE
Timestamp fix when downloading option chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ yfinance/__pycache__/*
 dist
 yfinance.egg-info
 *.pyc
+*.swp
+*.swo

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -249,7 +249,9 @@ class TickerBase():
 
     def _get_fundamentals(self, kind=None, proxy=None):
         def cleanup(data):
-            df = _pd.DataFrame(data).drop(columns=['maxAge'])
+            df = _pd.DataFrame(data)
+            if 'maxAge' in df:
+                df = df.drop(columns=['maxAge'])
             for col in df.columns:
                 df[col] = _np.where(
                     df[col].astype(str) == '-', _np.nan, df[col])

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -281,20 +281,22 @@ class TickerBase():
 
         # holders
         # url = "{}/{}/holders".format(self._scrape_url, self.ticker)
-        holders = _pd.read_html(url+'/holders')
-        self._major_holders = holders[0]
-        
-        if len(holders) <= 1:
-            self._institutional_holders = None
-        else:
-            self._institutional_holders = holders[1]
-            if 'Date Reported' in self._institutional_holders:
-                self._institutional_holders['Date Reported'] = _pd.to_datetime(
-                    self._institutional_holders['Date Reported'])
-            if '% Out' in self._institutional_holders:
-                self._institutional_holders['% Out'] = self._institutional_holders[
-                    '% Out'].str.replace('%', '').astype(float)/100
-         
+        try:
+            holders = _pd.read_html(url+'/holders')
+            self._major_holders = holders[0]
+
+            if len(holders) <= 1:
+                self._institutional_holders = None
+            else:
+                self._institutional_holders = holders[1]
+                if 'Date Reported' in self._institutional_holders:
+                    self._institutional_holders['Date Reported'] = _pd.to_datetime(
+                        self._institutional_holders['Date Reported'])
+                if '% Out' in self._institutional_holders:
+                    self._institutional_holders['% Out'] = self._institutional_holders[
+                        '% Out'].str.replace('%', '').astype(float)/100
+        except Exception:
+          pass
         # sustainability
         d = {}
         if isinstance(data.get('esgScores'), dict):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -256,7 +256,8 @@ class TickerBase():
                 df[col] = _np.where(
                     df[col].astype(str) == '-', _np.nan, df[col])
 
-            df.set_index('endDate', inplace=True)
+            if 'endDate' in df:
+                df.set_index('endDate', inplace=True)
             try:
                 df.index = _pd.to_datetime(df.index, unit='s')
             except ValueError:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -284,13 +284,17 @@ class TickerBase():
         holders = _pd.read_html(url+'/holders')
         self._major_holders = holders[0]
         
-        if len(holders) > 1:
+        if len(holders) <= 1:
+            self._institutional_holders = None
+        else:
             self._institutional_holders = holders[1]
             if 'Date Reported' in self._institutional_holders:
-                self._institutional_holders['Date Reported'] = _pd.to_datetime(self._institutional_holders['Date Reported'])
+                self._institutional_holders['Date Reported'] = _pd.to_datetime(
+                    self._institutional_holders['Date Reported'])
             if '% Out' in self._institutional_holders:
-                self._institutional_holders['% Out'] = self._institutional_holders['% Out'].str.replace('%', '').astype(float)/100
-        
+                self._institutional_holders['% Out'] = self._institutional_holders[
+                    '% Out'].str.replace('%', '').astype(float)/100
+         
         # sustainability
         d = {}
         if isinstance(data.get('esgScores'), dict):
@@ -504,7 +508,7 @@ class TickerBase():
         search_str = '"{}|'.format(ticker)
         if search_str not in data:
             if q.lower() in data.lower():
-                search_str = '"|'
+                search_str = '"|'.format(ticker)
                 if search_str not in data:
                     self._isin = '-'
                     return self._isin

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -280,8 +280,8 @@ class TickerBase():
         data = utils.get_json(url, proxy)
 
         # holders
-        url = "{}/{}/holders".format(self._scrape_url, self.ticker)
-        holders = _pd.read_html(url)
+        # url = "{}/{}/holders".format(self._scrape_url, self.ticker)
+        holders = _pd.read_html(url+'/holders')
         self._major_holders = holders[0]
         self._institutional_holders = holders[1]
         if 'Date Reported' in self._institutional_holders:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,14 +283,14 @@ class TickerBase():
         # url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url+'/holders')
         self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
-        if 'Date Reported' in self._institutional_holders:
-            self._institutional_holders['Date Reported'] = _pd.to_datetime(
-                self._institutional_holders['Date Reported'])
-        if '% Out' in self._institutional_holders:
-            self._institutional_holders['% Out'] = self._institutional_holders[
-                '% Out'].str.replace('%', '').astype(float)/100
-
+        
+        if len(holders) > 1:
+            self._institutional_holders = holders[1]
+            if 'Date Reported' in self._institutional_holders:
+                self._institutional_holders['Date Reported'] = _pd.to_datetime(self._institutional_holders['Date Reported'])
+            if '% Out' in self._institutional_holders:
+                self._institutional_holders['% Out'] = self._institutional_holders['% Out'].str.replace('%', '').astype(float)/100
+        
         # sustainability
         d = {}
         if isinstance(data.get('esgScores'), dict):

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -56,7 +56,7 @@ class Ticker(TickerBase):
         r = _requests.get(url=url, proxies=proxy).json()
         if r['optionChain']['result']:
             for exp in r['optionChain']['result'][0]['expirationDates']:
-                self._expirations[_datetime.datetime.fromtimestamp(
+                self._expirations[_datetime.datetime.utcfromtimestamp(
                     exp).strftime('%Y-%m-%d')] = exp
             return r['optionChain']['result'][0]['options'][0]
         return {}


### PR DESCRIPTION
If using this code in a timezone other than UTC, timestamp strings created when querying option chains in ticker.py may be off by a day.

Fixed by using `datetime.datetime.utcfromtimestamp` instead of `datetime.datetime.fromtimestamp`.