### PR TITLE
Make Historical Shares Outstanding number available (#892)

### DIFF
--- a/test_yfinance.py
+++ b/test_yfinance.py
@@ -50,6 +50,7 @@ class TestTicker(unittest.TestCase):
             ticker.sustainability
             ticker.options
             ticker.news
+            ticker.shares
 
     def test_holders(self):
         for ticker in tickers:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -139,6 +139,10 @@ class Ticker(TickerBase):
         return self.get_actions()
 
     @property
+    def shares(self):
+        return self.get_shares()
+
+    @property
     def info(self):
         return self.get_info()
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -107,6 +107,12 @@ def get_json(url, proxy=None, session=None):
         '(this)')[0].split(';\n}')[0].strip()
     data = _json.loads(json_str)[
         'context']['dispatcher']['stores']['QuoteSummaryStore']
+    # add data about Shares Outstanding for companies' tickers if they are available
+    try:
+        data['annualBasicAverageShares'] = _json.loads(json_str)[
+            'context']['dispatcher']['stores']['QuoteTimeSeriesStore']['timeSeries']['annualBasicAverageShares']
+    except Exception:
+        pass
 
     # return data
     new_data = _json.dumps(data).replace('{}', 'null')


### PR DESCRIPTION
Before this commit there was no option to get the last 4 years' Shares Outstanding of a company. Now, this numbers can be found at the <code>Ticker.shares</code> attribute. Specifically, they refer to the average number of basic shares for each year.