### PR TITLE
Fix KeyError: "['maxAge'] not found in axis" for HTOO ticker

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -383,11 +383,11 @@ class TickerBase():
         ):
 
             item = key[1] + 'History'
-            if isinstance(data.get(item), dict):
+            if isinstance(data.get(item), dict) and data[item][key[2]]:
                 key[0]['yearly'] = cleanup(data[item][key[2]])
 
             item = key[1]+'HistoryQuarterly'
-            if isinstance(data.get(item), dict):
+            if isinstance(data.get(item), dict) and data[item][key[2]]:
                 key[0]['quarterly'] = cleanup(data[item][key[2]])
 
         # earnings


### PR DESCRIPTION
During execution with HTOO ticker, `data` passed to `cleanup()` is an empty list:

```
    def _get_fundamentals(self, kind=None, proxy=None):
        def cleanup(data):
```

Debug `pprint(data)` in `cleanup()` body prints `[]`.

Modified code to not execute `cleanup()` with an empty array. Addresses issue #599.