### PR TITLE
Fix issue 639 fundamentals

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -115,7 +115,7 @@ class TickerBase():
 
         if start or period is None or period.lower() == "max":
             if start is None:
-                start = -2208988800
+                start = -631159200 #UNIX timestamp for 1.1.1950
             elif isinstance(start, _datetime.datetime):
                 start = int(_time.mktime(start.timetuple()))
             else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -393,7 +393,8 @@ class TickerBase():
             pass
 
         # get fundamentals
-        data = utils.get_json(ticker_url+'/financials', proxy, self.session)
+        url = "{}/{}/financials".format(self._scrape_url, self.ticker)
+        data = utils.get_json(url, proxy, self.session)
 
         # generic patterns
         for key in (


### PR DESCRIPTION
fundamentals are currently not being fetched as the URL contains the "/holders" part (similar issue as #480). I applied the solution already stated on issue #639 to pass right URL.