### PR TITLE
Backport Yahoo decryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ To install `yfinance` using `conda`, see
 -   [requests](http://docs.python-requests.org/en/master/) \>= 2.26
 -   [lxml](https://pypi.org/project/lxml/) \>= 4.9.1
 -   [appdirs](https://pypi.org/project/appdirs) \>= 1.4.4
+-   [cryptography](https://pypi.org/project/cryptography) \>=3.3.2
 
 ### Optional (if you want to use `pandas_datareader`)
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - multitasking >=0.0.7
     - lxml >=4.9.1
     - appdirs >= 1.4.4
+    - cryptography >= 3.3.2
     - pip
     - python
 
@@ -32,6 +33,7 @@ requirements:
     - multitasking >=0.0.7
     - lxml >=4.9.1
     - appdirs >= 1.4.4
+    - cryptography >= 3.3.2
     - python
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.26
 multitasking>=0.0.7
 lxml>=4.9.1
 appdirs>=1.4.4
+cryptography>=3.3.2

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
     install_requires=['pandas>=1.3.0', 'numpy>=1.16.5',
                       'requests>=2.26', 'multitasking>=0.0.7',
-                      'lxml>=4.9.1', 'appdirs>=1.4.4'],
+                      'lxml>=4.9.1', 'appdirs>=1.4.4'
+                      'cryptography>=3.3.2'],
     entry_points={
         'console_scripts': [
             'sample=sample:main',

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -36,6 +36,7 @@ import hashlib
 usePycryptodome = False  # slightly faster
 # usePycryptodome = True
 if usePycryptodome:
+    # NOTE: if decide to use 'pycryptodome', set min version to 3.6.6
     from Crypto.Cipher import AES
     from Crypto.Util.Padding import unpad
 else:


### PR DESCRIPTION
Backport of #1253 (credits to @Rogach & @fredrik-corneliusson). Until can decide which of `cryptography` or `pycryptodome` to use, include both in the code but defaulting to `cryptography` because *slightly* faster.