### PR TITLE
Retry with backoff on download request exception

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.15
 requests>=2.21
 multitasking>=0.0.7
 lxml>=4.5.1
+backoff>=1.10.0

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -173,7 +173,9 @@ def _download_one_threaded(ticker, start=None, end=None,
 
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException,
-                        RuntimeError),
+                        RuntimeError,
+                        request.exceptions.ProxyError,
+                        OSError),
                       max_time=60*10)
 def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False,

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -174,7 +174,7 @@ def _download_one_threaded(ticker, start=None, end=None,
 @backoff.on_exception(backoff.expo,
                       (requests.exceptions.RequestException,
                         RuntimeError,
-                        request.exceptions.ProxyError,
+                        requests.exceptions.ProxyError,
                         OSError),
                       max_time=60*10)
 def _download_one(ticker, start=None, end=None,

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -24,6 +24,8 @@ from __future__ import print_function
 import time as _time
 import multitasking as _multitasking
 import pandas as _pd
+import backoff
+import requests
 
 from . import Ticker, utils
 from . import shared
@@ -169,7 +171,9 @@ def _download_one_threaded(ticker, start=None, end=None,
     if progress:
         shared._PROGRESS_BAR.animate()
 
-
+@backoff.on_exception(backoff.expo,
+                      requests.exceptions.RequestException,
+                      max_time=60*10)
 def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False,
                   actions=False, period="max", interval="1d",

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -172,7 +172,8 @@ def _download_one_threaded(ticker, start=None, end=None,
         shared._PROGRESS_BAR.animate()
 
 @backoff.on_exception(backoff.expo,
-                      requests.exceptions.RequestException,
+                      (requests.exceptions.RequestException,
+                        RuntimeError),
                       max_time=60*10)
 def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False,


### PR DESCRIPTION
When downloading one record, catch request exception and retry with exponential backoff for up to 10 minutes. This prevents one bad request from interrupting and freezing the entire download operation.