### PR TITLE
Using the opposite operator instead

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+name: ci
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - uses: py-actions/flake8@v2

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -216,7 +216,7 @@ class TickerBase:
 
         err_msg = "No data found for this date range, symbol may be delisted"
         fail = False
-        if data is None or not type(data) is dict:
+        if data is None or type(data) is not dict:
             fail = True
         elif type(data) is dict and 'status_code' in data:
             err_msg += "(Yahoo status_code = {})".format(data["status_code"])
@@ -241,7 +241,7 @@ class TickerBase:
                 else:
                     print('%s: %s' % (self.ticker, err_msg))
             return utils.empty_df()
-        
+
         # parse quotes
         try:
             quotes = utils.parse_quotes(data["chart"]["result"][0])
@@ -588,8 +588,8 @@ class TickerBase:
             bad_dts = df_block.index[(df_block[price_cols]==tag).any(axis=1)]
 
             for idx in bad_dts:
-                if not idx in df_new.index:
-                    # Yahoo didn't return finer-grain data for this interval, 
+                if idx not in df_new.index:
+                    # Yahoo didn't return finer-grain data for this interval,
                     # so probably no trading happened.
                     print("no fine data")
                     continue
@@ -938,7 +938,7 @@ class TickerBase:
             data = self._fundamentals.financials.get_income_scrape(freq=freq, proxy=proxy)
         else:
             data = self._fundamentals.financials.get_income_time_series(freq=freq, proxy=proxy)
-            
+
         if pretty:
             data = data.copy()
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["EBIT", "EBITDA", "EPS", "NI"])

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -127,7 +127,7 @@ class Fiancials:
 
     def _fetch_time_series(self, name, timescale, proxy=None):
         # Fetching time series preferred over scraping 'QuoteSummaryStore',
-        # because it matches what Yahoo shows. But for some tickers returns nothing, 
+        # because it matches what Yahoo shows. But for some tickers returns nothing,
         # despite 'QuoteSummaryStore' containing valid data.
 
         allowed_names = ["income", "balance-sheet", "cash-flow"]
@@ -280,7 +280,7 @@ class Fiancials:
         data_stores = self._data.get_json_data_stores("financials", proxy)
 
         # Fetch raw data
-        if not "QuoteSummaryStore" in data_stores:
+        if "QuoteSummaryStore" not in data_stores:
             return pd.DataFrame()
         data = data_stores["QuoteSummaryStore"]
 

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -120,7 +120,7 @@ class Quote:
 
         self._info['logo_url'] = ""
         try:
-            if not 'website' in self._info:
+            if 'website' not in self._info:
                 self._info['logo_url'] = 'https://logo.clearbit.com/%s.com' % \
                                          self._info['shortName'].split(' ')[0].split(',')[0]
             else:

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -282,7 +282,7 @@ def camel2title(strings: List[str], sep: str = ' ', acronyms: Optional[List[str]
 
     # Apply str.title() to non-acronym words
     strings = [s.split(sep) for s in strings]
-    strings = [[j.title() if not j in acronyms else j for j in s] for s in strings]
+    strings = [[j.title() if j not in acronyms else j for j in s] for s in strings]
     strings = [sep.join(s) for s in strings]
 
     return strings
@@ -310,7 +310,7 @@ def _interval_to_timedelta(interval):
         return _dateutil.relativedelta(months=1)
     elif interval == "1wk":
         return _pd.Timedelta(days=7, unit='d')
-    else: 
+    else:
         return _pd.Timedelta(interval)
 
 
@@ -428,8 +428,8 @@ def set_df_tz(df, interval, tz):
 
 
 def fix_Yahoo_returning_live_separate(quotes, interval, tz_exchange):
-    # Yahoo bug fix. If market is open today then Yahoo normally returns 
-    # todays data as a separate row from rest-of week/month interval in above row. 
+    # Yahoo bug fix. If market is open today then Yahoo normally returns
+    # todays data as a separate row from rest-of week/month interval in above row.
     # Seems to depend on what exchange e.g. crypto OK.
     # Fix = merge them together
     n = quotes.shape[0]
@@ -621,9 +621,9 @@ def safe_merge_dfs(df_main, df_sub, interval):
 
 def fix_Yahoo_dst_issue(df, interval):
     if interval in ["1d", "1w", "1wk"]:
-        # These intervals should start at time 00:00. But for some combinations of date and timezone, 
+        # These intervals should start at time 00:00. But for some combinations of date and timezone,
         # Yahoo has time off by few hours (e.g. Brazil 23:00 around Jan-2022). Suspect DST problem.
-        # The clue is (a) minutes=0 and (b) hour near 0. 
+        # The clue is (a) minutes=0 and (b) hour near 0.
         # Obviously Yahoo meant 00:00, so ensure this doesn't affect date conversion:
         f_pre_midnight = (df.index.minute == 0) & (df.index.hour.isin([22, 23]))
         dst_error_hours = _np.array([0] * df.shape[0])


### PR DESCRIPTION
It is needlessly complex to invert the result of a boolean comparison. The opposite comparison should be made instead.