### PR TITLE
Get price even if open price not available

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -354,7 +354,7 @@ class TickerBase():
         try:
             # self._info['regularMarketPrice'] = self._info['regularMarketOpen']
             self._info['regularMarketPrice'] = data.get('price', {}).get(
-                'regularMarketPrice', self._info['regularMarketOpen'])
+                'regularMarketPrice', self._info.get('regularMarketOpen', None))
         except Exception:
             pass
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -350,6 +350,10 @@ class TickerBase():
                     self._info.update(data[item])
         except Exception:
             pass
+        
+        if not isinstance(data.get('summaryDetail'), dict):
+            # For some reason summaryDetail did not give any results. The price dict usually has most of the same info
+            self._info.update(data.get('price', {}))
 
         try:
             # self._info['regularMarketPrice'] = self._info['regularMarketOpen']


### PR DESCRIPTION
If for some reason the `regularMarketOpen` value is not retrieved in the `summaryDetail`, then still attempt to retrieve the `regularMarketPrice`

Example ticker of where this happens is 'ETHI.AX', which does not have anything in the `summaryDetail`. It also has the following error

```
{'err': {'elapsedTime': 10,
         'headers': {'age': '0',
                     'cache-control': 'max-age=0, private',
                     'content-length': '216',
                     'content-type': 'application/json;charset=utf-8',
                     'date': 'Wed, 16 Jun 2021 00:43:05 GMT',
                     'expires': '-1',
                     'server': 'envoy',
                     'vary': 'Origin',
                     'via': 'https/1.1 '
                            'media-router-api7007.prod.media.sg3.yahoo.com '
                            '(ApacheTrafficServer [cMsSf ])',
                     'x-envoy-upstream-service-time': '8',
                     'x-request-id': '2e424b2f-fb2b-447a-85b9-a09fc070c74f',
                     'x-yahoo-request-id': 'biaib19gcii8p',
                     'y-rid': 'biaib19gcii8p'},
         'requestUri': 'http://iquery.finance.yahoo.com:4080/v10/finance/quoteSummary/ETHI.AX?formatted=true&crumb=n21GbCuUO0I&lang=en-US&region=US&modules=defaultKeyStatistics%2CassetProfile%2CtopHoldings%2CfundPerformance%2CfundProfile%2CesgScores&ssl=true',
         'responseText': '{"quoteSummary":{"result":null,"error":{"code":"Not '
                         'Found","description":"No fundamentals data found for '
                         'any of the '
                         'summaryTypes=defaultKeyStatistics,assetProfile,topHoldings,fundPerformance,fundProfile,esgScores"}}}',
         'responseXML': None,
         'status': 404,
         'statusCode': 404,
         'statusText': 'Not Found'}}
```

The second commit fixes a test case of mine, there are some other fields that look like they are usually in the summaryDetail response. An example is `currency`.

It could be a better solution to detect when `summaryDetail` has failed, and in that case, use `price` instead (as it looks to have many of the same details). Some extras that seem to be only in the `price` dict are: `currencySymbol`, `exchange`, `exchangeDataDelayedBy`,`exchangeName`, `longName`, `marketState`, `post*`, `pre*`, `quoteSourceName`, `quoteType`, `regularMarketChange*`, `regularMarketSource`, `regularMarketTime`, `shortName`, `symbol`, `underlyingSymbol`.