### PR TITLE
Serve old financials when new financials are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ msft.capital_gains
 # show share count
 msft.shares
 
-# show income statement
+# Financials:
+# - income statement
 msft.income_stmt
 msft.quarterly_income_stmt
-
-# show balance sheet
+# - balance sheet
 msft.balance_sheet
 msft.quarterly_balance_sheet
-
-# show cash flow statement
+# - cash flow statement
 msft.cashflow
 msft.quarterly_cashflow
+# see `Ticker.get_income_stmt()` for more options
 
 # show major holders
 msft.major_holders

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -246,9 +246,24 @@ class TestTickerHolders(unittest.TestCase):
 
 
 class TestTickerMiscFinancials(unittest.TestCase):
+    session = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = requests_cache.CachedSession(backend='memory')
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.session is not None:
+            cls.session.close()
 
     def setUp(self):
-        self.ticker = yf.Ticker("GOOGL")
+        self.ticker = yf.Ticker("GOOGL", session=self.session)
+
+        # For ticker 'BSE.AX' (and others), Yahoo not returning 
+        # full quarterly financials (usually cash-flow) with all entries, 
+        # instead returns a smaller version in different data store.
+        self.ticker_old_fmt = yf.Ticker("BSE.AX", session=self.session)
 
     def tearDown(self):
         self.ticker = None
@@ -281,6 +296,16 @@ class TestTickerMiscFinancials(unittest.TestCase):
         for k in expected_keys:
             self.assertIn(k, data.index, "Did not find expected row in index")
 
+    def test_quarterly_income_statement_old_fmt(self):
+        expected_row = "TotalRevenue"
+        data = self.ticker_old_fmt.quarterly_income_stmt
+        self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
+        self.assertFalse(data.empty, "data is empty")
+        self.assertIn(expected_row, data.index, "Did not find expected row in index")
+
+        data_cached = self.ticker_old_fmt.quarterly_income_stmt
+        self.assertIs(data, data_cached, "data not cached")
+
     def test_balance_sheet(self):
         expected_row = "TotalAssets"
         data = self.ticker.balance_sheet
@@ -299,6 +324,16 @@ class TestTickerMiscFinancials(unittest.TestCase):
         self.assertIn(expected_row, data.index, "Did not find expected row in index")
 
         data_cached = self.ticker.quarterly_balance_sheet
+        self.assertIs(data, data_cached, "data not cached")
+
+    def test_quarterly_balance_sheet_old_fmt(self):
+        expected_row = "TotalAssets"
+        data = self.ticker_old_fmt.quarterly_balance_sheet
+        self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
+        self.assertFalse(data.empty, "data is empty")
+        self.assertIn(expected_row, data.index, "Did not find expected row in index")
+
+        data_cached = self.ticker_old_fmt.quarterly_balance_sheet
         self.assertIs(data, data_cached, "data not cached")
 
     def test_balance_sheet_formatting(self):
@@ -327,6 +362,16 @@ class TestTickerMiscFinancials(unittest.TestCase):
         self.assertIn(expected_row, data.index, "Did not find expected row in index")
 
         data_cached = self.ticker.quarterly_cashflow
+        self.assertIs(data, data_cached, "data not cached")
+
+    def test_quarterly_cashflow_old_fmt(self):
+        expected_row = "NetIncome"
+        data = self.ticker_old_fmt.quarterly_cashflow
+        self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
+        self.assertFalse(data.empty, "data is empty")
+        self.assertIn(expected_row, data.index, "Did not find expected row in index")
+
+        data_cached = self.ticker_old_fmt.quarterly_cashflow
         self.assertIs(data, data_cached, "data not cached")
 
     def test_cashflow_formatting(self):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -757,13 +757,13 @@ class TickerBase:
             return dict_data
         return data
 
-    def get_income_stmt(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
+    def get_income_stmt(self, proxy=None, as_dict=False, pretty=False, freq="yearly", legacy=False):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_income_time_series(freq=freq, proxy=proxy)
 
-        if (data is None or data.empty) and fallback:
-            print(f"{self.ticker}: Yahoo not displaying {freq}-income so falling back to old table format")
+        if legacy:
             data = self._fundamentals.financials.get_income_scrape(freq=freq, proxy=proxy)
+        else:
+            data = self._fundamentals.financials.get_income_time_series(freq=freq, proxy=proxy)
             
         if pretty:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["EBIT", "EBITDA", "EPS", "NI"])
@@ -771,27 +771,27 @@ class TickerBase:
             return data.to_dict()
         return data
 
