### PR TITLE
Fix cache error on read only system

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ Yahoo! finance API is intended for personal use only.**
 
 The `Ticker` module, which allows you to access ticker data in a more Pythonic way:
 
-Note: yahoo finance datetimes are received as UTC.
-
 ```python
 import yfinance as yf
 
@@ -212,6 +210,18 @@ data = yf.download(  # or pdr.get_data_yahoo(...
         # (optional, default is None)
         proxy = None
     )
+```
+
+### Timezone cache store
+
+When fetching price data, all dates are localized to stock exchange timezone. 
+But timezone retrieval is relatively slow, so yfinance attemps to cache them 
+in your users cache folder. 
+You can direct cache to use a different location with `set_tz_cache_location()`:
+```python
+import yfinance as yf
+yf.set_tz_cache_location("custom/cache/location")
+...
 ```
 
 ### Managing Multi-Level Columns

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -23,6 +23,7 @@ from . import version
 from .ticker import Ticker
 from .tickers import Tickers
 from .multi import download
+from .utils import set_tz_cache_location
 
 __version__ = version.version
 __author__ = "Ran Aroussi"
@@ -42,4 +43,4 @@ def pdr_override():
         pass
 
 
-__all__ = ['download', 'Ticker', 'Tickers', 'pdr_override']
+__all__ = ['download', 'Ticker', 'Tickers', 'pdr_override', 'set_tz_cache_location']

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -339,7 +339,11 @@ class TickerBase():
         if tkr_tz is None:
             tkr_tz = self.info["exchangeTimezoneName"]
             # info fetch is relatively slow so cache timezone
-            utils.cache_store_tkr_tz(self.ticker, tkr_tz)
+            try:
+                utils.cache_store_tkr_tz(self.ticker, tkr_tz)
+            except PermissionError:
+                # System probably read-only, so cannot cache
+                pass
 
         self._tz = tkr_tz
         return tkr_tz

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -322,6 +322,7 @@ def get_cache_dirpath():
         dp = _os.path.join(_ad.user_cache_dir(), "py-yfinance")
     else:
         dp = _os.path.join(_cache_dp, "py-yfinance")
+    return dp
 def set_tz_cache_location(dp):
     global _cache_dp
     _cache_dp = dp

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -316,8 +316,16 @@ class ProgressBar:
 
 
 # Simple file cache of ticker->timezone:
+_cache_dp = None
 def get_cache_dirpath():
-    return _os.path.join(_ad.user_cache_dir(), "py-yfinance")
+    if _cache_dp is None:
+        dp = _os.path.join(_ad.user_cache_dir(), "py-yfinance")
+    else:
+        dp = _os.path.join(_cache_dp, "py-yfinance")
+def set_tz_cache_location(dp):
+    global _cache_dp
+    _cache_dp = dp
+
 def cache_lookup_tkr_tz(tkr):
     fp = _os.path.join(get_cache_dirpath(), "tkr-tz.csv")
     if not _os.path.isfile(fp):


### PR DESCRIPTION
Silently handle errors in the timezone-cache without stopping execution.

Add `set_tz_cache_location()` so user can provide alternative location, in case default not accessible.

Resolves issue #1107