### PR TITLE
Bugfix: This weeks' price data across 2 rows

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -297,6 +297,30 @@ class TickerBase():
             if quotes.index[quotes.shape[0]-1] > endDt:
                 quotes = quotes.iloc[0:quotes.shape[0]-1]
 
+        # Fix bug in weekly data. If market is open today then Yahoo MAY return 
+        # todays data as a separate row from rest-of-week in above row. 
+        # Seems to depend on what exchange e.g. crypto OK.
+        # Fix = merge them together
+        n = quotes.shape[0]
+        if interval=="1wk" and n > 1:
+            if (quotes.index[n-1] - quotes.index[n-2]) <= _datetime.timedelta(days=5):
+                # Last two rows are within same week
+                idx1 = quotes.index[n-1]
+                idx2 = quotes.index[n-2]
+                # quotes.loc[idx2,"Open"] # Leave
+                quotes.loc[idx2,"High"] = max(quotes["High"][n-1], quotes["High"][n-2])
+                quotes.loc[idx2,"Low"] = min(quotes["Low"][n-1], quotes["Low"][n-2])
+                quotes.loc[idx2,"Close"] = quotes["Close"][n-1]
+                if "Adj High" in quotes.columns:
+                    quotes.loc[idx2,"Adj High"] = max(quotes["Adj High"][n-1], quotes["Adj High"][n-2])
+                if "Adj Low" in quotes.columns:
+                    quotes.loc[idx2,"Adj Low"] = min(quotes["Adj Low"][n-1], quotes["Adj Low"][n-2])
+                if "Adj Close" in quotes.columns:
+                    quotes.loc[idx2,"Adj Close"] = quotes["Adj Close"][n-1]
+                quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]
+                quotes = quotes.iloc[0:n-1]
+                n = quotes.shape[0]
+
         # combine
         df = _pd.concat([quotes, dividends, splits], axis=1, sort=True)
         df["Dividends"].fillna(0, inplace=True)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -308,7 +308,7 @@ class TickerBase():
             dt2 = quotes.index[n-2].tz_localize("UTC").tz_convert(tz_exchange)
             if interval in ["1wk", "1mo"]:
                 if interval == "1wk":
-                    last_rows_same_interval = (dt1-dt2 <= _datetime.timedelta(days=5)) and (dt1.weekday()>dt2.weekday())
+                    last_rows_same_interval = (dt1-dt2 <= _datetime.timedelta(days=5)) and (dt1.weekday()>=dt2.weekday())
                 else:
                     last_rows_same_interval = dt1.month==dt2.month
                 if last_rows_same_interval:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -315,14 +315,16 @@ class TickerBase():
                     # Last two rows are within same interval
                     idx1 = quotes.index[n-1]
                     idx2 = quotes.index[n-2]
-                    # quotes.loc[idx2,"Open"] # Leave
-                    quotes.loc[idx2,"High"] = max(quotes["High"][n-1], quotes["High"][n-2])
-                    quotes.loc[idx2,"Low"] = min(quotes["Low"][n-1], quotes["Low"][n-2])
+                    if _np.isnan(quotes.loc[idx2,"Open"]):
+                        quotes.loc[idx2,"Open"] = quotes["Open"][n-1]
+					# Note: _np.nanmax() ignores NaNs
+                    quotes.loc[idx2,"High"] = _np.nanmax([quotes["High"][n-1], quotes["High"][n-2]])
+                    quotes.loc[idx2,"Low"] = _np.nanmin([quotes["Low"][n-1], quotes["Low"][n-2]])
                     quotes.loc[idx2,"Close"] = quotes["Close"][n-1]
                     if "Adj High" in quotes.columns:
-                        quotes.loc[idx2,"Adj High"] = max(quotes["Adj High"][n-1], quotes["Adj High"][n-2])
+                        quotes.loc[idx2,"Adj High"] = _np.nanmax([quotes["Adj High"][n-1], quotes["Adj High"][n-2]])
                     if "Adj Low" in quotes.columns:
-                        quotes.loc[idx2,"Adj Low"] = min(quotes["Adj Low"][n-1], quotes["Adj Low"][n-2])
+                        quotes.loc[idx2,"Adj Low"] = _np.nanmin([quotes["Adj Low"][n-1], quotes["Adj Low"][n-2]])
                     if "Adj Close" in quotes.columns:
                         quotes.loc[idx2,"Adj Close"] = quotes["Adj Close"][n-1]
                     quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -317,7 +317,7 @@ class TickerBase():
                     idx2 = quotes.index[n-2]
                     if _np.isnan(quotes.loc[idx2,"Open"]):
                         quotes.loc[idx2,"Open"] = quotes["Open"][n-1]
