### PR TITLE
If fetching price history ending in future, don't use cache

### DIFF
--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -149,11 +149,12 @@ class TestTickerHistory(unittest.TestCase):
         session = requests_cache.CachedSession(backend='memory')
         ticker = yf.Ticker("GOOGL", session=session)
         ticker.history("1y")
-        actual_urls_called = tuple(session.cache.urls)
+        actual_urls_called = tuple([r.url for r in session.cache.filter()])
+        session.close()
         expected_urls = (
             'https://query2.finance.yahoo.com/v8/finance/chart/GOOGL?range=1y&interval=1d&includePrePost=False&events=div%2Csplits%2CcapitalGains',
         )
-        self.assertEquals(expected_urls, actual_urls_called, "Different than expected url used to fetch history.")
+        self.assertEqual(expected_urls, actual_urls_called, "Different than expected url used to fetch history.")
 
     def test_dividends(self):
         data = self.ticker.dividends

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -188,12 +188,9 @@ class TickerBase:
             get_fn = self._data.get
             if end is not None:
                 end_dt = _pd.Timestamp(end, unit='s').tz_localize("UTC")
-                dt_now = _datetime.datetime.utcnow().astimezone(end_dt.tzinfo)
-                print(dt_now)
                 dt_now = end_dt.tzinfo.localize(_datetime.datetime.utcnow())
-                print(dt_now)
-                # if end_dt.date() <= dt_now.date():
-                if end_dt <= dt_now:
+                data_delay = _datetime.timedelta(minutes=30)
+                if end_dt+data_delay <= dt_now:
                     # Date range in past so safe to fetch through cache:
                     get_fn = self._data.cache_get
             data = get_fn(
@@ -208,7 +205,6 @@ class TickerBase:
 
             data = data.json()
         except Exception:
-            raise
             pass
 
         err_msg = "No data found for this date range, symbol may be delisted"

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -185,7 +185,18 @@ class TickerBase:
         data = None
 
         try:
-            data = self._data.get(
+            get_fn = self._data.get
+            if end is not None:
+                end_dt = _pd.Timestamp(end, unit='s').tz_localize("UTC")
+                dt_now = _datetime.datetime.utcnow().astimezone(end_dt.tzinfo)
+                print(dt_now)
+                dt_now = end_dt.tzinfo.localize(_datetime.datetime.utcnow())
+                print(dt_now)
+                # if end_dt.date() <= dt_now.date():
+                if end_dt <= dt_now:
+                    # Date range in past so safe to fetch through cache:
+                    get_fn = self._data.cache_get
+            data = get_fn(
                 url=url,
                 params=params,
                 timeout=timeout
@@ -197,6 +208,7 @@ class TickerBase:
 
             data = data.json()
         except Exception:
+            raise
             pass
 
         err_msg = "No data found for this date range, symbol may be delisted"
@@ -639,7 +651,7 @@ class TickerBase:
         url = "{}/v8/finance/chart/{}".format(self._base_url, self.ticker)
 
         try:
-            data = self._data.get(url=url, params=params, proxy=proxy, timeout=timeout)
+            data = self._data.cache_get(url=url, params=params, proxy=proxy, timeout=timeout)
             data = data.json()
         except Exception as e:
             if debug_mode:
@@ -859,7 +871,7 @@ class TickerBase:
         url = 'https://markets.businessinsider.com/ajax/' \
               'SearchController_Suggest?max_results=25&query=%s' \
               % urlencode(q)
-        data = self._data.get(url=url, proxy=proxy).text
+        data = self._data.cache_get(url=url, proxy=proxy).text
 
         search_str = '"{}|'.format(ticker)
         if search_str not in data:
@@ -881,7 +893,7 @@ class TickerBase:
 
         # Getting data from json
         url = "{}/v1/finance/search?q={}".format(self._base_url, self.ticker)
-        data = self._data.get(url=url, proxy=proxy)
+        data = self._data.cache_get(url=url, proxy=proxy)
         if "Will be right back" in data.text:
             raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                "Our engineers are working quickly to resolve "
@@ -912,7 +924,7 @@ class TickerBase:
             url = "{}/calendar/earnings?symbol={}&offset={}&size={}".format(
                 _ROOT_URL_, self.ticker, page_offset, page_size)
 
-            data = self._data.get(url=url, proxy=proxy).text
+            data = self._data.cache_get(url=url, proxy=proxy).text
 
             if "Will be right back" in data:
                 raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -49,8 +49,6 @@ class TickerData:
         self.ticker = ticker
         self._session = session or requests
 
-    @lru_cache_freezeargs
-    @lru_cache(maxsize=cache_maxsize)
     def get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30):
         proxy = self._get_proxy(proxy)
         response = self._session.get(
@@ -60,6 +58,11 @@ class TickerData:
             timeout=timeout,
             headers=user_agent_headers or self.user_agent_headers)
         return response
+
+    @lru_cache_freezeargs
+    @lru_cache(maxsize=cache_maxsize)
+    def cache_get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30):
+        return self.get(url, user_agent_headers, params, proxy, timeout)
 
     def _get_proxy(self, proxy):
         # setup proxy in requests format

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -196,7 +196,7 @@ class Fiancials:
         url += "&period1={}&period2={}".format(int(start_dt.timestamp()), int(end.timestamp()))
 
         # Step 3: fetch and reshape data
-        json_str = self._data.get(url=url, proxy=proxy).text
+        json_str = self._data.cache_get(url=url, proxy=proxy).text
         json_data = json.loads(json_str)
         data_raw = json_data["timeseries"]["result"]
         # data_raw = [v for v in data_raw if len(v) > 1] # Discard keys with no data

--- a/yfinance/scrapers/holders.py
+++ b/yfinance/scrapers/holders.py
@@ -34,7 +34,7 @@ class Holders:
     def _scrape(self, proxy):
         ticker_url = "{}/{}".format(self._SCRAPE_URL_, self._data.ticker)
         try:
-            resp = self._data.get(ticker_url + '/holders', proxy)
+            resp = self._data.cache_get(ticker_url + '/holders', proxy)
             holders = pd.read_html(resp.text)
         except Exception:
             holders = []

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -198,7 +198,7 @@ class Quote:
                 int((datetime.datetime.now() - datetime.timedelta(days=365 // 2)).timestamp()))
             url += "&period2={}".format(int((datetime.datetime.now() + datetime.timedelta(days=1)).timestamp()))
 
-            json_str = self._data.get(url=url, proxy=proxy).text
+            json_str = self._data.cache_get(url=url, proxy=proxy).text
             json_data = json.loads(json_str)
             key_stats = json_data["timeseries"]["result"][0]
             if k not in key_stats:


### PR DESCRIPTION
`data` was being used to cache all price history requests, when only past date ranges should be cached (end < now).  To fix: restored original `get()` function and created new `cache_get()` wrapper with LRU decorators.

Also fixed some session issues in unit test `test_no_expensive_calls_introduced`