### PR TITLE
remove special chars from ticker

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -21,6 +21,8 @@
 
 from __future__ import print_function
 
+import re
+
 import time as _time
 import multitasking as _multitasking
 import pandas as _pd
@@ -70,8 +72,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
     tickers = tickers if isinstance(
         tickers, (list, set, tuple)) else tickers.replace(',', ' ').split()
 
-    tickers = list(set([ticker.upper() for ticker in tickers]))
-
+    tickers = list(set([re.sub('\W+','', ticker.upper()) for ticker in tickers]))
     if progress:
         shared._PROGRESS_BAR = utils.ProgressBar(len(tickers), 'completed')
 


### PR DESCRIPTION
When iterating over nasdaq public screener, some tickers containing "/" caused a failure that would not exit gracefully (this may be a threading issue at it's core, but this is the only trigger I've seen so far). For good measure, I suggest filtering for special characters.

Love this tool btw!