### PR TITLE
Support cache in `Tickers()`

### DIFF
--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -30,14 +30,14 @@ class Tickers():
     def __repr__(self):
         return 'yfinance.Tickers object <%s>' % ",".join(self.symbols)
 
-    def __init__(self, tickers):
+    def __init__(self, tickers, session=None):
         tickers = tickers if isinstance(
             tickers, list) else tickers.replace(',', ' ').split()
         self.symbols = [ticker.upper() for ticker in tickers]
         ticker_objects = {}
 
         for ticker in self.symbols:
-            ticker_objects[ticker] = Ticker(ticker)
+            ticker_objects[ticker] = Ticker(ticker, session=session)
 
         self.tickers = ticker_objects
         # self.tickers = _namedtuple(


### PR DESCRIPTION
See issue: #677.
In order `Tickers()` to support cache like `Ticker()` doing, this patch makes it allow to pass `session` option arg.

Example:
```python
session = requests_cache.CachedSession('yfinance.cache', allowable_codes=(200, 401))
ts = yfinance.Tickers('GOOG MSFT', session=session)
for t in ts.tickers.values():
  # t.session = session # is needed before.
  pprint.pp(t.info)
```