### PR TITLE
Fix timezone & datetime handling

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -311,13 +311,19 @@ class TickerBase():
                 quotes = quotes.iloc[0:quotes.shape[0]-1]
 
         # combine
-        df = _pd.concat([quotes, dividends, splits], axis=1, sort=True)
-        df["Dividends"].fillna(0, inplace=True)
-        df["Stock Splits"].fillna(0, inplace=True)
+        df = quotes
+        if dividends.shape[0] > 0:
+            df = _pd.concat([df, dividends], axis=1, sort=True)
+            df["Dividends"].fillna(0, inplace=True)
+        if splits.shape[0] > 0:
+            df = _pd.concat([df, splits], axis=1, sort=True)
+            df["Stock splits"].fillna(0, inplace=True)
 
         # index eod/intraday
-        df.index = df.index.tz_localize("UTC").tz_convert(
-            data["chart"]["result"][0]["meta"]["exchangeTimezoneName"])
+        if df.index[0].tz == None:
+            # Yahoo may date already with timezone set (correctly)
+            df.index = df.index.tz_localize("UTC")
+        df = df.tz_convert(data["chart"]["result"][0]["meta"]["exchangeTimezoneName"])
 
         if params["interval"][-1] == "m":
             df.index.name = "Datetime"

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -329,12 +329,12 @@ class TickerBase():
             data["chart"]["result"][0]["meta"]["exchangeTimezoneName"])
 
         if params["interval"] in ["1d","1w","1wk"]:
-            df.index = _pd.to_datetime(df.index.date)
+            df.index = _pd.to_datetime(df.index.date).tz_localize("UTC")
             df.index.name = "Date"
         else:
             df.index.name = "Datetime"
-            if not tz is None:
-                df.index = df.index.tz_convert(tz)
+        if not tz is None:
+            df.index = df.index.tz_convert(tz)
 
         # duplicates and missing rows cleanup
         df.dropna(how='all', inplace=True)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -160,7 +160,6 @@ class TickerBase():
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
                     end = end.replace(tzinfo=_tz.timezone(self.info["exchangeTimezoneName"]))
-                print("end = {}".format(end))
                 end = int(end.timestamp())
             if start is None:
                 if interval == "1m":

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -159,7 +159,11 @@ class TickerBase():
                     end = _datetime.datetime.combine(end, _datetime.time(23, 59))
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
-                    end = end.replace(tzinfo=_tz.timezone(self.info["exchangeTimezoneName"]))
+                    tz = utils.cache_lookup_tkr_tz(self.ticker)
+                    if tz is None:
+                        tz = self.info["exchangeTimezoneName"]
+                        utils.cache_store_tkr_tz(self.ticker, tz)
+                    end = end.replace(tzinfo=_tz.timezone(tz))
                 end = int(end.timestamp())
             if start is None:
                 if interval == "1m":
@@ -174,7 +178,11 @@ class TickerBase():
                     start = _datetime.datetime.combine(start, _datetime.time(0))
                 if isinstance(start, _datetime.datetime) and start.tzinfo is None:
                     # Assume user is referring to exchange's timezone
-                    start = start.replace(tzinfo=_tz.timezone(self.info["exchangeTimezoneName"]))
+                    tz = utils.cache_lookup_tkr_tz(self.ticker)
+                    if tz is None:
+                        tz = self.info["exchangeTimezoneName"]
+                        utils.cache_store_tkr_tz(self.ticker, tz)
+                    start = start.replace(tzinfo=_tz.timezone(tz))
                 start = int(start.timestamp())
             params = {"period1": start, "period2": end}
         else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -165,7 +165,7 @@ class TickerBase():
                         tz = self.info["exchangeTimezoneName"]
                         # info fetch is relatively slow so cache timezone
                         utils.cache_store_tkr_tz(self.ticker, tz)
-                    end = end.replace(tzinfo=_tz.timezone(tz))
+                    end = _tz.timezone(tz).localize(end)
                 end = int(end.timestamp())
             if start is None:
                 if interval == "1m":
@@ -185,7 +185,7 @@ class TickerBase():
                         tz = self.info["exchangeTimezoneName"]
                         # info fetch is relatively slow so cache timezone
                         utils.cache_store_tkr_tz(self.ticker, tz)
-                    start = start.replace(tzinfo=_tz.timezone(tz))
+                    start = _tz.timezone(tz).localize(start)
                 start = int(start.timestamp())
             params = {"period1": start, "period2": end}
         else:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -153,32 +153,40 @@ class TickerBase():
             if end is None:
                 end = int(_time.time())
             else:
