### PR TITLE
Fix the fetching of fundamentals

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -276,14 +276,14 @@ class TickerBase():
         if self._fundamentals:
             return
 
+        ticker_url = "{}/{}".format(self._scrape_url, self.ticker)
+
         # get info and sustainability
-        url = '%s/%s' % (self._scrape_url, self.ticker)
-        data = utils.get_json(url, proxy)
+        data = utils.get_json(ticker_url, proxy)
 
         # holders
-        url = "{}/{}/holders".format(self._scrape_url, self.ticker)
-        holders = _pd.read_html(url)
-        
+        holders = _pd.read_html(ticker_url+'/holders')
+
         if len(holders)>=3:
             self._major_holders = holders[0]
             self._institutional_holders = holders[1]
@@ -293,10 +293,10 @@ class TickerBase():
             self._institutional_holders = holders[1]
         else:
             self._major_holders = holders[0]
-        
+
         #self._major_holders = holders[0]
         #self._institutional_holders = holders[1]
-        
+
         if self._institutional_holders is not None:
             if 'Date Reported' in self._institutional_holders:
                 self._institutional_holders['Date Reported'] = _pd.to_datetime(
@@ -373,7 +373,7 @@ class TickerBase():
             pass
 
         # get fundamentals
-        data = utils.get_json(url+'/financials', proxy)
+        data = utils.get_json(ticker_url+'/financials', proxy)
 
         # generic patterns
         for key in (


### PR DESCRIPTION
As of now, the fetching of fundamentals is broken for some (all?) tickers (e.g. BIM.PA, AF.PA, IBM, etc.).


The reason for that is located in the `_get_fundamentals` method implemented in `base.py`, between the lines 280 and 285: the `url` var (containing the base_url and the ticker) has "/holders" appended, and when fetching the fundamentals, only "/financials" is appended again, instead of replacing "/holders".

This PR fixes the issue.

Before:
```python
import yfinance as yf

yf.Ticker('BIM.PA').earnings
#=> Empty DataFrame
#=> Columns: [Open, High, Low, Close, Adj Close, Volume]
#=> Index: []
```

After:
```python
import yfinance as yf

yf.Ticker('BIM.PA').financials
#=>          Revenue   Earnings
#=> Year
#=> 2016  2103200000  179100000
#=> 2017  2288200000  238100000
#=> 2018  2421300000  256500000
#=> 2019  2674800000  272800000
```