-					# Note: _np.nanmax() ignores NaNs
+                    # Note: _np.nanmax() ignores NaNs
                     quotes.loc[idx2,"High"] = _np.nanmax([quotes["High"][n-1], quotes["High"][n-2]])
                     quotes.loc[idx2,"Low"] = _np.nanmin([quotes["Low"][n-1], quotes["Low"][n-2]])
                     quotes.loc[idx2,"Close"] = quotes["Close"][n-1]

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -320,6 +320,13 @@ class TickerBase():
                 quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]
                 quotes = quotes.iloc[0:n-1]
                 n = quotes.shape[0]
+        # Similar bug in daily data, except most data is simply duplicated
+        # - exception is volume, *slightly* different on final row (and matches website)
+        if interval=="1d" and n > 1:
+            if quotes.index[n-1].date() == quotes.index[n-2].date():
+                # Last two rows are on same day. Drop second-to-last row
+                quotes = quotes.drop(quotes.index[n-2])
+                n = quotes.shape[0]
 
         # combine
         df = _pd.concat([quotes, dividends, splits], axis=1, sort=True)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -291,52 +291,15 @@ class TickerBase():
         # actions
         dividends, splits = utils.parse_actions(data["chart"]["result"][0], tz)
 
+        tz_exchange = data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
+
         # Yahoo bug fix - it often appends latest price even if after end date
         if end and not quotes.empty:
             endDt = _pd.to_datetime(_datetime.datetime.fromtimestamp(end))
             if quotes.index[quotes.shape[0]-1] > endDt:
                 quotes = quotes.iloc[0:quotes.shape[0]-1]
 
-        # Yahoo bug fix. If market is open today then Yahoo normally returns 
-        # todays data as a separate row from rest-of-interval in above row. 
-        # Seems to depend on what exchange e.g. crypto OK.
-        # Fix = merge them together
-        n = quotes.shape[0]
-        if n > 1:
-            tz_exchange = data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
-            dt1 = quotes.index[n-1].tz_localize("UTC").tz_convert(tz_exchange)
-            dt2 = quotes.index[n-2].tz_localize("UTC").tz_convert(tz_exchange)
-            if interval in ["1wk", "1mo"]:
-                if interval == "1wk":
-                    last_rows_same_interval = (dt1-dt2 <= _datetime.timedelta(days=5)) and (dt1.weekday()>=dt2.weekday())
-                else:
-                    last_rows_same_interval = dt1.month==dt2.month
-                if last_rows_same_interval:
-                    # Last two rows are within same interval
-                    idx1 = quotes.index[n-1]
-                    idx2 = quotes.index[n-2]
-                    if _np.isnan(quotes.loc[idx2,"Open"]):
-                        quotes.loc[idx2,"Open"] = quotes["Open"][n-1]
-                    # Note: _np.nanmax() ignores NaNs
-                    quotes.loc[idx2,"High"] = _np.nanmax([quotes["High"][n-1], quotes["High"][n-2]])
-                    quotes.loc[idx2,"Low"] = _np.nanmin([quotes["Low"][n-1], quotes["Low"][n-2]])
-                    quotes.loc[idx2,"Close"] = quotes["Close"][n-1]
-                    if "Adj High" in quotes.columns:
-                        quotes.loc[idx2,"Adj High"] = _np.nanmax([quotes["Adj High"][n-1], quotes["Adj High"][n-2]])
-                    if "Adj Low" in quotes.columns:
-                        quotes.loc[idx2,"Adj Low"] = _np.nanmin([quotes["Adj Low"][n-1], quotes["Adj Low"][n-2]])
-                    if "Adj Close" in quotes.columns:
-                        quotes.loc[idx2,"Adj Close"] = quotes["Adj Close"][n-1]
-                    quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]
-                    quotes = quotes.iloc[0:n-1]
-                    n = quotes.shape[0]
-            # Similar bug in daily data, except most data is simply duplicated
-            # - exception is volume, *slightly* different on final row (and matches website)
-            elif interval=="1d":
-                if dt1.date() == dt2.date():
-                    # Last two rows are on same day. Drop second-to-last row
-                    quotes = quotes.drop(quotes.index[n-2])
-                    n = quotes.shape[0]
+        quotes = utils.fix_Yahoo_returning_live_separate(quotes, params["interval"], tz_exchange)
 
         # combine
         df = _pd.concat([quotes, dividends, splits], axis=1, sort=True)

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -21,6 +21,7 @@
 
 from __future__ import print_function
 
