### PR TITLE
Cofirming length of holders list prior to accessing it

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -379,8 +379,8 @@ class TickerBase():
 
     def _set_institutional_holders(self, holders):
         if len(holders) <= 1:
-	    return
-			
+            return
+
         self._institutional_holders = holders[1]
         if 'Date Reported' in self._institutional_holders:
             self._institutional_holders['Date Reported'] = _pd.to_datetime(

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,13 +283,7 @@ class TickerBase():
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
         self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
-        if 'Date Reported' in self._institutional_holders:
-            self._institutional_holders['Date Reported'] = _pd.to_datetime(
-                self._institutional_holders['Date Reported'])
-        if '% Out' in self._institutional_holders:
-            self._institutional_holders['% Out'] = self._institutional_holders[
-                '% Out'].str.replace('%', '').astype(float)/100
+        self._set_institutional_holders(holders)
 
         # sustainability
         d = {}
@@ -382,6 +376,18 @@ class TickerBase():
             self._earnings['quarterly'] = df
 
         self._fundamentals = True
+        
+    def _set_institutional_holders(self, holders):
+		if len(holders) <= 1:
+			return
+			
+		self._institutional_holders = holders[1]
+        if 'Date Reported' in self._institutional_holders:
+            self._institutional_holders['Date Reported'] = _pd.to_datetime(
+                self._institutional_holders['Date Reported'])
+        if '% Out' in self._institutional_holders:
+            self._institutional_holders['% Out'] = self._institutional_holders[
+                '% Out'].str.replace('%', '').astype(float)/100
 
     def get_recommendations(self, proxy=None, as_dict=False, *args, **kwargs):
         self._get_fundamentals(proxy)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -376,12 +376,12 @@ class TickerBase():
             self._earnings['quarterly'] = df
 
         self._fundamentals = True
-        
+
     def _set_institutional_holders(self, holders):
-	if len(holders) <= 1:
+        if len(holders) <= 1:
 	    return
 			
-	self._institutional_holders = holders[1]
+        self._institutional_holders = holders[1]
         if 'Date Reported' in self._institutional_holders:
             self._institutional_holders['Date Reported'] = _pd.to_datetime(
                 self._institutional_holders['Date Reported'])

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -378,10 +378,10 @@ class TickerBase():
         self._fundamentals = True
         
     def _set_institutional_holders(self, holders):
-		if len(holders) <= 1:
-			return
+	if len(holders) <= 1:
+	    return
 			
-		self._institutional_holders = holders[1]
+	self._institutional_holders = holders[1]
         if 'Date Reported' in self._institutional_holders:
             self._institutional_holders['Date Reported'] = _pd.to_datetime(
                 self._institutional_holders['Date Reported'])


### PR DESCRIPTION
When I was using this to retrieve data for the symbol, MCRO.L (Micro Focus International), I was getting an exception.  This was due to the holders list having fewer elements than expected so an index out of range exception was being thrown.

I've modified it so that it checks the length of the list prior and only setting it if the index exists.

Additionally, it might be worth adding MCRO.L to the list of symbols the tests run on.

Thanks!