### PR TITLE
Fix the fixes for Yahoo data issues (DST, weekly-2-rows) + tests

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -460,10 +460,6 @@ def set_df_tz(df, interval, tz):
     if df.index.tz is None:
         df.index = df.index.tz_localize("UTC")
     df.index = df.index.tz_convert(tz)
-    if interval in ["1d", "1w", "1wk", "1mo", "3mo"]:
-        # If localizing a midnight during DST transition hour when clocks roll back, 
-        # meaning clock hits midnight twice, then use the 2nd (ambiguous=True)
-        df.index = _pd.to_datetime(df.index.date).tz_localize(tz, ambiguous=True)
     return df
 
 


### PR DESCRIPTION
In the reordering of quotes processing (base.py#L297) I had accidentally disabled 2x Yahoo bug fixes:
- Yahoo messing up DST
- Yahoo returning weekly/monthly data across 2 rows

Now enabled, with tests to be sure.