### PR TITLE
Fix disable prints inside threads (bpython deadlock)

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -145,6 +145,9 @@ class TickerBase():
         debug_mode = True
         if "debug" in kwargs and isinstance(kwargs["debug"], bool):
             debug_mode = kwargs["debug"]
+        if "many" in kwargs and kwargs["many"]:
+            # Disable prints with threads, it deadlocks/throws
+            debug_mode = False
 
         err_msg = "No data found for this date range, symbol may be delisted"
 
@@ -155,7 +158,7 @@ class TickerBase():
                 # Every valid ticker has a timezone. Missing = problem
                 shared._DFS[self.ticker] = utils.empty_df()
                 shared._ERRORS[self.ticker] = err_msg
-                if "many" not in kwargs and debug_mode:
+                if debug_mode:
                     print('- %s: %s' % (self.ticker, err_msg))
                 return utils.empty_df()
 
@@ -215,7 +218,7 @@ class TickerBase():
         if data is None or not type(data) is dict or 'status_code' in data.keys():
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode:
+            if debug_mode:
                 print('- %s: %s' % (self.ticker, err_msg))
             return utils.empty_df()
 
@@ -223,7 +226,7 @@ class TickerBase():
             err_msg = data["chart"]["error"]["description"]
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode:
+            if debug_mode:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -231,7 +234,7 @@ class TickerBase():
                 not data["chart"]["result"]:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode:
+            if debug_mode:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -246,7 +249,7 @@ class TickerBase():
         except Exception:
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode:
+            if debug_mode:
                 print('- %s: %s' % (self.ticker, err_msg))
             return shared._DFS[self.ticker]
 
@@ -282,7 +285,7 @@ class TickerBase():
                 err_msg = "back_adjust failed with %s" % e
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if "many" not in kwargs and debug_mode:
+            if debug_mode:
                 print('- %s: %s' % (self.ticker, err_msg))
 
         if rounding:

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -198,7 +198,7 @@ def _download_one_threaded(ticker, start=None, end=None,
 
     data = _download_one(ticker, start, end, auto_adjust, back_adjust,
                          actions, period, interval, prepost, proxy, rounding,
-                         keepna, timeout)
+                         keepna, timeout, many=True)
     shared._DFS[ticker.upper()] = data
     if progress:
         shared._PROGRESS_BAR.animate()
@@ -208,11 +208,11 @@ def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False,
                   actions=False, period="max", interval="1d",
                   prepost=False, proxy=None, rounding=False,
-                  keepna=False, timeout=None):
+                  keepna=False, timeout=None, many=False):
 
     return Ticker(ticker).history(period=period, interval=interval,
                                   start=start, end=end, prepost=prepost,
                                   actions=actions, auto_adjust=auto_adjust,
                                   back_adjust=back_adjust, proxy=proxy,
-                                  rounding=rounding, keepna=keepna, many=True,
-                                  timeout=timeout)
+                                  rounding=rounding, keepna=keepna, timeout=timeout, 
+                                  many=many)


### PR DESCRIPTION
`debug_mode` was not correctly disabled during threaded execution, causing bpython interpreter to deadlock. Fixes #1096