### PR TITLE
Fix corrupt tkr-tz-csv halting code

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -336,7 +336,7 @@ def cache_lookup_tkr_tz(tkr):
         return None
 
     mutex.acquire()
-    df = _pd.read_csv(fp, index_col="Ticker")
+    df = _pd.read_csv(fp, index_col="Ticker", on_bad_lines="skip")
     mutex.release()
     if tkr in df.index:
         return df.loc[tkr,"Tz"]
@@ -355,7 +355,7 @@ def cache_store_tkr_tz(tkr,tz):
         df.to_csv(fp)
 
     else:
-        df = _pd.read_csv(fp, index_col="Ticker")
+        df = _pd.read_csv(fp, index_col="Ticker", on_bad_lines="skip")
         if tz is None:
             # Delete if in cache:
             if tkr in df.index:


### PR DESCRIPTION
Somehow additional ',' were appearing in ticker tz csv, i.e. adding more than 2 columns (issue #1158), generating an exception:

> pandas.errors.ParserError: Error tokenizing data. C error: Expected 2 fields saw 3

Fix = silently discard corrupt csv rows.