### PR TITLE
Yahoo daily date has accurate datetime - remove overwrite

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -306,10 +306,7 @@ class TickerBase():
         elif params["interval"] == "1h":
             pass
         else:
-            df.index = _pd.to_datetime(df.index.date)
-            if tz is not None:
-                df.index = df.index.tz_localize(tz)
-            df.index.name = "Date"
+            df.index.name = "Datetime"
 
         # duplicates and missing rows cleanup
         df.dropna(how='all', inplace=True)


### PR DESCRIPTION
@ranaroussi , a question for you.

When Yahoo returns daily price data it includes an accurate time e.g.:

|  | Open | High | Low | Close | Adj Close | Volume
| - | - | - | - | - | - | - |
**2022-02-07 14:30:00+00:00** | 48.130001 | 48.66 | 47.959999 | 48.18 | 47.802139 | 27558500

That's UTC, aka 9.30am Eastern, start of trading day. This time is useful.

Q. But in yfinance you discard the time. Can you remember why?

Btw if user has provided 'tz', then date column prints as `2022-02-07 00:00:00` rather than `2022-02-07.` I think better to restore time.

--

This merge will restore time value.