-                # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
-                if isinstance(end, str):
-                    end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')
-                if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):
-                    end = _datetime.datetime.combine(end, _datetime.time(0))
-                if isinstance(end, _datetime.datetime) and end.tzinfo is None:
-                    # Assume user is referring to exchange's timezone
-                    tkr_tz = self._get_ticker_tz()
-                    end = _tz.timezone(tkr_tz).localize(end)
-                end = int(end.timestamp())
+                if isinstance(end, int):
+                    ## Should already be epoch, test with conversion:
+                    end_dt = _datetime.datetime.fromtimestamp(end)
+                else:
+                    # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
+                    if isinstance(end, str):
+                        end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')
+                    if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):
+                        end = _datetime.datetime.combine(end, _datetime.time(0))
+                    if isinstance(end, _datetime.datetime) and end.tzinfo is None:
+                        # Assume user is referring to exchange's timezone
+                        tkr_tz = self._get_ticker_tz()
+                        end = _tz.timezone(tkr_tz).localize(end)
+                    end = int(end.timestamp())
             if start is None:
                 if interval == "1m":
                     start = end - 604800  # Subtract 7 days
                 else:
                     start = -631159200
             else:
-                # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
-                if isinstance(start, str):
-                    start = _datetime.datetime.strptime(str(start), '%Y-%m-%d')
-                if isinstance(start, _datetime.date) and not isinstance(start, _datetime.datetime):
-                    start = _datetime.datetime.combine(start, _datetime.time(0))
-                if isinstance(start, _datetime.datetime) and start.tzinfo is None:
-                    # Assume user is referring to exchange's timezone
-                    tkr_tz = self._get_ticker_tz()
-                    start = _tz.timezone(tkr_tz).localize(start)
-                start = int(start.timestamp())
+                if isinstance(start, int):
+                    ## Should already be epoch, test with conversion:
+                    start_dt = _datetime.datetime.fromtimestamp(start)
+                else:
+                    # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
+                    if isinstance(start, str):
+                        start = _datetime.datetime.strptime(str(start), '%Y-%m-%d')
+                    if isinstance(start, _datetime.date) and not isinstance(start, _datetime.datetime):
+                        start = _datetime.datetime.combine(start, _datetime.time(0))
+                    if isinstance(start, _datetime.datetime) and start.tzinfo is None:
+                        # Assume user is referring to exchange's timezone
+                        tkr_tz = self._get_ticker_tz()
+                        start = _tz.timezone(tkr_tz).localize(start)
+                    start = int(start.timestamp())
             params = {"period1": start, "period2": end}
         else:
             period = period.lower()

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -153,15 +153,17 @@ class TickerBase():
                 end = int(_time.time())
             else:
                 # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
+                # - if time not set, set to midnight aka 00:00 next day
                 if isinstance(end, str):
-                    end = _datetime.datetime.strptime(str(end)+" 23:59", '%Y-%m-%d %H:%S')
+                    end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')+_datetime.timedelta(days=1)
                 if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):
-                    end = _datetime.datetime.combine(end, _datetime.time(23, 59))
+                    end = _datetime.datetime.combine(end, _datetime.time(0))+_datetime.timedelta(days=1)
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
                     tz = utils.cache_lookup_tkr_tz(self.ticker)
                     if tz is None:
                         tz = self.info["exchangeTimezoneName"]
+                        # info fetch is relatively slow so cache timezone
                         utils.cache_store_tkr_tz(self.ticker, tz)
                     end = end.replace(tzinfo=_tz.timezone(tz))
                 end = int(end.timestamp())
@@ -181,6 +183,7 @@ class TickerBase():
                     tz = utils.cache_lookup_tkr_tz(self.ticker)
                     if tz is None:
                         tz = self.info["exchangeTimezoneName"]
+                        # info fetch is relatively slow so cache timezone
                         utils.cache_store_tkr_tz(self.ticker, tz)
                     start = start.replace(tzinfo=_tz.timezone(tz))
                 start = int(start.timestamp())

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -313,10 +313,14 @@ class TickerBase():
         df = quotes
         if dividends.shape[0] > 0:
             df = _pd.concat([df, dividends], axis=1, sort=True)
-            df["Dividends"].fillna(0, inplace=True)
+        else:
+            df["Dividends"] = _np.nan
+        df["Dividends"].fillna(0, inplace=True)
         if splits.shape[0] > 0:
             df = _pd.concat([df, splits], axis=1, sort=True)
-            df["Stock splits"].fillna(0, inplace=True)
+        else:
+            df["Stock splits"] = _np.nan
+        df["Stock splits"].fillna(0, inplace=True)
 
         # establish timezone
         df.index = df.index.tz_localize("UTC")

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -153,7 +153,6 @@ class TickerBase():
                 end = int(_time.time())
             else:
                 # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
-                # - if time not set, set to midnight aka 00:00 next day
                 if isinstance(end, str):
                     end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')
                 if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -155,7 +155,7 @@ class TickerBase():
                 # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
                 if isinstance(end, str):
                     end = _datetime.datetime.strptime(str(end)+" 23:59", '%Y-%m-%d %H:%S')
