### PR TITLE
Add .news ticker property

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,9 @@ Note: yahoo finance datetimes are received as UTC.
     # show options expirations
     msft.options
 
+    # show news
+    msft.news
+
     # get option chain for specific expiration
     opt = msft.option_chain('YYYY-MM-DD')
     # data available via: opt.calls, opt.puts

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,6 +67,9 @@ msft.isin
 # show options expirations
 msft.options
 
+# show news
+msft.news
+
 # get option chain for specific expiration
 opt = msft.option_chain('YYYY-MM-DD')
 # data available via: opt.calls, opt.puts

--- a/test_yfinance.py
+++ b/test_yfinance.py
@@ -49,6 +49,7 @@ class TestTicker(unittest.TestCase):
             ticker.quarterly_cashflow
             ticker.sustainability
             ticker.options
+            ticker.news
 
     def test_holders(self):
         for ticker in tickers:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -57,6 +57,7 @@ class TickerBase():
         self._institutional_holders = None
         self._mutualfund_holders = None
         self._isin = None
+        self._news = []
 
         self._calendar = None
         self._expirations = {}
@@ -617,3 +618,31 @@ class TickerBase():
 
         self._isin = data.split(search_str)[1].split('"')[0].split('|')[0]
         return self._isin
+
+    def get_news(self, proxy=None):
+        if self._news:
+            return self._news
+
+        # setup proxy in requests format
+        if proxy is not None:
+            if isinstance(proxy, dict) and "https" in proxy:
+                proxy = proxy["https"]
+            proxy = {"https": proxy}
+
+        # Getting data from json
+        url = "{}/v1/finance/search?q={}".format(self._base_url, self.ticker)
+        data = self.session.get(
+            url=url,
+            proxies=proxy,
+            headers=utils.user_agent_headers
+        )
+        if "Will be right back" in data.text:
+            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
+                               "Our engineers are working quickly to resolve "
+                               "the issue. Thank you for your patience.")
+        data = data.json()
+
+        # parse news
+        self._news = data.get("news", [])
+        return self._news
+

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -199,3 +199,7 @@ class Ticker(TickerBase):
         if not self._expirations:
             self._download_options()
         return tuple(self._expirations.keys())
+
+    @property
+    def news(self):
+        return self.get_news()


### PR DESCRIPTION
This patch partially implements #837.

It adds the `news` property to the ticker class, which can be used to fetch the latest news related to it.

Tests and documentation have been updated accordingly too.