### PR TITLE
add error handling to _get_fundamentals

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -18,16 +18,78 @@ from __future__ import print_function
 import yfinance as yf
 
 
-def test_yfinance():
-    for symbol in ['MSFT', 'IWO', 'VFINX', '^GSPC', 'BTC-USD']:
-        print(">>", symbol, end=' ... ')
-        ticker = yf.Ticker(symbol)
+# import pickle
+from pathlib import Path
+# import functools
+import pandas as pd
+try:
+    from urllib.parse import quote as urlencode
+except ImportError:
+    from urllib import quote as urlencode
 
+
+import multiprocessing
+from multiprocessing import Pool as ProcessPool
+from multiprocessing.pool import ThreadPool as ThreadPool
+# from multiprocessing.pool import ThreadPool as ProcessPool 
+from yfinance.utils import ProgressBar, retry
+
+from multiprocessing.sharedctypes import Value
+
+import time
+from functools import partial
+
+
+def download(fn, url, path='.test_data_cache'):
+    path = Path(path)
+    path.mkdir(exist_ok=True)
+    filepath = path / urlencode(url, safe='')
+    if not filepath.exists():
+        filepath.touch()
+        res = fn(url)
+        res.to_csv(filepath)
+    return pd.read_csv(filepath)
+
+
+
+URL_TICKER_LIST = 'ftp://ftp.nasdaqtrader.com/symboldirectory/nasdaqlisted.txt'
+URL_100_MOST_POPULAR = 'https://etfdb.com/compare/volume/'
+
+# broken on yahoo finance -- not the library's fault.
+# known_to_be_broken = {'BLNKW', 'KBLMW'} 
+known_to_be_broken = set() 
+broken = []
+
+count = Value('i', 0)
+
+def get_test_symbols():
+    nasdaq = set(download(lambda url: pd.read_csv(url, sep='|'), URL_TICKER_LIST).Symbol.unique())
+    _100_most_popular = set(download(lambda url: pd.read_html(url)[0], URL_100_MOST_POPULAR).Symbol.unique())
+    more_stuff = {'IWO', 'GC=F', 'CL=F', 'BELP'}
+    vanguard_mutual = {'VTSAX', 'VFIAX', 'VFINX', 'VGSLX', 'VMMSX', 'VTRIX', 'VHGEX', 'VSTCX', 'VWUSX', 'VDADX'} 
+    vanguard_etf = {'VTI', 'VIG', 'VV', 'MGV', 'VONE', 'VTV', 'VTWO', 'VB'}
+    rates = {'^IRX', '^FVX', '^TNX', '^TYX'}
+    indices = {'^GSPC', '^DJI', '^IXIC', '^VIX', '^FTSE', '^N225', '^HSI'}
+    currency = {'BTCUSD=X', 'ETHUSD=X', 'EURUSD=X', 'HKD=X', 'DX-Y.NYB'}
+
+    symbols = set().union(  nasdaq, _100_most_popular, 
+                            more_stuff, vanguard_mutual, 
+                            vanguard_etf, rates, indices, currency)
+    # symbols = set().union( more_stuff, rates, indices, currency)
+
+    return symbols
+
+# @retry(total=4)
+def test_ticker(symbol, let_slide=known_to_be_broken):
+    # print(">>", symbol, end=' ... ')
+    ticker = yf.Ticker(symbol)
+
+    # following should always gracefully handled, no crashes
+    try:
         # always should have info and history for valid symbols
         assert(ticker.info is not None and ticker.info != {})
-        assert(ticker.history(period="max").empty is False)
-
-        # following should always gracefully handled, no crashes
+        if symbol not in let_slide:
+            assert (ticker.history(period="max").empty is False)
         ticker.cashflow
         ticker.balance_sheet
         ticker.financials
@@ -35,8 +97,58 @@ def test_yfinance():
         ticker.major_holders
         ticker.institutional_holders
 
-        print("OK")
+        return symbol, (ticker.history(period="max"), ticker.cashflow, 
+            ticker.balance_sheet, ticker.financials, ticker.sustainability, 
+            ticker.major_holders, ticker.institutional_holders )
 