-    def get_balance_sheet(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
+    def get_balance_sheet(self, proxy=None, as_dict=False, pretty=False, freq="yearly", legacy=False):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_balance_sheet_time_series(freq=freq, proxy=proxy)
 
-        if (data is None or data.empty) and fallback:
-            print(f"{self.ticker}: Yahoo not displaying {freq}-balance-sheet so falling back to old table format")
+        if legacy:
             data = self._fundamentals.financials.get_balance_sheet_scrape(freq=freq, proxy=proxy)
-            
+        else:
+            data = self._fundamentals.financials.get_balance_sheet_time_series(freq=freq, proxy=proxy)
+
         if pretty:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["PPE"])
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_cashflow(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
+    def get_cashflow(self, proxy=None, as_dict=False, pretty=False, freq="yearly", legacy=False):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_cash_flow_time_series(freq=freq, proxy=proxy)
-        
-        if (data is None or data.empty) and fallback:
-            print(f"{self.ticker}: Yahoo not displaying {freq}-cashflow so falling back to old table format")
+
+        if legacy:
             data = self._fundamentals.financials.get_cash_flow_scrape(freq=freq, proxy=proxy)
+        else:
+            data = self._fundamentals.financials.get_cash_flow_time_series(freq=freq, proxy=proxy)
 
         if pretty:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["PPE"])

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -757,23 +757,38 @@ class TickerBase:
             return dict_data
         return data
 
-    def get_income_stmt(self, proxy=None, as_dict=False, freq="yearly"):
+    def get_income_stmt(self, proxy=None, as_dict=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_income(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_income_time_series(freq=freq, proxy=proxy)
+
+        if (data is None or data.empty) and fallback:
+            print(f"{self.ticker}: Yahoo not displaying {freq}-income so falling back to old table format")
+            data = self._fundamentals.financials.get_income_scrape(freq=freq, proxy=proxy)
+
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_balance_sheet(self, proxy=None, as_dict=False, freq="yearly"):
+    def get_balance_sheet(self, proxy=None, as_dict=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_balance_sheet(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_balance_sheet_time_series(freq=freq, proxy=proxy)
+
+        if (data is None or data.empty) and fallback:
+            print(f"{self.ticker}: Yahoo not displaying {freq}-balance-sheet so falling back to old table format")
+            data = self._fundamentals.financials.get_balance_sheet_scrape(freq=freq, proxy=proxy)
+
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_cashflow(self, proxy=None, as_dict=False, freq="yearly"):
+    def get_cashflow(self, proxy=None, as_dict=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_cash_flow(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_cash_flow_time_series(freq=freq, proxy=proxy)
+
+        if (data is None or data.empty) and fallback:
+            print(f"{self.ticker}: Yahoo not displaying {freq}-cashflow so falling back to old table format")
+            data = self._fundamentals.financials.get_cash_flow_scrape(freq=freq, proxy=proxy)
+
         if as_dict:
             return data.to_dict()
         return data

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -759,7 +759,7 @@ class TickerBase:
 
     def get_income_stmt(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_income(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_income_time_series(freq=freq, proxy=proxy)
 
         if (data is None or data.empty) and fallback:
             print(f"{self.ticker}: Yahoo not displaying {freq}-income so falling back to old table format")
@@ -773,7 +773,7 @@ class TickerBase:
 
     def get_balance_sheet(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_balance_sheet(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_balance_sheet_time_series(freq=freq, proxy=proxy)
 
         if (data is None or data.empty) and fallback:
             print(f"{self.ticker}: Yahoo not displaying {freq}-balance-sheet so falling back to old table format")
@@ -787,7 +787,7 @@ class TickerBase:
 
     def get_cashflow(self, proxy=None, as_dict=False, pretty=False, freq="yearly", fallback=True):
         self._fundamentals.proxy = proxy
-        data = self._fundamentals.financials.get_cash_flow(freq=freq, proxy=proxy)
+        data = self._fundamentals.financials.get_cash_flow_time_series(freq=freq, proxy=proxy)
         
         if (data is None or data.empty) and fallback:
             print(f"{self.ticker}: Yahoo not displaying {freq}-cashflow so falling back to old table format")


### PR DESCRIPTION
For some tickers Yahoo does not display quarterly financials. I notice most with Australian tickers e.g. BSE.AX . https://finance.yahoo.com/quote/BSE.AX/cash-flow?p=BSE.AX

This means `yfinance` using the TimeSeries API also returns an empty table. But the old-style table is still present in QuoteTimeSeriesStore, so I propose returning this. Question - should user be alerted to switch? How?

@git-shogg