### PR TITLE
Improve performance of fetching Ticker timezone

### DIFF
--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -1,0 +1,36 @@
+from .context import yfinance as yf
+
+import unittest
+
+import requests_cache
+session = requests_cache.CachedSession("/home/gonzo/.cache/yfinance.cache")
+
+class TestTicker(unittest.TestCase):
+	def setUp(self):
+		self.session = session
+
+	def tearDown(self):
+		pass
+
+
+	def test_getTz(self):
+		tkrs = []
+		tkrs.append("IMP.JO")
+		tkrs.append("BHG.JO")
+		tkrs.append("SSW.JO")
+		tkrs.append("BP.L")
+		tkrs.append("INTC")
+		test_run = False
+		for tkr in tkrs:
+			# First step: remove ticker from tz-cache
+			yf.utils.tz_cache.store(tkr, None)
+
+			# Test:
+			dat = yf.Ticker(tkr, session=self.session)
+			tz = dat._get_ticker_tz(debug_mode=False, proxy=None, timeout=None)
+
+			self.assertIsNotNone(tz)
+
+
+if __name__ == '__main__':
+	unittest.main()

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -2,12 +2,9 @@ from .context import yfinance as yf
 
 import unittest
 
-import requests_cache
-session = requests_cache.CachedSession("/home/gonzo/.cache/yfinance.cache")
-
 class TestTicker(unittest.TestCase):
 	def setUp(self):
-		self.session = session
+		pass
 
 	def tearDown(self):
 		pass
@@ -26,7 +23,7 @@ class TestTicker(unittest.TestCase):
 			yf.utils.tz_cache.store(tkr, None)
 
 			# Test:
-			dat = yf.Ticker(tkr, session=self.session)
+			dat = yf.Ticker(tkr)
 			tz = dat._get_ticker_tz(debug_mode=False, proxy=None, timeout=None)
 
 			self.assertIsNotNone(tz)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -558,7 +558,7 @@ class TickerBase():
 
     def _fetch_ticker_tz(self, proxy=None, timeout=None):
         # Query Yahoo for basic price data just to get returned timezone
-        
+
         params = {"range":"1wk", "interval":"1d"}
 
         # setup proxy in requests format
@@ -576,20 +576,6 @@ class TickerBase():
             if "Will be right back" in data.text or data is None:
                 return None
             data = data.json()
