### PR TITLE
Update base.py

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -406,28 +406,28 @@ class TickerBase():
         self._fundamentals = True
 
     def get_recommendations(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._recommendations
         if as_dict:
             return data.to_dict()
         return data
 
     def get_calendar(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._calendar
         if as_dict:
             return data.to_dict()
         return data
 
     def get_major_holders(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._major_holders
         if as_dict:
             return data.to_dict()
         return data
 
     def get_institutional_holders(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._institutional_holders
         if data is not None:
             if as_dict:
@@ -435,7 +435,7 @@ class TickerBase():
             return data
 
     def get_mutualfund_holders(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._mutualfund_holders
         if data is not None:
             if as_dict:
@@ -443,35 +443,35 @@ class TickerBase():
             return data
 
     def get_info(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._info
         if as_dict:
             return data.to_dict()
         return data
 
     def get_sustainability(self, proxy=None, as_dict=False, *args, **kwargs):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._sustainability
         if as_dict:
             return data.to_dict()
         return data
 
     def get_earnings(self, proxy=None, as_dict=False, freq="yearly"):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._earnings[freq]
         if as_dict:
             return data.to_dict()
         return data
 
     def get_financials(self, proxy=None, as_dict=False, freq="yearly"):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._financials[freq]
         if as_dict:
             return data.to_dict()
         return data
 
     def get_balancesheet(self, proxy=None, as_dict=False, freq="yearly"):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._balancesheet[freq]
         if as_dict:
             return data.to_dict()
@@ -481,7 +481,7 @@ class TickerBase():
         return self.get_balancesheet(proxy, as_dict, freq)
 
     def get_cashflow(self, proxy=None, as_dict=False, freq="yearly"):
-        self._get_fundamentals(proxy)
+        self._get_fundamentals(proxy=proxy)
         data = self._cashflow[freq]
         if as_dict:
             return data.to_dict()


### PR DESCRIPTION
Proxy was not successfully passed through in calls to _get_fundamentals. This is due to _get_fundamentals having two keyword arguments "def _get_fundamentals(self, kind=None, proxy=None):" thus proxy was being stored to "kind" by default.

Fixed by adding keyword back into calls to _get_fundamentals