### PR TITLE
Resolves UnboundLocalError in base.py history()

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -190,14 +190,23 @@ class TickerBase():
                 headers=utils.user_agent_headers,
                 timeout=timeout
             )
-            if "Will be right back" in data.text or data is None:
+            if "Will be right back" in data.text:
                 raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                    "Our engineers are working quickly to resolve "
                                    "the issue. Thank you for your patience.")
 
+        except Exception:
+            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
+                               "Our engineers are working quickly to resolve "
+                               "the issue. Thank you for your patience.")
+
+
+        try:
             data = data.json()
         except Exception:
-            pass
+            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
+                               "Our engineers are working quickly to resolve "
+                               "the issue. Thank you for your patience.")
 
         # Work with errors
         debug_mode = True


### PR DESCRIPTION
In base.py history(), session.get can return None. Clarify exception catching within the history() method of base.py.

Ensure a RuntimeError is thrown before the json parse exception, connection exception, or unbound exception can be thrown.

https://imgur.com/a/iXfZsvb

* Ensure YFinance is wrapped by try, except. Pass when this runtime error occurs.