### PR TITLE
Prevents accessing an empty list of holders

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,7 +283,7 @@ class TickerBase():
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
         self._major_holders = holders[0]
-        if len(holders) > 1:    
+        if len(holders) > 1:
             self._institutional_holders = holders[1]
             if 'Date Reported' in self._institutional_holders:
                 self._institutional_holders['Date Reported'] = _pd.to_datetime(

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,13 +283,14 @@ class TickerBase():
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
         self._major_holders = holders[0]
-        self._institutional_holders = holders[1]
-        if 'Date Reported' in self._institutional_holders:
-            self._institutional_holders['Date Reported'] = _pd.to_datetime(
-                self._institutional_holders['Date Reported'])
-        if '% Out' in self._institutional_holders:
-            self._institutional_holders['% Out'] = self._institutional_holders[
-                '% Out'].str.replace('%', '').astype(float)/100
+        if len(holders) > 1:    
+            self._institutional_holders = holders[1]
+            if 'Date Reported' in self._institutional_holders:
+                self._institutional_holders['Date Reported'] = _pd.to_datetime(
+                    self._institutional_holders['Date Reported'])
+            if '% Out' in self._institutional_holders:
+                self._institutional_holders['% Out'] = self._institutional_holders[
+                    '% Out'].str.replace('%', '').astype(float)/100
 
         # sustainability
         d = {}


### PR DESCRIPTION
This fixes #438, #416, #412, #405, and #401 (among others).

This issue has been widely reported, and the proposed PR would allow querying of tickers without institutional holders. 