### PR TITLE
Fixed Options Expiration Date and Added Datetime Note to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,8 @@ The Ticker module
 The ``Ticker`` module, which allows you to access
 ticker data in amore Pythonic way:
 
+Note: yahoo finance datetimes are received as UTC.
+
 .. code:: python
 
     import yfinance as yf

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -56,7 +56,7 @@ class Ticker(TickerBase):
         r = _requests.get(url=url, proxies=proxy).json()
         if r['optionChain']['result']:
             for exp in r['optionChain']['result'][0]['expirationDates']:
-                self._expirations[_datetime.datetime.fromtimestamp(
+                self._expirations[_datetime.datetime.utcfromtimestamp(
                     exp).strftime('%Y-%m-%d')] = exp
             return r['optionChain']['result'][0]['options'][0]
         return {}


### PR DESCRIPTION
Added note to README that datetimes are in UTC so people aren't confused. 

Also fixed options expiration date datetime into converting timestamp to UTC. It now matches the date specified on contractSymbol and the data on yahoo finance.