### PR TITLE
Make ticker object use persistent HTTPS connection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,27 @@ To initialize multiple ``Ticker`` objects, use
     tickers.tickers.GOOG.actions
 
 
+Pooling requests
+~~~~~~~~~~~~~~~~
+
+``Ticker`` objects also have an optional session argument, expecting
+a requests.Session() object. Ticker objects that are passed the same
+Session object will share a common TCP connection for GET requests.
+
+.. code:: python
+
+    import yfinance as yf
+    from requests import Session
+
+    session = Session()
+
+    tsla = yf.Ticker("TSLA", session)
+    msft = yf.Ticker("MSFT", session)
+
+    tsla.history()
+    msft.history()
+
+
 Fetching data for multiple tickers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import time as _time
 import datetime as _datetime
 import requests as _requests
+from requests import Session
 import pandas as _pd
 import numpy as _np
 
@@ -42,13 +43,16 @@ from . import shared
 
 
 class TickerBase():
-    def __init__(self, ticker):
+    def __init__(self, ticker,session:Session=None):
         self.ticker = ticker.upper()
         self._history = None
         self._base_url = 'https://query1.finance.yahoo.com'
         self._scrape_url = 'https://finance.yahoo.com/quote'
 
-        self.request_session = _requests.Session()
+        if not session:
+            self.request_session = _requests.Session()
+        else:
+            self.request_session = session
 
         self._fundamentals = False
         self._info = None
@@ -150,7 +154,7 @@ class TickerBase():
 
         # Getting data from json
         url = "{}/v8/finance/chart/{}".format(self._base_url, self.ticker)
-        data = self._request_session.get(url=url, params=params, proxies=proxy)
+        data = self.request_session.get(url=url, params=params, proxies=proxy)
         if "Will be right back" in data.text:
             raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                "Our engineers are working quickly to resolve "

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -48,6 +48,8 @@ class TickerBase():
         self._base_url = 'https://query1.finance.yahoo.com'
         self._scrape_url = 'https://finance.yahoo.com/quote'
 
+        self.request_session = _requests.Session()
+
         self._fundamentals = False
         self._info = None
         self._sustainability = None
@@ -148,7 +150,7 @@ class TickerBase():
 
         # Getting data from json
         url = "{}/v8/finance/chart/{}".format(self._base_url, self.ticker)
-        data = _requests.get(url=url, params=params, proxies=proxy)
+        data = self._request_session.get(url=url, params=params, proxies=proxy)
         if "Will be right back" in data.text:
             raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                "Our engineers are working quickly to resolve "
@@ -530,7 +532,7 @@ class TickerBase():
         url = 'https://markets.businessinsider.com/ajax/' \
               'SearchController_Suggest?max_results=25&query=%s' \
             % urlencode(q)
-        data = _requests.get(url=url, proxies=proxy).text
+        data = self.request_session.get(url=url, proxies=proxy).text
 
         search_str = '"{}|'.format(ticker)
         if search_str not in data:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -24,7 +24,6 @@ from __future__ import print_function
 import time as _time
 import datetime as _datetime
 import requests as _requests
-from requests import Session
 import pandas as _pd
 import numpy as _np
 
@@ -43,13 +42,13 @@ from . import shared
 
 
 class TickerBase():
-    def __init__(self, ticker,session:Session=None):
+    def __init__(self, ticker, session=None):
         self.ticker = ticker.upper()
         self._history = None
         self._base_url = 'https://query1.finance.yahoo.com'
         self._scrape_url = 'https://finance.yahoo.com/quote'
 
-        if not session:
+        if not session or not isinstance(session,_requests.Session):
             self.request_session = _requests.Session()
         else:
             self.request_session = session

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -29,7 +29,7 @@ from . import Ticker, utils
 from . import shared
 
 
