### PR TITLE
Handle case that the API returns no data for shares of a specific year (#999)

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -521,7 +521,9 @@ class TickerBase():
 
         # shares outstanding
         try:
-            shares = _pd.DataFrame(data['annualBasicAverageShares'])
+            # keep only years with non None data
+            available_shares = [shares_data for shares_data in data['annualBasicAverageShares'] if shares_data]
+            shares = _pd.DataFrame(available_shares)
             shares['Year'] = shares['asOfDate'].agg(lambda x: int(x[:4]))
             shares.set_index('Year', inplace=True)
             shares.drop(columns=['dataId', 'asOfDate', 'periodType', 'currencyCode'], inplace=True)


### PR DESCRIPTION
Before this commit, if the API returned no shares' data of a ticker for one or more years, the <code>shares</code> attribute of <code>Ticker</code> returned None. Now, it returns the shares data for the available years.