### PR TITLE
Fixed max period when interval is 1 minute

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -144,20 +144,22 @@ class TickerBase():
         """
 
         if start or period is None or period.lower() == "max":
-            if start is None:
-                start = -631159200
-            elif isinstance(start, _datetime.datetime):
-                start = int(_time.mktime(start.timetuple()))
-            else:
-                start = int(_time.mktime(
-                    _time.strptime(str(start), '%Y-%m-%d')))
             if end is None:
                 end = int(_time.time())
             elif isinstance(end, _datetime.datetime):
                 end = int(_time.mktime(end.timetuple()))
             else:
-                end = int(_time.mktime(_time.strptime(str(end), '%Y-%m-%d')))
-
+                end = int(_time.mktime(_time.strptime(str(end), '%Y-%m-%d'))) 
+            if start is None:
+                if interval=="1m":
+                    start = end - 604800 # Subtract 7 days 
+                else:
+                    start = -631159200
+            elif isinstance(start, _datetime.datetime):
+                start = int(_time.mktime(start.timetuple()))
+            else:
+                start = int(_time.mktime(
+                    _time.strptime(str(start), '%Y-%m-%d')))
             params = {"period1": start, "period2": end}
         else:
             period = period.lower()


### PR DESCRIPTION
When attempting to retrieve the maximum period of time (period="max") at 1 minute intervals, the previous default start period of 1900-01-01 (631159200) would result in an error from the API with description "1m data not available for startTime=*START TIME OF PRICE HISTORY* and endTime=*NOW*. Only 7 days worth of 1m granularity data are allowed to be fetched per request." . By setting the start time to the end time minus 604800 (86400*7) when the interval="1m", it now returns 1 week of 1 minute interval data which is the maximum period for which the API supports at 1 minute intervals.