### PR TITLE
Fix runtest.py examples

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -11,7 +11,8 @@ Sanity check for most common library uses all working
 - ETF: Russell 2000 Growth
 - Mutual fund: Vanguard 500 Index fund
 - Index: S&P500
-- Currency BTC-USD
+- Currency: BTC-USD
+- Stock: Nestle
 """
 
 from __future__ import print_function
@@ -38,25 +39,12 @@ def test_yfinance():
 
         print("OK")
 
-    # Ford has no institutional investors table or mutual fund holders
-    ticker = yf.Ticker('F')
-    print(">> F", end=" ... ")
-    assert(ticker.info is not None and ticker.info != {})
-    assert(ticker.major_holders is not None)
-    assert(ticker.institutional_holders is None)
-    print("OK")
-    # NKLA has no institutional investors table or mutual fund holders
-    ticker = yf.Ticker('NKLA')
-    print(">> NKLA", end=" ... ")
-    assert(ticker.info is not None and ticker.info != {})
-    assert(ticker.major_holders is not None)
-    assert(ticker.institutional_holders is None)
-    print("OK")
-    # NKLA has no institutional investors table or mutual fund holders
+    # NESN.SW has no institutional holders table
     ticker = yf.Ticker('NESN.SW')
     print(">> NESN.SW", end=" ... ")
     assert(ticker.info is not None and ticker.info != {})
     assert(ticker.major_holders is not None)
+    assert(ticker.mutualfund_holders is not None)
     assert(ticker.institutional_holders is None)
     print("OK")
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -290,7 +290,7 @@ class TickerBase():
             self._mutualfund_holders = holders[2]
         elif len(holders)>=2:
             self._major_holders = holders[0]
-            self._institutional_holders = holders[1]
+            self._mutualfund_holders = holders[1]
         else:
             self._major_holders = holders[0]
         


### PR DESCRIPTION
Minor changes to allow runtest.py to function without raising AssertionErrors.

A number of the Yahoo tickers have mutual fund holders, but no institutional holders. The previous Ford (F) and Nikola (NKLA) examples both have all of the requested holder information causing the AssertionError when asserting that they don't have this information.