-                if isinstance(end, _datetime.date):
+                if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):
                     end = _datetime.datetime.combine(end, _datetime.time(23, 59))
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
@@ -171,7 +171,7 @@ class TickerBase():
                 # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
                 if isinstance(start, str):
                     start = _datetime.datetime.strptime(str(start), '%Y-%m-%d')
-                if isinstance(start, _datetime.date):
+                if isinstance(start, _datetime.date) and not isinstance(start, _datetime.datetime):
                     start = _datetime.datetime.combine(start, _datetime.time(0))
                 if isinstance(start, _datetime.datetime) and start.tzinfo is None:
                     # Assume user is referring to exchange's timezone

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -150,14 +150,14 @@ class TickerBase():
             if end is None:
                 end = int(_time.time())
             else:
-                end = self._parse_user_dt(end)
+                end = utils._parse_user_dt(end, self._get_ticker_tz())
             if start is None:
                 if interval == "1m":
                     start = end - 604800  # Subtract 7 days
                 else:
                     start = -631159200
             else:
-                start = self._parse_user_dt(start)
+                start = utils._parse_user_dt(start, self._get_ticker_tz())
             params = {"period1": start, "period2": end}
         else:
             period = period.lower()
@@ -336,23 +336,6 @@ class TickerBase():
 
         self._tz = tkr_tz
         return tkr_tz
-
-    def _parse_user_dt(self, dt):
-        if isinstance(dt, int):
-            ## Should already be epoch, test with conversion:
-            _datetime.datetime.fromtimestamp(dt)
-        else:
-            # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
-            if isinstance(dt, str):
-                dt = _datetime.datetime.strptime(str(dt), '%Y-%m-%d')
-            if isinstance(dt, _datetime.date) and not isinstance(dt, _datetime.datetime):
-                dt = _datetime.datetime.combine(dt, _datetime.time(0))
-            if isinstance(dt, _datetime.datetime) and dt.tzinfo is None:
-                # Assume user is referring to exchange's timezone
-                tkr_tz = self._get_ticker_tz()
-                dt = _tz.timezone(tkr_tz).localize(dt)
-            dt = int(dt.timestamp())
-        return dt
 
     def _get_info(self, proxy=None):
         # setup proxy in requests format

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -54,6 +54,7 @@ class TickerBase():
         self._history = None
         self._base_url = _BASE_URL_
         self._scrape_url = _SCRAPE_URL_
+        self._tz = None
 
         self._fundamentals = False
         self._info = None
@@ -342,11 +343,16 @@ class TickerBase():
     # ------------------------
 
     def _get_ticker_tz(self):
+        if not self._tz is None:
+            return self._tz
+
         tkr_tz = utils.cache_lookup_tkr_tz(self.ticker)
         if tkr_tz is None:
             tkr_tz = self.info["exchangeTimezoneName"]
             # info fetch is relatively slow so cache timezone
             utils.cache_store_tkr_tz(self.ticker, tkr_tz)
+
+        self._tz = tkr_tz
         return tkr_tz
 
     def _get_info(self, proxy=None):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -155,9 +155,9 @@ class TickerBase():
                 # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
                 # - if time not set, set to midnight aka 00:00 next day
                 if isinstance(end, str):
-                    end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')+_datetime.timedelta(days=1)
+                    end = _datetime.datetime.strptime(str(end), '%Y-%m-%d')
                 if isinstance(end, _datetime.date) and not isinstance(end, _datetime.datetime):
-                    end = _datetime.datetime.combine(end, _datetime.time(0))+_datetime.timedelta(days=1)
+                    end = _datetime.datetime.combine(end, _datetime.time(0))
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
                     tkr_tz = utils.cache_lookup_tkr_tz(self.ticker)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -26,7 +26,7 @@ import datetime as _datetime
 import requests as _requests
 import pandas as _pd
 import numpy as _np
-import zoneinfo as _zi
+import pytz as _tz
 import re as _re
 
 try:
@@ -159,7 +159,7 @@ class TickerBase():
                     end = _datetime.datetime.combine(end, _datetime.time(23, 59))
                 if isinstance(end, _datetime.datetime) and end.tzinfo is None:
                     # Assume user is referring to exchange's timezone
-                    end = end.replace(tzinfo=_zi.ZoneInfo(self.info["exchangeTimezoneName"]))
+                    end = end.replace(tzinfo=_tz.timezone(self.info["exchangeTimezoneName"]))
                 print("end = {}".format(end))
                 end = int(end.timestamp())
             if start is None:
@@ -175,7 +175,7 @@ class TickerBase():
                     start = _datetime.datetime.combine(start, _datetime.time(0))
                 if isinstance(start, _datetime.datetime) and start.tzinfo is None:
                     # Assume user is referring to exchange's timezone