+import datetime as _datetime
 import requests as _requests
 import re as _re
 import pandas as _pd
@@ -236,6 +237,52 @@ def parse_actions(data, tz=None):
             splits = splits["Stock Splits"]
 
     return dividends, splits
+
+
+def fix_Yahoo_returning_live_separate(quotes, interval, tz_exchange):
+    # Yahoo bug fix. If market is open today then Yahoo normally returns 
+    # todays data as a separate row from rest-of-interval in above row. 
+    # Seems to depend on what exchange e.g. crypto OK.
+    # Fix = merge them together
+    n = quotes.shape[0]
+    if n > 1:
+        dt1 = quotes.index[n-1].tz_localize("UTC").tz_convert(tz_exchange)
+        dt2 = quotes.index[n-2].tz_localize("UTC").tz_convert(tz_exchange)
+        if interval in ["1wk", "1mo", "3mo"]:
+            if interval == "1wk":
+                last_rows_same_interval = dt1.year==dt2.year and dt1.week==dt2.week
+            elif interval == "1mo":
+                last_rows_same_interval = dt1.month==dt2.month
+            elif interval == "3mo":
+                last_rows_same_interval = dt1.year==dt2.year and dt1.quarter==dt2.quarter
+            if last_rows_same_interval:
+                # Last two rows are within same interval
+                idx1 = quotes.index[n-1]
+                idx2 = quotes.index[n-2]
+                if _np.isnan(quotes.loc[idx2,"Open"]):
+                    quotes.loc[idx2,"Open"] = quotes["Open"][n-1]
+                # Note: nanmax() & nanmin() ignores NaNs
+                quotes.loc[idx2,"High"] = _np.nanmax([quotes["High"][n-1], quotes["High"][n-2]])
+                quotes.loc[idx2,"Low"] = _np.nanmin([quotes["Low"][n-1], quotes["Low"][n-2]])
+                quotes.loc[idx2,"Close"] = quotes["Close"][n-1]
+                if "Adj High" in quotes.columns:
+                    quotes.loc[idx2,"Adj High"] = _np.nanmax([quotes["Adj High"][n-1], quotes["Adj High"][n-2]])
+                if "Adj Low" in quotes.columns:
+                    quotes.loc[idx2,"Adj Low"] = _np.nanmin([quotes["Adj Low"][n-1], quotes["Adj Low"][n-2]])
+                if "Adj Close" in quotes.columns:
+                    quotes.loc[idx2,"Adj Close"] = quotes["Adj Close"][n-1]
+                quotes.loc[idx2,"Volume"] += quotes["Volume"][n-1]
+                quotes = quotes.iloc[0:n-1]
+                n = quotes.shape[0]
+        
+        # Similar bug in daily data except most data is simply duplicated
+        # - exception is volume, *slightly* different on final row (and matches website)
+        elif interval=="1d":
+            if dt1.date() == dt2.date():
+                # Last two rows are on same day. Drop second-to-last row
+                quotes = quotes.drop(quotes.index[n-2])
+                n = quotes.shape[0]
+    return quotes
 
 
 class ProgressBar:


### PR DESCRIPTION
Yahoo sometimes returns this week price data across two rows - todays data separated from rest-of-week. Seems to depend on the clock time (e.g. evening after exchange closed) and what ticker/exchange. Happens with monthly too.

yf.Ticker("IMP.JP).history(start="2022-06-10",end="2022-06-25", interval="1wk")
> 
>                                    Open          High           Low  ...        Volume  Dividends  Stock Splits
> 2022-06-06 00:00:00+00:00  30215.279297  30609.310547  26762.648438  ...  112969275959          0             0
> 2022-06-13 00:00:00+00:00  26737.578125  26795.589844  17708.623047  ...  309685915250          0             0
> **2022-06-20 00:00:00+00:00**  20553.371094  21620.628906  19689.169922  ...  114551561992          0             0
> **2022-06-24 20:41:00+00:00**  21112.822266  21327.408203  20786.849609  ...   25183909888          0             0

Fix merges these rows - min/max/sum as appropriate.

Similar bug in daily data except only volume is different - last row slightly higher and matches website. Fix is to drop second-to-last row.