### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,9 +157,9 @@ To initialize multiple ``Ticker`` objects, use
     # ^ returns a named tuple of Ticker objects
 
     # access each ticker using (example)
-    tickers.msft.info
-    tickers.aapl.history(period="1mo")
-    tickers.goog.actions
+    tickers.tickers.MSFT.info
+    tickers.tickers.AAPL.history(period="1mo")
+    tickers.tickers.GOOG.actions
 
 
 Fetching data for multiple tickers


### PR DESCRIPTION
There seems to be a missing method call and the tab completion has uppercase tickers available. `tickers.msft.info` results in `AttributeError: 'Tickers' object has no attribute 'msft'`, while `tickers.tickers.MSFT.info` works as expected.