-                    start = start.replace(tzinfo=_zi.ZoneInfo(self.info["exchangeTimezoneName"]))
+                    start = start.replace(tzinfo=_tz.timezone(self.info["exchangeTimezoneName"]))
                 start = int(start.timestamp())
             params = {"period1": start, "period2": end}
         else:

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -176,7 +176,7 @@ def back_adjust(data):
     return df[["Open", "High", "Low", "Close", "Volume"]]
 
 
-def parse_quotes(data, tz=None):
+def parse_quotes(data):
     timestamps = data["timestamp"]
     ohlc = data["indicators"]["quote"][0]
     volumes = ohlc["volume"]
@@ -199,13 +199,10 @@ def parse_quotes(data, tz=None):
     quotes.index = _pd.to_datetime(timestamps, unit="s")
     quotes.sort_index(inplace=True)
 
-    if tz is not None:
-        quotes.index = quotes.index.tz_localize(tz)
-
     return quotes
 
 
-def parse_actions(data, tz=None):
+def parse_actions(data):
     dividends = _pd.DataFrame(
         columns=["Dividends"], index=_pd.DatetimeIndex([]))
     splits = _pd.DataFrame(
@@ -218,8 +215,6 @@ def parse_actions(data, tz=None):
             dividends.set_index("date", inplace=True)
             dividends.index = _pd.to_datetime(dividends.index, unit="s")
             dividends.sort_index(inplace=True)
-            if tz is not None:
-                dividends.index = dividends.index.tz_localize(tz)
 
             dividends.columns = ["Dividends"]
 
@@ -229,8 +224,6 @@ def parse_actions(data, tz=None):
             splits.set_index("date", inplace=True)
             splits.index = _pd.to_datetime(splits.index, unit="s")
             splits.sort_index(inplace=True)
-            if tz is not None:
-                splits.index = splits.index.tz_localize(tz)
             splits["Stock Splits"] = splits["numerator"] / \
                 splits["denominator"]
             splits = splits["Stock Splits"]

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 
 import datetime as _datetime
+import pytz as _tz
 import requests as _requests
 import re as _re
 import pandas as _pd
@@ -136,6 +137,23 @@ def get_json(url, proxy=None, session=None):
 
 def camel2title(o):
     return [_re.sub("([a-z])([A-Z])", r"\g<1> \g<2>", i).title() for i in o]
+
+
+def _parse_user_dt(dt, exchange_tz):
+    if isinstance(dt, int):
+        ## Should already be epoch, test with conversion:
+        _datetime.datetime.fromtimestamp(dt)
+    else:
+        # Convert str/date -> datetime, set tzinfo=exchange, get timestamp:
+        if isinstance(dt, str):
+            dt = _datetime.datetime.strptime(str(dt), '%Y-%m-%d')
+        if isinstance(dt, _datetime.date) and not isinstance(dt, _datetime.datetime):
+            dt = _datetime.datetime.combine(dt, _datetime.time(0))
+        if isinstance(dt, _datetime.datetime) and dt.tzinfo is None:
+            # Assume user is referring to exchange's timezone
+            dt = _tz.timezone(exchange_tz).localize(dt)
+        dt = int(dt.timestamp())
+    return dt
 
 
 def auto_adjust(data):


### PR DESCRIPTION
This big update fixes all problems related to timezones:
1. Convert Yahoo datetimes from UTC into timezone of exchange [#978](https://github.com/ranaroussi/yfinance/issues/978) [#1010](https://github.com/ranaroussi/yfinance/issues/1010)
2. If user provided timezone-naive datetimes then assume they mean timezone of exchange [#1010](https://github.com/ranaroussi/yfinance/issues/1010)
3. Use `datetime` module for epoch read/write instead of `time` [#954](https://github.com/ranaroussi/yfinance/issues/954) [#949](https://github.com/ranaroussi/yfinance/issues/949)
4. Yahoo can mess up DST so day start time is off by an hour - e.g. Brazil around Jan-2022 is 23:00 instead of 00:00. So detect and adjust to 00:00
5. Process user-provided `tz` argument correctly - use it to convert, not localize

This requires knowing exchange timezone, which means looking up `Ticker.info[]` but that's expensive! Splitting `info[]` creation out of `_get_fundamentals()` into `_get_info()` helped but still slow. So solution is to cache the timezone in users cache folder, because why would it change?

I've been using this personally for a month now, no problems.

Will fix these issues: [#971](https://github.com/ranaroussi/yfinance/issues/971)

These issues probably fixed too (difficult to test): [#890](https://github.com/ranaroussi/yfinance/issues/890) [#871](https://github.com/ranaroussi/yfinance/issues/871) [#805](https://github.com/ranaroussi/yfinance/issues/805) [#413](https://github.com/ranaroussi/yfinance/issues/413)