### PR TITLE
Fixed bookvalue / bookvalue per share discrepancy

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -441,6 +441,16 @@ class TickerBase():
         except Exception:
             pass
 
+        #rename bookvalue to bookvalue per share
+        #calculate and create true bookvalue
+        try:
+            if 'bookValue' in self._info:
+                self._info['bookValuePS'] = self._info.pop('bookValue')
+                if 'sharesOutstanding' in self._info:
+                    self._info['bookValue'] = self._info['bookValuePS']*self._info['sharesOutstanding']
+        except Exception:
+            pass
+
     def _get_fundamentals(self, proxy=None):
         def cleanup(data):
             df = _pd.DataFrame(data).drop(columns=['maxAge'])


### PR DESCRIPTION
bookValue entry is currently the book value per share. I renamed bookValue to bookValuePS. Also created a new bookValue entry with the true book value by multiplying bookValuePS by the # of shares outstanding. Resolves #936. 

(This is my first pull request and was for a class project, so apologies if this is a low quality submission!)
