### PR TITLE
Be safe in reading json

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -159,12 +159,21 @@ class TickerBase():
             raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                "Our engineers are working quickly to resolve "
                                "the issue. Thank you for your patience.")
-        data = data.json()
 
         # Work with errors
         debug_mode = True
         if "debug" in kwargs and isinstance(kwargs["debug"], bool):
             debug_mode = kwargs["debug"]
+
+        try:
+            data = data.json()
+        except:
+            err_msg = f"Failed to read the json data for {self.ticker}. [{data.text}]"
+            shared._DFS[self.ticker] = utils.empty_df()
+            shared._ERRORS[self.ticker] = err_msg
+            if "many" not in kwargs and debug_mode:
+                print('- %s: %s' % (self.ticker, err_msg))
+            return shared._DFS[self.ticker]
 
         err_msg = "No data found for this date range, symbol may be delisted"
         if "chart" in data and data["chart"]["error"]:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -167,8 +167,8 @@ class TickerBase():
 
         try:
             data = data.json()
-        except:
-            err_msg = f"Failed to read the json data for {self.ticker}. [{data.text}]"
+        except Exception:
+            err_msg = "Failed to read the json data for %s. [%s]" % (self.ticker, data.text)
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
             if "many" not in kwargs and debug_mode:


### PR DESCRIPTION
When bad requests happen in using `yf.download`, either because an element in the list is wrongly formatted, or because of shaky internet connection, one bad ticker causes this line to blow up, and the `download` gets stuck. This small fix works around any type of bad requests leading to mis-formatted returns.