### PR TITLE
FIX url for financials

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -373,7 +373,8 @@ class TickerBase():
             pass
 
         # get fundamentals
-        data = utils.get_json(url+'/financials', proxy)
+        url = "{}/{}/financials".format(self._scrape_url, self.ticker)
+        data = utils.get_json(url, proxy)
 
         # generic patterns
         for key in (


### PR DESCRIPTION
get_balancesheet et al. were not working.
previous assignment for holders caused it to be (scrape_url)/(ticker)/holders/financials
instead of (scrape_url)/(ticker)/financials

(a tiny contribution, thanks for your excellent work!)