### PR TITLE
[New Feature] Argument added for silencing error printing

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -31,7 +31,7 @@ from . import shared
 
 def download(tickers, start=None, end=None, actions=False, threads=True,
              group_by='column', auto_adjust=False, back_adjust=False,
-             progress=True, period="max", interval="1d", prepost=False,
+             progress=True, period="max", show_errors=True, interval="1d", prepost=False,
              proxy=None, rounding=False, **kwargs):
     """Download yahoo tickers
     :Parameters:
@@ -64,6 +64,8 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             Optional. Proxy server URL scheme. Default is None
         rounding: bool
             Optional. Round values to 2 decimal places?
+        show_errors: bool
+            Optional. Doesn't print errors if True
     """
 
     # create ticker list
@@ -109,7 +111,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
     if progress:
         shared._PROGRESS_BAR.completed()
 
-    if shared._ERRORS:
+    if shared._ERRORS and show_errors:
         print('\n%.f Failed download%s:' % (
             len(shared._ERRORS), 's' if len(shared._ERRORS) > 1 else ''))
         # print(shared._ERRORS)


### PR DESCRIPTION
`show_errors` argument added to `download` method with default value `True`.
`if show_errors == False` then errors **will not be printed.**

This is a fix for **Symbol Delisted** error printed if the data for that symbol is unavailable on Yahoo! Finance and discussed in #147 