### PR TITLE
Bump minimal numpy version to fix python 3.7 build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas>=0.24
-numpy>=1.15
+numpy>=1.16.5
 requests>=2.21
 multitasking>=0.0.7
 lxml>=4.5.1


### PR DESCRIPTION
[Travis builds pass for python 2.7, 3.5, 3.6, but fail for 3.7.](https://github.com/ranaroussi/yfinance/runs/1722016237)

The error:
```
ERROR: Failure: ImportError (this version of pandas is incompatible with numpy < 1.16.5
your numpy version is 1.16.4.
Please upgrade numpy to >= 1.16.5 to use this pandas version)
```

So let's try specifying in requirements.txt that numpy is at least that
version.