### PR TITLE
Restore lxml dep, set min ver = 4.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ To install `yfinance` using `conda`, see
 -   [Pandas](https://github.com/pydata/pandas) \>= 1.3.0
 -   [Numpy](http://www.numpy.org) \>= 1.16.5
 -   [requests](http://docs.python-requests.org/en/master/) \>= 2.26
+-   [lxml](https://pypi.org/project/lxml/) \>= 4.9.1
 -   [appdirs](https://pypi.org/project/appdirs) \>= 1.4.4
 
 ### Optional (if you want to use `pandas_datareader`)

--- a/meta.yaml
+++ b/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - numpy >=1.16.5
     - requests >=2.26
     - multitasking >=0.0.7
+    - lxml >=4.9.1
     - appdirs >= 1.4.4
     - pip
     - python
@@ -29,6 +30,7 @@ requirements:
     - numpy >=1.16.5
     - requests >=2.26
     - multitasking >=0.0.7
+    - lxml >=4.9.1
     - appdirs >= 1.4.4
     - python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ pandas>=1.3.0
 numpy>=1.16.5
 requests>=2.26
 multitasking>=0.0.7
+lxml>=4.9.1
 appdirs>=1.4.4

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
     install_requires=['pandas>=1.3.0', 'numpy>=1.16.5',
                       'requests>=2.26', 'multitasking>=0.0.7',
-                      'appdirs>=1.4.4'],
+                      'lxml>=4.9.1', 'appdirs>=1.4.4'],
     entry_points={
         'console_scripts': [
             'sample=sample:main',


### PR DESCRIPTION
#1231 incorrectly removed `lxml` dependency. This PR restores it, but raises minimum version to 4.9.1 to fix #1211.