### PR TITLE
Skip dicts that have been replaced with an error dict

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -337,7 +337,8 @@ class TickerBase():
             if isinstance(data.get(item), dict):
                 self._info.update(data[item])
 
-        self._info['regularMarketPrice'] = self._info['regularMarketOpen']
+        if self._info.get('regularMarketOpen'):
+            self._info['regularMarketPrice'] = self._info['regularMarketOpen']
         self._info['logo_url'] = ""
         try:
             domain = self._info['website'].split(

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -60,7 +60,9 @@ def get_json(url, proxy=None):
     new_data = _re.sub(
         r'\{[\'|\"]raw[\'|\"]:(.*?),(.*?)\}', r'\1', new_data)
 
-    return _json.loads(new_data)
+    data = _json.loads(new_data)
+    data = {k:v for k,v in data.items() if not (isinstance(v, dict) and 'err' in v)}
+    return data
 
 
 def camel2title(o):


### PR DESCRIPTION
We get json from the page found at [`ticker_url`](https://github.com/ranaroussi/yfinance/blob/8bdc51f9fa71eae83c78cd04694eff60dfd6bb4d/yfinance/base.py#L282) and from the page found at [`ticker_url+'/financials'`](https://github.com/ranaroussi/yfinance/blob/8bdc51f9fa71eae83c78cd04694eff60dfd6bb4d/yfinance/base.py#L376). This json has a schema, so to speak. It presents its information category by category at the "top level" of the json object, and we drill into each one to get the information it contains. For example, we have code specialized in drilling into the [`esgScores`](https://github.com/ranaroussi/yfinance/blob/8bdc51f9fa71eae83c78cd04694eff60dfd6bb4d/yfinance/base.py#L318) key, and other code specialized in drilling into the [`'summaryProfile', 'summaryDetail', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail', 'financialData'`](https://github.com/ranaroussi/yfinance/blob/8bdc51f9fa71eae83c78cd04694eff60dfd6bb4d/yfinance/base.py#L334-L335) keys.

However, some tickers are missing some categories of information, and this manifests itself as the category key leading to an error payload rather than the information we'd normally find inside it. Here is an error payload that I came across in various keys while querying `BBSC`, a fairly new ETF.
```json
{
  "err": {
    "elapsedTime": 9,
    "headers": {
      "server": "envoy",
      "x-envoy-upstream-service-time": "8",
      "via": "https/1.1 media-router-api7057.prod.media.bf1.yahoo.com (ApacheTrafficServer [cMsSf ])",
      "content-type": "application/json",
      "x-request-id": "09df127e-8d1b-4a4f-9781-94b67db76960",
      "date": "Sun, 14 Mar 2021 16:33:15 GMT",
      "cache-control": "max-age=0, private",
      "vary": "Origin",
      "expires": "-1",
      "y-rid": "138dqa5g4semb",
      "content-length": "216",
      "x-yahoo-request-id": "138dqa5g4semb",
      "age": "0"
    },
    "requestUri": "http://iquery.finance.yahoo.com:4080/v10/finance/quoteSummary/BBSC?formatted=true&crumb=edw7wWAg9rA&lang=en-US&region=US&modules=defaultKeyStatistics%2CassetProfile%2CtopHoldings%2CfundPerformance%2CfundProfile%2CesgScores&ssl=true",
    "responseText": {
      "quoteSummary": {
        "result": null,
        "error": {
          "code": "Not Found",
          "description": "No fundamentals data found for any of the summaryTypes=defaultKeyStatistics,assetProfile,topHoldings,fundPerformance,fundProfile,esgScores"
        }
      }
    },
    "responseXML": null,
    "status": 404,
    "statusCode": 404,
    "statusText": "Not Found"
  }
}
```

In this commit, I'm proposing a solution where we skip any payloads that we find to have an `'err'` key. Additionally, since this results in some data being missing, I've added a conditional in one place in that code that expected a certain piece of data to be present.