### PR TITLE
Bump pandas to 1.3.0 ; Remove unused lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,12 +274,10 @@ To install `yfinance` using `conda`, see
 ### Requirements
 
 -   [Python](https://www.python.org) \>= 2.7, 3.4+
--   [Pandas](https://github.com/pydata/pandas) (tested to work with
-    \>=0.23.1)
--   [Numpy](http://www.numpy.org) \>= 1.11.1
--   [requests](http://docs.python-requests.org/en/master/) \>= 2.14.2
--   [lxml](https://pypi.org/project/lxml/) \>= 4.5.1
--   [appdirs](https://pypi.org/project/appdirs) \>=1.4.4
+-   [Pandas](https://github.com/pydata/pandas) \>= 1.3.0
+-   [Numpy](http://www.numpy.org) \>= 1.16.5
+-   [requests](http://docs.python-requests.org/en/master/) \>= 2.26
+-   [appdirs](https://pypi.org/project/appdirs) \>= 1.4.4
 
 ### Optional (if you want to use `pandas_datareader`)
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yfinance" %}
-{% set version = "0.1.58" %}
+{% set version = "0.1.87" %}
 
 package:
   name: "{{ name|lower }}"
@@ -16,21 +16,19 @@ build:
 
 requirements:
   host:
-    - pandas >=0.24.0
+    - pandas >=1.3.0
     - numpy >=1.16.5
-    - requests >=2.21
+    - requests >=2.26
     - multitasking >=0.0.7
-    - lxml >=4.5.1
     - appdirs >= 1.4.4
     - pip
     - python
 
   run:
-    - pandas >=0.24.0
+    - pandas >=1.3.0
     - numpy >=1.16.5
-    - requests >=2.21
+    - requests >=2.26
     - multitasking >=0.0.7
-    - lxml >=4.5.1
     - appdirs >= 1.4.4
     - python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-pandas>=0.24.0
+pandas>=1.3.0
 numpy>=1.16.5
 requests>=2.26
 multitasking>=0.0.7
-lxml>=4.5.1
 appdirs>=1.4.4

--- a/setup.py
+++ b/setup.py
@@ -61,9 +61,9 @@ setup(
     platforms=['any'],
     keywords='pandas, yahoo finance, pandas datareader',
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
-    install_requires=['pandas>=0.24.0', 'numpy>=1.15',
+    install_requires=['pandas>=1.3.0', 'numpy>=1.16.5',
                       'requests>=2.26', 'multitasking>=0.0.7',
-                      'lxml>=4.5.1', 'appdirs>=1.4.4'],
+                      'appdirs>=1.4.4'],
     entry_points={
         'console_scripts': [
             'sample=sample:main',


### PR DESCRIPTION
Bump pandas version to 1.3.0, needed for `on_bad_lines` (#1230)
Remove unused `lxml` (#1222)