### PR TITLE
Fix datetime index

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -136,7 +136,7 @@ class TickerBase():
         params["includePrePost"] = prepost
         params["events"] = "div,splits"
 
-        # 1) fix weired bug with Yahoo! - returning 60m for 30m bars
+        # 1) fix weird bug with Yahoo! - returning 60m for 30m bars
         if params["interval"] == "30m":
             params["interval"] = "15m"
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -231,7 +231,7 @@ class TickerBase():
         df.index = df.index.tz_localize("UTC").tz_convert(
             data["chart"]["result"][0]["meta"]["exchangeTimezoneName"])
 
-        if params["interval"][-1] == "m":
+        if params["interval"][-1] in "mh":
             df.index.name = "Datetime"
         else:
             df.index = _pd.to_datetime(df.index.date)


### PR DESCRIPTION
Fixes the problem that the time section of the datetime index is discarded when `interval="1h"`
This is mentioned e.g. in  #490 by @KennSmithDS