-        except Exception:
-            data = None
-
-        fail = False
-        if data is None or not type(data) is dict:
-            fail = True
-        elif type(data) is dict and 'status_code' in data.keys():
-            fail = True
-        elif not "chart" in data or data["chart"]["result"] is None or not data["chart"]["result"]:
-            fail = True
-        if fail:
-            return None
-
-        try:
             return data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
         except:
             return None

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -103,7 +103,7 @@ class TickerBase():
     def history(self, period="1mo", interval="1d",
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
-                proxy=None, rounding=False, timeout=None, **kwargs):
+                proxy=None, rounding=False, timeout=10, **kwargs):
         """
         :Parameters:
             period : str
@@ -139,7 +139,7 @@ class TickerBase():
             timeout: None or float
                 If not None stops waiting for a response after given number of
                 seconds. (Can also be a fraction of a second e.g. 0.01)
-                Default is None.
+                Default is 10 seconds.
             **kwargs: dict
                 debug: bool
                     Optional. If passed as False, will suppress
@@ -159,7 +159,7 @@ class TickerBase():
 
         if start or period is None or period.lower() == "max":
             # Check can get TZ. Fail => probably delisted
-            tz = self._get_ticker_tz(proxy, timeout)
+            tz = self._get_ticker_tz(debug_mode, proxy, timeout)
             if tz is None:
                 # Every valid ticker has a timezone. Missing = problem
                 err_msg = "No timezone found, symbol certainly delisted"
@@ -533,7 +533,7 @@ class TickerBase():
         return df
 
 
-    def _get_ticker_tz(self, proxy=None, timeout=None):
+    def _get_ticker_tz(self, debug_mode, proxy, timeout):
         if not self._tz is None:
             return self._tz
 
@@ -545,7 +545,7 @@ class TickerBase():
             tz = None
 
         if tz is None:
-            tz = self._fetch_ticker_tz(proxy, timeout)
+            tz = self._fetch_ticker_tz(debug_mode, proxy, timeout)
 
             if utils.is_valid_timezone(tz):
                 # info fetch is relatively slow so cache timezone
@@ -556,10 +556,10 @@ class TickerBase():
         self._tz = tz
         return tz
 
-    def _fetch_ticker_tz(self, proxy=None, timeout=None):
+    def _fetch_ticker_tz(self, debug_mode, proxy, timeout):
         # Query Yahoo for basic price data just to get returned timezone
 
-        params = {"range":"1wk", "interval":"1d"}
+        params = {"range":"1d", "interval":"1d"}
 
         # setup proxy in requests format
         if proxy is not None:
@@ -575,7 +575,9 @@ class TickerBase():
             data = session.get(url=url, params=params, proxies=proxy, headers=utils.user_agent_headers, timeout=timeout)
             data = data.json()
             return data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
-        except:
+        except Exception as e:
+            if debug_mode:
+                print("Failed to get ticker '{}' reason: {}".format(self.ticker, e))
             return None
 
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -573,8 +573,6 @@ class TickerBase():
         session = self.session or _requests
         try:
             data = session.get(url=url, params=params, proxies=proxy, headers=utils.user_agent_headers, timeout=timeout)
-            if "Will be right back" in data.text or data is None:
-                return None
             data = data.json()
             return data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
         except:

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -32,7 +32,7 @@ from . import shared
 def download(tickers, start=None, end=None, actions=False, threads=True, ignore_tz=True, 
              group_by='column', auto_adjust=False, back_adjust=False, repair=False, keepna=False,
              progress=True, period="max", show_errors=True, interval="1d", prepost=False,
-             proxy=None, rounding=False, timeout=None, **kwargs):
+             proxy=None, rounding=False, timeout=10, **kwargs):
     """Download yahoo tickers
     :Parameters:
         tickers : str, list
@@ -198,7 +198,7 @@ def _download_one_threaded(ticker, start=None, end=None,
                            auto_adjust=False, back_adjust=False, repair=False, 
                            actions=False, progress=True, period="max",
                            interval="1d", prepost=False, proxy=None,
-                           keepna=False, rounding=False, timeout=None):
+                           keepna=False, rounding=False, timeout=10):
 
     data = _download_one(ticker, start, end, auto_adjust, back_adjust, repair, 
                          actions, period, interval, prepost, proxy, rounding,
@@ -212,7 +212,7 @@ def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False, repair=False, 
                   actions=False, period="max", interval="1d",
                   prepost=False, proxy=None, rounding=False,
-                  keepna=False, timeout=None):
+                  keepna=False, timeout=10):
 
     return Ticker(ticker).history(period=period, interval=interval,
                                   start=start, end=end, prepost=prepost,

--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -49,7 +49,7 @@ class Tickers():
                 actions=True, auto_adjust=True, repair=False,
                 proxy=None,
                 threads=True, group_by='column', progress=True,
-                timeout=None, **kwargs):
+                timeout=10, **kwargs):
 
         return self.download(
             period, interval,
@@ -64,7 +64,7 @@ class Tickers():
                  actions=True, auto_adjust=True, repair=False, 
                  proxy=None,
                  threads=True, group_by='column', progress=True,
-                 timeout=None, **kwargs):
+                 timeout=10, **kwargs):
 
         data = multi.download(self.symbols,
                               start=start, end=end,


### PR DESCRIPTION
Instead of fetching and building `info`, just fetch basic price data which contains timezone. ~1.7x speedup. Hopefully also reduces failures to get timezone (issue #1076)