### PR TITLE
Added get_earnings_history to fetch earnings data

### DIFF
--- a/test_yfinance.py
+++ b/test_yfinance.py
@@ -52,6 +52,8 @@ class TestTicker(unittest.TestCase):
             ticker.options
             ticker.news
             ticker.shares
+            ticker.earnings_history
+
 
     def test_holders(self):
         for ticker in tickers:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -43,6 +43,7 @@ from . import shared
 
 _BASE_URL_ = 'https://query2.finance.yahoo.com'
 _SCRAPE_URL_ = 'https://finance.yahoo.com/quote'
+_ROOT_URL_ = 'https://finance.yahoo.com'
 
 class TickerBase():
     def __init__(self, ticker, session=None):
@@ -791,3 +792,32 @@ class TickerBase():
         # parse news
         self._news = data.get("news", [])
         return self._news
+
+    def get_earnings_history(self, proxy=None):
+        # setup proxy in requests format
+        if proxy is not None:
+            if isinstance(proxy, dict) and "https" in proxy:
+                proxy = proxy["https"]
+            proxy = {"https": proxy}
+
+        url = "{}/calendar/earnings?symbol={}".format(_ROOT_URL_, self.ticker)
+        session = self.session or _requests
+        data = session.get(
+            url=url,
+            proxies=proxy,
+            headers=utils.user_agent_headers
+        ).text
+
+        if "Will be right back" in data:
+            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
+                               "Our engineers are working quickly to resolve "
+                               "the issue. Thank you for your patience.")
+
+        try:
+            # read_html returns a list of pandas Dataframes of all the tables in `data`
+            data = _pd.read_html(data)[0]
+        # if no tables are found a ValueError is thrown
+        except ValueError:
+            print("Could not find data for {}.".format(self.ticker))
+            return
+        return data

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -211,3 +211,7 @@ class Ticker(TickerBase):
     @property
     def analysis(self):
         return self.get_analysis()
+
+    @property
+    def earnings_history(self):
+        return self.get_earnings_history()


### PR DESCRIPTION
I've been using yfinance for a while and I noticed that it's missing methods to fetch substantial earnings data. The method sends a request to https://finance.yahoo.com/calendar/earnings?symbol={ticker} where {ticker} is self.ticker in the parent class. I used pandas to parse the HTML to pandas.DataFrame since the content in the HTML is a table.