### PR TITLE
Do not use relative links in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ I've since renamed it to ``yfinance`` as I no longer consider it a mere "fix".
 For reasons of backward-compatibility, ``fix-yahoo-finance`` now import and
 uses ``yfinance``, but you should install and use ``yfinance`` directly.
 
-`Changelog » <./CHANGELOG.rst>`__
+`Changelog » <https://github.com/ranaroussi/yfinance/edit/main/README.rst>`__
 
 -----
 


### PR DESCRIPTION
Relative links will not work when the README is displayed on an external page e.g. https://pypi.org/project/yfinance/ which is the first google entry for this project.