### PR TITLE
Fix issue 570

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -115,7 +115,7 @@ class TickerBase():
 
         if start or period is None or period.lower() == "max":
             if start is None:
-                start = -2208988800
+                start = -631159200 #UNIX timestamp for 1.1.1950
             elif isinstance(start, _datetime.datetime):
                 start = int(_time.mktime(start.timetuple()))
             else:


### PR DESCRIPTION
Hi,
issue is that currently start parameter for request is set to 1.1.1900 (actually to the corresponding UNIX timestamp -2208994789). My fix is to use the timestamp for 1.1.1950 (-631159200), so the 100 year limit set by yahoo finance is not exceeded. Any other date not more than 100 years prior to current date would be enough (e.g. 1.1.1940 or 1.1.1930), but I think the chosen date is fine. 