### PR TITLE
Bugfix: Get logo url when no website exists

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -460,9 +460,12 @@ class TickerBase():
 
         self._info['logo_url'] = ""
         try:
-            domain = self._info['website'].split(
-                '://')[1].split('/')[0].replace('www.', '')
-            self._info['logo_url'] = 'https://logo.clearbit.com/%s' % domain
+            if not 'website' in self._info:
+                self._info['logo_url'] = 'https://logo.clearbit.com/%s.com' % self._info['shortName'].split(' ')[0].split(',')[0]
+            else:
+                domain = self._info['website'].split(
+                    '://')[1].split('/')[0].replace('www.', '')
+                self._info['logo_url'] = 'https://logo.clearbit.com/%s' % domain
         except Exception:
             pass
 


### PR DESCRIPTION
Hi.
This is a very helpful project. I noticed that when no website exists on the info, the logo url is not generated. I add a little change that in this case uses the small name that allways is present.
I think this could help with this Issue:
 
yfinance info logo_url value problem #1062