### PR TITLE
Fix and improve timezone cache concurrency

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -379,7 +379,7 @@ class TickerBase():
         if not self._tz is None:
             return self._tz
 
-        tz = utils.cache_lookup_tkr_tz(self.ticker)
+        tz = utils.tz_cache.lookup(self.ticker)
 
         if tz is not None:
             invalid_value = not isinstance(tz, str)
@@ -391,7 +391,7 @@ class TickerBase():
 
             if invalid_value:
                 # Clear from cache and force re-fetch
-                utils.cache_store_tkr_tz(self.ticker, None)
+                utils.tz_cache.store(self.ticker, None)
                 tz = None
 
         if tz is None:
@@ -407,7 +407,7 @@ class TickerBase():
                     tz = None
             if tz is not None:
                 # info fetch is relatively slow so cache timezone
-                utils.cache_store_tkr_tz(self.ticker, tz)
+                utils.tz_cache.store(self.ticker, tz)
 
         self._tz = tz
         return tz

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -559,6 +559,8 @@ class _TzCache:
     def tz_db(self):
         # lazy init
         if self._tz_db is None:
+            if not _os.path.isdir(self.cache_dirpath):
+                _os.makedirs(self.cache_dirpath)
             self._tz_db = _KVStore(_os.path.join(self.cache_dirpath, "tkr-tz.db"))
             self._migrate_cache_tkr_tz()
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -532,4 +532,5 @@ def cache_store_tkr_tz(tkr, tz):
             tz_db.delete(tkr)
         elif tz_db.get(tkr) is not None:
             raise Exception("Tkr {} tz already in cache".format(tkr))
-        return tz_db.set(tkr, tz)
+        else:
+            tz_db.set(tkr, tz)

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -517,7 +517,7 @@ class _KVStore:
         if item:
             return next(item, (None,))[0]
 
-    def set(self, key: str, value) -> str:
+    def set(self, key: str, value: str) -> str:
         with self._cache_mutex:
             self.conn.execute('replace into "kv" (key, value) values (?,?)', (key, value))
             self.conn.commit()
@@ -570,6 +570,7 @@ class _TzCache:
         if not _os.path.isfile(fp):
             return None
         df = _pd.read_csv(fp, index_col="Ticker")
+        print(df.to_dict()['Tz'])
         self.tz_db.bulk_set(df.to_dict()['Tz'])
         _os.remove(fp)
 


### PR DESCRIPTION
Instead of doing homegrown caching using CSV files and having to handle tricky concurrency issues use built in python module SQLite (simple SQL-database) for the ticker/timezone-cache.

Hopefully this should lead to less issues and better performance.

I did some performance tests and on my machine (*) adding 1000 tickers and reading them back took 1s. And 2:nd run when they did not need to be added to cache it took 100ms.

Also did some test with running concurrent python scripts reading/writing the same db and it seems to work well.

* Windows 10, Python 3.8 AMD Ryzen 5 3600 and SSD)

```
def main():
    res_list = []
    for i in range(1000):
        k = f"key_{i}"
        v = f"val_{i}"
        res = tz_db.get(k)
        if not res:
            tz_db.set(k, v)
        res_list.append(tz_db.get(k))
    return res_list

if __name__ == '__main__':
    start = time.time()
    main()
    end = time.time()
    print(f"Took: {end-start}")
```

First run and no existing db or empty:
```
Took: 1.1271133422851562
```

Second run when all keys was found:
```
Took: 0.015013933181762695
```
