### PR TITLE
Fixing issue 980 by changing default timestamp for start parameter in…

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -164,7 +164,8 @@ class TickerBase:
                 if interval == "1m":
                     start = end - 604800  # Subtract 7 days
                 else:
-                    start = -631159200
+		    #time stamp of 01/01/1900
+                    start = -2208994789
             else:
                 start = utils._parse_user_dt(start, tz)
             params = {"period1": start, "period2": end}


### PR DESCRIPTION
default timestamp for "start" parameter was set to 01/01/1950, so no data before that date was fetched. Set default value to 01/01/1900. This should fix https://github.com/ranaroussi/yfinance/issues/980

… base.py