### PR TITLE
Fix README.rst 'compatibility' typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ NOTE
 
 The library was originally named ``fix-yahoo-finance``, but
 I've since renamed it to ``yfinance`` as I no longer consider it a mere "fix".
-For reasons of backward-competability, ``fix-yahoo-finance`` now import and
+For reasons of backward-compatibility, ``fix-yahoo-finance`` now import and
 uses ``yfinance``, but you should install and use ``yfinance`` directly.
 
 `Changelog » <./CHANGELOG.rst>`__


### PR DESCRIPTION
Fixing README.rst 'compatibility' typo (issue #504)