### PR TITLE
For ETFs & Mutual Funds, add fundProfile & fundPerformance details

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -652,6 +652,20 @@ class TickerBase():
         except Exception:
             pass
 
+        # For ETFs & Mutual Funds, provide fund profile
+        try:
+            if 'fundProfile' in data:
+                self._info.update(data['fundProfile'])
+        except Exception:
+            pass
+
+        # For ETFs & Mutual Funds, provide fund performance
+        try:
+            if 'fundPerformance' in data:
+                self._info.update(data['fundPerformance'])
+        except Exception:
+            pass
+
         try:
             if not isinstance(data.get('summaryDetail'), dict):
                 # For some reason summaryDetail did not give any results. The price dict usually has most of the same info

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -638,7 +638,6 @@ class TickerBase:
                         print("-------------")
         return None
 
-
     def get_recommendations(self, proxy=None, as_dict=False):
         self._quote.proxy = proxy
         data = self._quote.recommendations

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -97,6 +97,20 @@ class Quote:
         except Exception:
             pass
 
+        # For ETFs & Mutual Funds, provide fund profile
+        try:
+            if 'fundProfile' in quote_summary_store:
+                self._info.update(quote_summary_store['fundProfile'])
+        except Exception:
+            pass
+
+        # For ETFs & Mutual Funds, provide fund performance
+        try:
+            if 'fundPerformance' in quote_summary_store:
+                self._info.update(quote_summary_store['fundPerformance'])
+        except Exception:
+            pass
+
         try:
             if not isinstance(quote_summary_store.get('summaryDetail'), dict):
                 # For some reason summaryDetail did not give any results. The price dict


### PR DESCRIPTION
Hi,

This change will add support for showing fundProfile & fundPerformance of ETFs and Mutual Funds.

fundProfile will add support for useful fields like

- family
- categoryName
- brokerages
- managementInfo
- feesExpensesInvestment
- feesExpensesInvestmentCat

fundPerfomance will add support for useful fields like

- trailingReturns
- trailingReturnsCat
- trailingReturnsNav
- performanceOverview
- performanceOverviewCat
- riskOverviewStatistics
- riskOverviewStatisticsCat
- rankInCategory
- loadAdjustedReturns
- pastQuarterlyReturns
- annualTotalReturns
- returnsCat
