### PR TITLE
Fix: dev: AttributeError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas>=0.24.0
+pandas>=0.24.0,<=1.3.5
 numpy>=1.16.5
 requests>=2.26
 multitasking>=0.0.7

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     platforms=['any'],
     keywords='pandas, yahoo finance, pandas datareader',
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
-    install_requires=['pandas>=0.24', 'numpy>=1.15',
+    install_requires=['pandas>=0.24.0,<=1.3.5', 'numpy>=1.15',
                       'requests>=2.26', 'multitasking>=0.0.7',
                       'lxml>=4.5.1'],
     entry_points={


### PR DESCRIPTION
Lock pandas version to fix AttributeError: 'Index' object has no attribute 'tz_localize' after pandas upgrade version to 1.4.0
Closes #937 