### PR TITLE
Resolves UnboundLocalError in base.py history()

### DIFF
--- a/test_yfinance.py
+++ b/test_yfinance.py
@@ -25,7 +25,8 @@ class TestTicker(unittest.TestCase):
         for ticker in tickers:
             # always should have info and history for valid symbols
             assert(ticker.info is not None and ticker.info != {})
-            assert(ticker.history(period="max").empty is False)
+            history = ticker.history(period="max")
+            assert(history.empty is False and history is not None)
 
     def test_attributes(self):
         for ticker in tickers:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -182,6 +182,8 @@ class TickerBase():
 
         session = self.session or _requests
 
+        data = None
+
         try:
             data = session.get(
                 url=url,
@@ -205,6 +207,14 @@ class TickerBase():
             debug_mode = kwargs["debug"]
 
         err_msg = "No data found for this date range, symbol may be delisted"
+
+        if data is None or not type(data) is dict or 'status_code' in data.keys():
+            shared._DFS[self.ticker] = utils.empty_df()
+            shared._ERRORS[self.ticker] = err_msg
+            if "many" not in kwargs and debug_mode:
+                print('- %s: %s' % (self.ticker, err_msg))
+            return utils.empty_df()
+
         if "chart" in data and data["chart"]["error"]:
             err_msg = data["chart"]["error"]["description"]
             shared._DFS[self.ticker] = utils.empty_df()


### PR DESCRIPTION
In base.py history(), session.get can return None or 404. Clarify exception catching within the history() method of base.py.

Ensure none and 404 values are caught prior to quote processing.

This prevents json parse exception, connection exception, or unbound exception from being thrown during data collection.

https://imgur.com/a/iXfZsvb

Includes updated unit testing.