-def download(tickers, start=None, end=None, actions=False, threads=True,
+def download(tickers, session=None, start=None, end=None, actions=False, threads=True,
              group_by='column', auto_adjust=False, back_adjust=False,
              progress=True, period="max", interval="1d", prepost=False,
              proxy=None, rounding=False, **kwargs):
@@ -85,7 +85,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             threads = min([len(tickers), _multitasking.cpu_count() * 2])
         _multitasking.set_max_threads(threads)
         for i, ticker in enumerate(tickers):
-            _download_one_threaded(ticker, period=period, interval=interval,
+            _download_one_threaded(ticker, session=session, period=period, interval=interval,
                                    start=start, end=end, prepost=prepost,
                                    actions=actions, auto_adjust=auto_adjust,
                                    back_adjust=back_adjust,
@@ -97,7 +97,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
     # download synchronously
     else:
         for i, ticker in enumerate(tickers):
-            data = _download_one(ticker, period=period, interval=interval,
+            data = _download_one(ticker, session=session, period=period, interval=interval,
                                  start=start, end=end, prepost=prepost,
                                  actions=actions, auto_adjust=auto_adjust,
                                  back_adjust=back_adjust, rounding=rounding)
@@ -157,25 +157,24 @@ def _realign_dfs():
 
 
 @_multitasking.task
-def _download_one_threaded(ticker, start=None, end=None,
+def _download_one_threaded(ticker, session=None, start=None, end=None,
                            auto_adjust=False, back_adjust=False,
                            actions=False, progress=True, period="max",
                            interval="1d", prepost=False, proxy=None,
                            rounding=False):
 
-    data = _download_one(ticker, start, end, auto_adjust, back_adjust,
+    data = _download_one(ticker, session, start, end, auto_adjust, back_adjust,
                          actions, period, interval, prepost, proxy, rounding)
     shared._DFS[ticker.upper()] = data
     if progress:
         shared._PROGRESS_BAR.animate()
 
 
-def _download_one(ticker, start=None, end=None,
+def _download_one(ticker, session=None, start=None, end=None,
                   auto_adjust=False, back_adjust=False,
                   actions=False, period="max", interval="1d",
                   prepost=False, proxy=None, rounding=False):
-
-    return Ticker(ticker).history(period=period, interval=interval,
+    return Ticker(ticker,session).history(period=period, interval=interval,
                                   start=start, end=end, prepost=prepost,
                                   actions=actions, auto_adjust=auto_adjust,
                                   back_adjust=back_adjust, proxy=proxy,

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 
 # import time as _time
 import datetime as _datetime
-import requests as _requests
 import pandas as _pd
 # import numpy as _np
 
@@ -53,7 +52,7 @@ class Ticker(TickerBase):
                 proxy = proxy["https"]
             proxy = {"https": proxy}
 
-        r = _requests.get(url=url, proxies=proxy).json()
+        r = self.request_session.get(url=url, proxies=proxy).json()
         if r['optionChain']['result']:
             for exp in r['optionChain']['result'][0]['expirationDates']:
                 self._expirations[_datetime.datetime.utcfromtimestamp(

--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -21,6 +21,8 @@
 
 from __future__ import print_function
 
+import requests as _requests
+
 from . import Ticker, multi
 from collections import namedtuple as _namedtuple
 
@@ -48,8 +50,10 @@ class Tickers():
         self.symbols = [ticker.upper() for ticker in tickers]
         ticker_objects = {}
 
+        self.session = _requests.Session()
+        
         for ticker in self.symbols:
-            ticker_objects[ticker] = Ticker(ticker)
+            ticker_objects[ticker] = Ticker(ticker,self.session)
 
         self.tickers = _namedtuple(
             "Tickers", ticker_objects.keys(), rename=True
@@ -74,7 +78,7 @@ class Tickers():
                  threads=True, group_by='column', progress=True,
                  **kwargs):
 
-        data = multi.download(self.symbols,
+        data = multi.download(self.symbols, session=self.session,
                               start=start, end=end,
                               actions=actions,
                               auto_adjust=auto_adjust,


### PR DESCRIPTION
**Request Pooling**
- New requests.Session in TickerBase, allowing reuse of TCP connection when connecting to Yfinance API for same ticker object
- Optional 'session' argument for TickerBase, allowing one to pass a requests.Session() object. In the most common use case (Fetching data for more than just one ticker), this enables a substantial reduction in CPU and network overhead due to only using a single TCP connection.
