### PR TITLE
Fix Yahoo returning 1wk data across 2 rows

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -315,6 +315,13 @@ class TickerBase():
                 quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]
                 quotes = quotes.iloc[0:n-1]
                 n = quotes.shape[0]
+        # Similar bug in daily data, except most data is simply duplicated
+        # - exception is volume, *slightly* different on final row (and matches website)
+        if interval=="1d" and n > 1:
+            if quotes.index[n-1].date() == quotes.index[n-2].date():
+                # Last two rows are on same day. Drop second-to-last row
+                quotes = quotes.drop(quotes.index[n-2])
+                n = quotes.shape[0]
 
         # combine
         df = _pd.concat([quotes, dividends, splits], axis=1, sort=True)


### PR DESCRIPTION
Yahoo sometimes returns this week price data across two rows - todays data separated from rest-of-week. Seems to depend on the clock time (e.g. evening after exchange closed) and what ticker/exchange.

yf.Ticker("IMP.JP).history(start="2022-06-10",end="2022-06-25", interval="1wk")
> 
>                                    Open          High           Low  ...        Volume  Dividends  Stock Splits
> 2022-06-06 00:00:00+00:00  30215.279297  30609.310547  26762.648438  ...  112969275959          0             0
> 2022-06-13 00:00:00+00:00  26737.578125  26795.589844  17708.623047  ...  309685915250          0             0
> **2022-06-20 00:00:00+00:00**  20553.371094  21620.628906  19689.169922  ...  114551561992          0             0
> **2022-06-24 20:41:00+00:00**  21112.822266  21327.408203  20786.849609  ...   25183909888          0             0

Fix merges these rows - min/max/sum as appropriate.