### PR TITLE
Feature - repair 100x price errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@ data = yf.download(  # or pdr.get_data_yahoo(...
         # (optional, default is False)
         auto_adjust = True,
 
+        # identify and attempt repair of currency unit mixups e.g. $/cents
+        repair = False,
+
         # download pre/post regular market hours data
         # (optional, default is False)
         prepost = True,

--- a/tests/prices.py
+++ b/tests/prices.py
@@ -243,6 +243,65 @@ class TestPriceHistory(unittest.TestCase):
 		self.assertTrue((f_100|f_1).all())
 
 
+	def test_repair_weekly2_preSplit(self):
+		# Sometimes, Yahoo returns prices 100x the correct value. 
+		# Suspect mixup between £/pence or $/cents etc.
+		# E.g. ticker PNL.L
+
+		# PNL.L has a stock-split in 2022. Sometimes requesting data before 2022 is not split-adjusted.
+
+		tkr = "PNL.L"
+		start = "2020-01-06"
+		end = "2021-06-01"
+		import requests_cache ; session = requests_cache.CachedSession("/home/gonzo/.cache/yfinance.cache")
+		dat = yf.Ticker(tkr, session=session)
+
+		data_cols = ["Low","High","Open","Close","Adj Close"]
+		df_bad = dat.history(start=start, end=end, interval="1wk", auto_adjust=False, repair=False)
+		f_outlier = _np.where(df_bad[data_cols]>1000.0)
+		indices = None
+		if len(f_outlier[0])==0:
+			self.skipTest("Skipping test_repair_weekly() because no price 100x errors to repair")
+
+		# Outliers detected
+		indices = []
+		for i in range(len(f_outlier[0])):
+			indices.append((f_outlier[0][i], f_outlier[1][i]))
+
+		df = dat.history(start=start, end=end, interval="1wk", auto_adjust=False, repair=True)
+
+		# First test - no errors left
+		df_data = df[data_cols].values
+		for i,j in indices:
+			try:
+				self.assertTrue(df_data[i,j] < 1000.0)
+			except:
+				print("Detected uncorrected error: idx={}, {}={}".format(df.index[i], data_cols[j], df_data[i,j]))
+				# print(df.iloc[i-1:i+2])
+				raise
+
+		# Second test - all differences should be either ~1x or ~100x
+		ratio = df_bad[data_cols].values/df[data_cols].values
+		ratio = ratio.round(2)
+		# - round near-100 ratio to 100:
+		f = ratio>90
+		ratio[f] = (ratio[f]/10).round().astype(int)*10 # round ratio to nearest 10
+		# - now test
+		f_100 = ratio==100
+		f_1 = ratio==1
+		try:
+			self.assertTrue((f_100|f_1).all())
+		except:
+			f_bad = ~(f_100|f_1)
+			print("df_bad[f_bad]:")
+			print(df_bad[f_bad.any(axis=1)])
+			print("df[f_bad]:")
+			print(df[f_bad.any(axis=1)])
+			print("ratio[f_bad]")
+			print(ratio[f_bad])
+			raise
+
+
 	def test_repair_daily(self):
 		# Sometimes, Yahoo returns prices 100x the correct value. 
 		# Suspect mixup between £/pence or $/cents etc.

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -424,6 +424,7 @@ class TickerBase():
                         mixups[idx]["Adj Factor"] = df.loc[idx,"Adj Close"]/df.loc[idx,"Close"]
                     else:
                         mixups[idx]["fields"].add(dc)
+        n_mixups = len(mixups)
 
         if len(mixups) > 0:
             # Problem with Yahoo's mixup is they calculate high & low after, so they can be corrupted.
@@ -489,8 +490,10 @@ class TickerBase():
                     if len(m["fields"])==0:
                         del mixups[idx]
 
+            n_fixed = n_mixups - len(mixups)
+            print("{}: fixed {} currency unit mixups in {} price data".format(self.ticker, n_fixed, interval))
             if len(mixups)>0:
-                print("WARNING: Failed to correct {} currency unit mixups".format(len(mixups)))
+                print("    ... and failed to correct {}".format(len(mixups)))
 
         return df
 

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -30,7 +30,7 @@ from . import shared
 
 
 def download(tickers, start=None, end=None, actions=False, threads=True, ignore_tz=True, 
-             group_by='column', auto_adjust=False, back_adjust=False, keepna=False,
+             group_by='column', auto_adjust=False, back_adjust=False, repair=False, keepna=False,
              progress=True, period="max", show_errors=True, interval="1d", prepost=False,
              proxy=None, rounding=False, timeout=None, **kwargs):
     """Download yahoo tickers
@@ -56,6 +56,9 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             Default is False
         auto_adjust: bool
             Adjust all OHLC automatically? Default is False
+        repair: bool
+            Detect currency unit 100x mixups and attempt repair
+            Default is False
         keepna: bool
             Keep NaN rows returned by Yahoo?
             Default is False
@@ -111,7 +114,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             _download_one_threaded(ticker, period=period, interval=interval,
                                    start=start, end=end, prepost=prepost,
                                    actions=actions, auto_adjust=auto_adjust,
-                                   back_adjust=back_adjust, keepna=keepna,
+                                   back_adjust=back_adjust, repair=repair, keepna=keepna,
                                    progress=(progress and i > 0), proxy=proxy,
                                    rounding=rounding, timeout=timeout)
         while len(shared._DFS) < len(tickers):
@@ -123,7 +126,8 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             data = _download_one(ticker, period=period, interval=interval,
                                  start=start, end=end, prepost=prepost,
                                  actions=actions, auto_adjust=auto_adjust,
-                                 back_adjust=back_adjust, keepna=keepna, proxy=proxy,
+                                 back_adjust=back_adjust, repair=repair, keepna=keepna, 
+                                 proxy=proxy, 
                                  rounding=rounding, timeout=timeout)
             shared._DFS[ticker.upper()] = data
             if progress:
@@ -191,12 +195,12 @@ def _realign_dfs():
 
 @_multitasking.task
 def _download_one_threaded(ticker, start=None, end=None,
-                           auto_adjust=False, back_adjust=False,
+                           auto_adjust=False, back_adjust=False, repair=False, 
                            actions=False, progress=True, period="max",
                            interval="1d", prepost=False, proxy=None,
                            keepna=False, rounding=False, timeout=None):
 
-    data = _download_one(ticker, start, end, auto_adjust, back_adjust,
+    data = _download_one(ticker, start, end, auto_adjust, back_adjust, repair, 
                          actions, period, interval, prepost, proxy, rounding,
                          keepna, timeout)
     shared._DFS[ticker.upper()] = data
@@ -205,7 +209,7 @@ def _download_one_threaded(ticker, start=None, end=None,
 
 
 def _download_one(ticker, start=None, end=None,
-                  auto_adjust=False, back_adjust=False,
+                  auto_adjust=False, back_adjust=False, repair=False, 
                   actions=False, period="max", interval="1d",
                   prepost=False, proxy=None, rounding=False,
                   keepna=False, timeout=None):
@@ -213,6 +217,6 @@ def _download_one(ticker, start=None, end=None,
     return Ticker(ticker).history(period=period, interval=interval,
                                   start=start, end=end, prepost=prepost,
                                   actions=actions, auto_adjust=auto_adjust,
-                                  back_adjust=back_adjust, proxy=proxy,
+                                  back_adjust=back_adjust, repair=repair, proxy=proxy,
                                   rounding=rounding, keepna=keepna, many=True,
                                   timeout=timeout)

--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -46,20 +46,23 @@ class Tickers():
 
     def history(self, period="1mo", interval="1d",
                 start=None, end=None, prepost=False,
-                actions=True, auto_adjust=True, proxy=None,
+                actions=True, auto_adjust=True, repair=False,
+                proxy=None,
                 threads=True, group_by='column', progress=True,
                 timeout=None, **kwargs):
 
         return self.download(
             period, interval,
             start, end, prepost,
-            actions, auto_adjust, proxy,
+            actions, auto_adjust, repair, 
+            proxy,
             threads, group_by, progress,
             timeout, **kwargs)
 
     def download(self, period="1mo", interval="1d",
                  start=None, end=None, prepost=False,
-                 actions=True, auto_adjust=True, proxy=None,
+                 actions=True, auto_adjust=True, repair=False, 
+                 proxy=None,
                  threads=True, group_by='column', progress=True,
                  timeout=None, **kwargs):
 
@@ -67,6 +70,7 @@ class Tickers():
                               start=start, end=end,
                               actions=actions,
                               auto_adjust=auto_adjust,
+                              repair=repair,
                               period=period,
                               interval=interval,
                               prepost=prepost,

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -255,6 +255,17 @@ def parse_actions(data):
     return dividends, splits
 
 
+def set_df_tz(df, interval, tz):
+    if df.index.tz is None:
+        df.index = df.index.tz_localize("UTC")
+    df.index = df.index.tz_convert(tz)
+    if interval in ["1d","1w","1wk","1mo","3mo"]:
+        # If localizing a midnight during DST transition hour when clocks roll back, 
+        # meaning clock hits midnight twice, then use the 2nd (ambiguous=True)
+        df.index = _pd.to_datetime(df.index.date).tz_localize(tz, ambiguous=True)
+    return df
+
+
 def fix_Yahoo_returning_live_separate(quotes, interval, tz_exchange):
     # Yahoo bug fix. If market is open today then Yahoo normally returns 
     # todays data as a separate row from rest-of week/month interval in above row. 
@@ -262,8 +273,13 @@ def fix_Yahoo_returning_live_separate(quotes, interval, tz_exchange):
     # Fix = merge them together
     n = quotes.shape[0]
     if n > 1:
-        dt1 = quotes.index[n-1].tz_localize("UTC").tz_convert(tz_exchange)
-        dt2 = quotes.index[n-2].tz_localize("UTC").tz_convert(tz_exchange)
+        dt1 = quotes.index[n-1]
+        dt2 = quotes.index[n-2]
+        if quotes.index.tz is None:
+            dt1 = dt1.tz_localize("UTC")
+            dt2 = dt2.tz_localize("UTC")
+        dt1 = dt1.tz_convert(tz_exchange)
+        dt2 = dt2.tz_convert(tz_exchange)
         if interval in ["1wk", "1mo", "3mo"]:
             if interval == "1wk":
                 last_rows_same_interval = dt1.year==dt2.year and dt1.week==dt2.week


### PR DESCRIPTION
Yahoo sometimes returns random prices 100x correct value. Only seen in London tickers, typically weekly data. Looks like Yahoo is mixing up currency units £ and pence. See issue #552 for detail.

Solution uses a `scipy` module to find these outliers. For Open/Close divide by 100, simple. For High/Low must recalculate because corrupted - 100 x low = new high. Recalculation fetches data at next resolution, e.g. if repairing weekly data fetch daily data for that week. Potential to trigger Yahoo spam detection, but normally only few outliers in a year of data so not expecting to trigger.

Deliberately not adding scipy to dependencies, assuming most users won't use this feature.