### PR TITLE
Add meta info as new attribute `_meta` to TickerBase

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -46,6 +46,7 @@ class TickerBase:
         self.ticker = ticker.upper()
         self.session = session
         self._history = None
+        self._meta = {}
         self._base_url = _BASE_URL_
         self._scrape_url = _SCRAPE_URL_
         self._tz = None
@@ -233,6 +234,9 @@ class TickerBase:
                 else:
                     print('%s: %s' % (self.ticker, err_msg))
             return utils.empty_df()
+
+        # store the meta information to make it accessible from the outside
+        self._meta = data["chart"]["result"][0]["meta"]
 
         # parse quotes
         try:


### PR DESCRIPTION
Meta information is returned by Yahoo anyway and can for example be used
to check the currency of the data retuerned. Like so:

```python
from yfinance import ticker
msft = ticker.Ticker("MSFT")
hist = msft.history()
print(msft._meta["currency"])
```

See also https://github.com/ranaroussi/yfinance/issues/1195