### PR TITLE
Replace drop duplicate prices with indexes

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -259,8 +259,7 @@ class TickerBase():
 
         # duplicates and missing rows cleanup
         df.dropna(how='all', inplace=True)
-        df.drop_duplicates(inplace=True)
-        df = df.groupby(df.index).last()
+        df = df[~df.index.duplicated(keep='first')]
 
         self._history = df.copy()
 


### PR DESCRIPTION
Reindex the resutling price DataFrame by removing duplicate DatetimeIndex values instead of price data. Remove the call to groupby which is made redundant by the reindexing. This method appears to be the fastest based on a single data point found here.

This fixes an issue where valid trading days are removed from the returned data. Currently duplicates are dropped broadly under the (presumed) assumption that the chance of a stock's open, high, low, close and adjusted close all to be the same within a data range is an edge case that would never happen. With mutual funds and other securities that price daily (and correspondingly don't have a OHLC) this is much more likely.

Resolves: #793