### PR TITLE
Another info[] fix for #1256

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -439,7 +439,10 @@ class TickerBase():
 
                 self._sustainability = s[~s.index.isin(
                     ['maxAge', 'ratingYear', 'ratingMonth'])]
+            else:
+                self._sustainability = utils.empty_df()
         except Exception:
+            self._sustainability = utils.empty_df()
             pass
 
         # info (be nice to python 2)
@@ -515,6 +518,7 @@ class TickerBase():
             self._recommendations = rec[[
                 'Firm', 'To Grade', 'From Grade', 'Action']].sort_index()
         except Exception:
+            self._recommendations = utils.empty_df()
             pass
 
         # Complementary key-statistics. For now just want 'trailing PEG ratio'


### PR DESCRIPTION
If ticker lacked `_sustainability` or `_recommendations` because Yahoo lacked, was causing `info[]` to be recreated every call.