### PR TITLE
Fix incorrect financials url

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -283,7 +283,7 @@ class TickerBase():
         # holders
         url = "{}/{}/holders".format(self._scrape_url, self.ticker)
         holders = _pd.read_html(url)
-        
+
         if len(holders)>=3:
             self._major_holders = holders[0]
             self._institutional_holders = holders[1]
@@ -293,10 +293,10 @@ class TickerBase():
             self._institutional_holders = holders[1]
         else:
             self._major_holders = holders[0]
-        
+
         #self._major_holders = holders[0]
         #self._institutional_holders = holders[1]
-        
+
         if self._institutional_holders is not None:
             if 'Date Reported' in self._institutional_holders:
                 self._institutional_holders['Date Reported'] = _pd.to_datetime(
@@ -373,6 +373,7 @@ class TickerBase():
             pass
 
         # get fundamentals
+        url = "{}/{}/financials".format(self._scrape_url, self.ticker)
         data = utils.get_json(url+'/financials', proxy)
 
         # generic patterns


### PR DESCRIPTION
Hi,

First off, this is a great package thanks! I am using it for some novice/fun data mining for stock investing stuff.

I noticed this bug playing around with the lib, I was getting no data returned when calling: `yf.Ticker('MSFT').balance_sheet`

Upon further investigation is seems the url that was being called was still set to the values needed for holders resulting in a 404, the url being called ended up being: https://finance.yahoo.com/quote/APHA/holders/financials (before fix in this PR)

Fix here seems to work/data comes back now after changing the url with this one liner.