### PR TITLE
Move get 'trailingPegRatio' into _get_info(), simplify & optimise

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -706,6 +706,50 @@ class TickerBase():
         except Exception:
             pass
 
+        # Complementary key-statistics. For now just want 'trailing PEG ratio'
+        session = self.session or _requests
+        keys = {"trailingPegRatio"}
+        if len(keys)>0:
+            # Simplified the original scrape code for key-statistics. Very expensive for fetching
+            # just one value, best if scraping most/all:
+            #
+            # p = _re.compile(r'root\.App\.main = (.*);')
+            # url = 'https://finance.yahoo.com/quote/{}/key-statistics?p={}'.format(self.ticker, self.ticker)
+            # try:
+            #     r = session.get(url, headers=utils.user_agent_headers)
+            #     data = _json.loads(p.findall(r.text)[0])
+            #     key_stats = data['context']['dispatcher']['stores']['QuoteTimeSeriesStore']["timeSeries"]
+            #     for k in keys:
+            #         if k not in key_stats or len(key_stats[k])==0:
+            #             # Yahoo website prints N/A, indicates Yahoo lacks necessary data to calculate
+            #             v = None
+            #         else:
+            #             # Select most recent (last) raw value in list:
+            #             v = key_stats[k][-1]["reportedValue"]["raw"]
+            #         self._info[k] = v
+            # except Exception:
+            #     raise
+            #     pass
+            #
+            # For just one/few variable is faster to query directly:
+            url = "https://query1.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/{}?symbol={}".format(self.ticker, self.ticker)
+            for k in keys:
+                url += "&type="+k
+            # Request 6 months of data
+            url += "&period1={}".format(int((_datetime.datetime.now()-_datetime.timedelta(days=365//2)).timestamp()))
+            url += "&period2={}".format(int((_datetime.datetime.now()+_datetime.timedelta(days=1)).timestamp()))
+            json_str = session.get(url=url, proxies=proxy, headers=utils.user_agent_headers).text
+            json_data = _json.loads(json_str)
+            key_stats = json_data["timeseries"]["result"][0]
+            if k not in key_stats:
+                # Yahoo website prints N/A, indicates Yahoo lacks necessary data to calculate
+                v = None
+            else:
+                # Select most recent (last) raw value in list:
+                v = key_stats[k][-1]["reportedValue"]["raw"]
+            self._info[k] = v
+
+
     def _get_fundamentals(self, proxy=None):
         def cleanup(data):
             df = _pd.DataFrame(data).drop(columns=['maxAge'])
@@ -864,48 +908,6 @@ class TickerBase():
                     c for c in analysis.columns if c not in dict_cols]]
             except Exception:
                 pass
-
-        # Complementary key-statistics (currently fetching the important trailingPegRatio which is the value shown in the website)
-        res = {}
-        try:
-            my_headers = {'user-agent': 'curl/7.55.1', 'accept': 'application/json', 'content-type': 'application/json',
-                          'referer': 'https://finance.yahoo.com/', 'cache-control': 'no-cache', 'connection': 'close'}
-            p = _re.compile(r'root\.App\.main = (.*);')
-            r = _requests.session().get('https://finance.yahoo.com/quote/{}/key-statistics?p={}'.format(self.ticker,
-                                                                                                        self.ticker), headers=my_headers)
-            q_results = {}
-            my_qs_keys = ['pegRatio']  # QuoteSummaryStore
-            # , 'quarterlyPegRatio']  # QuoteTimeSeriesStore
-            my_ts_keys = ['trailingPegRatio']
-
-            # Complementary key-statistics
-            data = _json.loads(p.findall(r.text)[0])
-            key_stats = data['context']['dispatcher']['stores']['QuoteTimeSeriesStore']
-            q_results.setdefault(self.ticker, [])
-            for i in my_ts_keys:
-                # j=0
-                try:
-                    # res = {i: key_stats['timeSeries'][i][1]['reportedValue']['raw']}
-                    # We need to loop over multiple items, if they exist: 0,1,2,..
-                    zzz = key_stats['timeSeries'][i]
-                    for j in range(len(zzz)):
-                        if key_stats['timeSeries'][i][j]:
-                            res = {i: key_stats['timeSeries']
-                                   [i][j]['reportedValue']['raw']}
-                            q_results[self.ticker].append(res)
-
-                # print(res)
-                # q_results[ticker].append(res)
-                except:
-                    q_results[ticker].append({i: np.nan})
-
-            res = {'Company': ticker}
-            q_results[ticker].append(res)
-        except Exception:
-            pass
-
-        if 'trailingPegRatio' in res:
-            self._info['trailingPegRatio'] = res['trailingPegRatio']
 
         self._fundamentals = True
 


### PR DESCRIPTION
Resolve #1114, which was caused by redundant code so just removed it.

Move the logic into `_get_info()` - I introduced this bug in my big timezone update (#1048), so 'trailingPegRatio' would have disappeared from `info[]`.

Simplify the code as loop is unnecessary. Also disable it, replacing with a direct GET - scraping a whole page for one variable is a waste. Keep the original code in case do want all key statistics in future.

@rickturner2001 I believe you first requested that 'trailingPegRatio' be fixed (#903).