### PR TITLE
fixes #609

### DIFF
--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -51,9 +51,7 @@ class Tickers():
         for ticker in self.symbols:
             ticker_objects[ticker] = Ticker(ticker)
 
-        self.tickers = _namedtuple(
-            "Tickers", ticker_objects.keys(), rename=True
-        )(*ticker_objects.values())
+        self.tickers = ticker_objects
 
     def history(self, period="1mo", interval="1d",
                 start=None, end=None, prepost=False,
@@ -88,7 +86,7 @@ class Tickers():
                               **kwargs)
 
         for symbol in self.symbols:
-            getattr(self.tickers, symbol)._history = data[symbol]
+            self.tickers[symbol]._history = data[symbol]
 
         if group_by == 'column':
             data.columns = data.columns.swaplevel(0, 1)


### PR DESCRIPTION
When using tickers.py with non-US ticker formats we get an SttributeError, which corresponds to the line 90-91 of the function download in yfinance/tickers.py: <br>
```
["CABK.MC", "BBVA.MC","SAN.MC"]
AttributeError: 'Tickers' object has no attribute 'CABK.MC'
```

This happens because the class _Tickers_ uses a namedTuple to store the tickers, but formats like _CABK.MC_ (spanish ticker) or _GC=F_ (Gold's ticker), aren't valid keys for a namedTuple and they get automatically replaced by his index within the previous dict(0,1,...).
So my proposal is, since there's only one place where this self.tickers is used, we can leave the original dict. 

And alternative could be enforce a valid format by replacing the non-valid characters by "_" (CABK.MC -> CABK_MC), but I seem this more problematic since we depend on yahoo finance's formats.