### PR TITLE
Add `history_metadata` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ msft.info
 # get historical market data
 hist = msft.history(period="max")
 
+# show meta information about the history (requires history() to be called first)
+msft.history_metadata
+
 # show actions (dividends, splits, capital gains)
 msft.actions
 

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -136,7 +136,10 @@ class TestTickerHistory(unittest.TestCase):
         self.ticker = None
 
     def test_history(self):
+        with self.assertRaises(RuntimeError):
+            self.ticker.history_metadata
         data = self.ticker.history("1y")
+        self.assertIn("IBM", self.ticker.history_metadata.values(), "metadata missing")
         self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -51,6 +51,7 @@ class TickerBase:
         self.ticker = ticker.upper()
         self.session = session
         self._history = None
+        self._history_metadata = None
         self._base_url = _BASE_URL_
         self._scrape_url = _SCRAPE_URL_
         self._tz = None
@@ -234,6 +235,12 @@ class TickerBase:
                 else:
                     print('%s: %s' % (self.ticker, err_msg))
             return utils.empty_df()
+        
+        # Store the meta data that gets retrieved simultaneously:
+        try:
+            self._history_metadata = data["chart"]["result"][0]["meta"]
+        except KeyError:
+            self._history_metadata = {}
 
         # parse quotes
         try:
@@ -1003,3 +1010,9 @@ class TickerBase:
         self._earnings_dates[limit] = dates
 
         return dates
+
+    def get_history_metadata(self) -> dict:
+        if self._history_metadata is None:
+            raise RuntimeError("Metadata was never retrieved so far, "
+                               "call history() to retrieve it")
+        return self._history_metadata

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -208,6 +208,12 @@ class TickerBase:
         except Exception:
             pass
 
+        # Store the meta data that gets retrieved simultaneously
+        try:
+            self._history_metadata = data["chart"]["result"][0]["meta"]
+        except KeyError:
+            self._history_metadata = {}
+
         err_msg = "No data found for this date range, symbol may be delisted"
         fail = False
         if data is None or not type(data) is dict:
@@ -221,9 +227,9 @@ class TickerBase:
         elif "chart" not in data or data["chart"]["result"] is None or not data["chart"]["result"]:
             fail = True
         elif period is not None and "timestamp" not in data["chart"]["result"][0] and period not in \
-                data["chart"]["result"][0]["meta"]["validRanges"]:
+                self._history_metadata["validRanges"]:
             # User provided a bad period. The minimum should be '1d', but sometimes Yahoo accepts '1h'.
-            err_msg = "Period '{}' is invalid, must be one of {}".format(period, data["chart"]["result"][0]["meta"][
+            err_msg = "Period '{}' is invalid, must be one of {}".format(period, self._history_metadata[
                 "validRanges"])
             fail = True
         if fail:
@@ -236,12 +242,6 @@ class TickerBase:
                     print('%s: %s' % (self.ticker, err_msg))
             return utils.empty_df()
         
-        # Store the meta data that gets retrieved simultaneously:
-        try:
-            self._history_metadata = data["chart"]["result"][0]["meta"]
-        except KeyError:
-            self._history_metadata = {}
-
         # parse quotes
         try:
             quotes = utils.parse_quotes(data["chart"]["result"][0])
@@ -281,9 +281,9 @@ class TickerBase:
                 pass
 
         # Select useful info from metadata
-        quote_type = data["chart"]["result"][0]["meta"]["instrumentType"]
+        quote_type = self._history_metadata["instrumentType"]
         expect_capital_gains = quote_type in ('MUTUALFUND', 'ETF')
-        tz_exchange = data["chart"]["result"][0]["meta"]["exchangeTimezoneName"]
+        tz_exchange = self._history_metadata["exchangeTimezoneName"]
 
         # Note: ordering is important. If you change order, run the tests!
         quotes = utils.set_df_tz(quotes, params["interval"], tz_exchange)

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -222,3 +222,7 @@ class Ticker(TickerBase):
     @property
     def earnings_forecasts(self) -> _pd.DataFrame:
         return self.get_earnings_forecast()
+
+    @property
+    def history_metadata(self) -> dict:
+        return self.get_history_metadata()


### PR DESCRIPTION
Here's the PR for `history_metadata`.

- See also https://github.com/ranaroussi/yfinance/issues/1195.
- I ended up calling it `history_metadata` after all rather than `exchange_metadata` because it not only includes exchange-related information (e.g., `currency`, `symbol`, `instrumentType`).
- Also, this is a new PR. The old one at https://github.com/ranaroussi/yfinance/pull/1198 can be closed.

(BTW, is it just me or is the code base pretty messy? For example, type hints are very inconsistent. And what is the purpose of `TickerBase` vs `Ticker` class?)