+    except Exception as e:
+        print(e)
+        print(e.url)
+        broken.append(symbol)
+        return symbol, None, None, None, None, None, None, None
+
+
+    
+
+
+def test_tickers(symbols, let_slide, threads, total=None):
+    print(f'\ttesting {len(symbols)} symbols')
+    global count
+    with ThreadPool(threads) as tp:
+        for res in tp.imap_unordered(test_ticker, symbols):
+            # print('res:',res)
+            count.value += 1
+            if count.value % 100 == 0:
+                print(f'test {count.value}/{len(symbols) if total is None else total} symbols', end='\r', flush=True)
+
+def test_yfinance(processes=4, threads_per_process=200):
+    symbols = get_test_symbols()
+ 
+    print(f'testing {len(symbols)} symbols')
+
+    
+    with ProcessPool(processes) as pp:
+        func = partial(test_tickers, 
+                            let_slide=known_to_be_broken, 
+                            threads=threads_per_process,
+                            total=len(symbols)
+                        )
+        chunksize = len(symbols)//processes
+        symbols = list(symbols)
+        chunks = [symbols[i*chunksize:(i+1)*chunksize] for i in range(processes)]
+        chunks[-1] += symbols[processes*chunksize:]
+        [_ for _ in pp.imap_unordered(func, chunks)]
+        
+    
+    print('done' + ' '*76, end='\r', flush=True)
+
+    try:
+        assert len(broken) == 0, f'{len(broken)} tickers failed...'
+        print('all passed :-)')
+    except Exception as e:
+        print(e)
+        print('>>>>>>> Broken Tickers: <<<<<<<<<<<<')
+        print(broken)
 
 if __name__ == "__main__":
     test_yfinance()

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -282,8 +282,13 @@ class TickerBase():
         # holders
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
-        self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
+        try:
+            self._major_holders = holders[0]
+            self._institutional_holders = holders[1]
+        except IndexError:
+            self._institutional_holders = self._major_holders = {} 
+            
+       
         if 'Date Reported' in self._institutional_holders:
             self._institutional_holders['Date Reported'] = _pd.to_datetime(
                 self._institutional_holders['Date Reported'])

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 import time as _time
 import datetime as _datetime
-import requests as _requests
+from .utils import _requests
 import pandas as _pd
 import numpy as _np
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -307,10 +307,12 @@ class TickerBase():
 
             s = _pd.DataFrame(index=[0], data=d)[-1:].T
             s.columns = ['Value']
-            s.index.name = '%.f-%.f' % (
-                s[s.index == 'ratingYear']['Value'].values[0],
-                s[s.index == 'ratingMonth']['Value'].values[0])
-
+            try:
+                s.index.name = '%.f-%.f' % (
+                    s[s.index == 'ratingYear']['Value'].values[0],
+                    s[s.index == 'ratingMonth']['Value'].values[0])
+            except IndexError:
+                pass
             self._sustainability = s[~s.index.isin(
                 ['maxAge', 'ratingYear', 'ratingMonth'])]
 

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 
 # import time as _time
 import datetime as _datetime
-import requests as _requests
+from .utils import _requests
 import pandas as _pd
 # import numpy as _np
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -254,6 +254,12 @@ class dotdict(dict):
                 self[k] = dotdict(v).wrap()
         return self
 
+    def unwrap(self):
+        for k,v in self.items():
+            if isinstance(v, dotdict):
+                self[k] = dict(v.unwrap())
+        return dict(self)
+
     @classmethod
     def treePrint(cls, D, tablevel=0):
         if isinstance(D, dict):


### PR DESCRIPTION
For some tickers (example: [BELP](https://finance.yahoo.com/quote/BELP/)) the `holders` list comes back empty ([see here](https://github.com/ranaroussi/yfinance/blob/476cf81beb55efec78eb0719ce1a42e9fbd9421a/yfinance/base.py#L284)).

This PR proposes adding a check for `IndexError` around the unpacking of `holders` into `self._major_holders` and `self._institutional_holders` ([original](https://github.com/ranaroussi/yfinance/blob/476cf81beb55efec78eb0719ce1a42e9fbd9421a/yfinance/base.py#L285-L286)) and simply defaulting them to an empty dictionary if the unpacking raises an `IndexError` ([proposed](https://github.com/JackLangerman/yfinance/blob/b1299f0fb55387f4db14e7fb0d0fb078976e3b8c/yfinance/base.py#L285-L289)).

PS
Thanks for the very useful library!



