### PR TITLE
Fetching ESG data for a ticker

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ===========
 
+0.2.4
+-----
+- Fix Yahoo data decryption #1297
+- New feature: 'Ticker.get_shares_full()' #1301
+- Improve caching of financials data #1284
+- Restore download() original alignment behaviour #1283
+- Fix the database lock error in multithread download #1276
+
 0.2.3
 -----
 - Make financials API '_' use consistent

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "yfinance" %}
-{% set version = "0.2.3" %}
+{% set version = "0.2.4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/yfinance/version.py
+++ b/yfinance/version.py
@@ -1,1 +1,1 @@
-version = "0.2.3"
+version = "0.2.4"


### PR DESCRIPTION
In reference to issue #1241 :

- Added an ESG module in the scrapper sub-package to collect ESG-related data for a ticker.
- Added the esg property for the ticker class in order to return the esg-related scores in form of the pandas data frame.