### PR TITLE
Feature/share count

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ msft.capital_gains
 
 # show share count
 msft.shares
+msft.get_shares_full()
 
 # show financials:
 # - income statement

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -65,6 +65,7 @@ class TestTicker(unittest.TestCase):
         dat.splits
         dat.actions
         dat.shares
+        dat.shares_full
         dat.info
         dat.calendar
         dat.recommendations
@@ -100,6 +101,7 @@ class TestTicker(unittest.TestCase):
         dat.splits
         dat.actions
         dat.shares
+        dat.shares_full
         dat.info
         dat.calendar
         dat.recommendations
@@ -651,6 +653,11 @@ class TestTickerMiscFinancials(unittest.TestCase):
     def test_shares(self):
         data = self.ticker.shares
         self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
+        self.assertFalse(data.empty, "data is empty")
+
+    def test_shares_full(self):
+        data = self.ticker.get_shares_full()
+        self.assertIsInstance(data, pd.Series, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 
     def test_info(self):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1160,7 +1160,7 @@ class TickerBase:
 
         shares_data = json_data["timeseries"]["result"]
         try:
-            df = _pd.DataFrame(data={"count":shares_data[0]["shares_out"]}, index=_pd.to_datetime(shares_data[0]["timestamp"], unit="s"))
+            df = _pd.Series(shares_data[0]["shares_out"], index=_pd.to_datetime(shares_data[0]["timestamp"], unit="s"))
         except:
             print(f"{self.ticker}: Failed to parse shares count data")
             return None

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1124,6 +1124,8 @@ class TickerBase:
 
         # Implement some smart caching, only requesting data from Yahoo if not 
         # in self._shares_full:
+        if start is None and end is None:
+            start = dt_now - _datetime.timedelta(days=365)
         if start is not None:
             tz = self._get_ticker_tz()
             start_ts = utils._parse_user_dt(start, tz)

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -40,6 +40,7 @@ from .scrapers.analysis import Analysis
 from .scrapers.fundamentals import Fundamentals
 from .scrapers.holders import Holders
 from .scrapers.quote import Quote
+import json as _json
 
 _BASE_URL_ = 'https://query2.finance.yahoo.com'
 _SCRAPE_URL_ = 'https://finance.yahoo.com/quote'
@@ -1120,21 +1121,21 @@ class TickerBase:
         return data
 
     def get_shares_full(self, start=None, end=None, proxy=None):
-        dt_now = _tz.timezone("UTC").localize(_datetime.datetime.utcnow())
+        dt_now = _pd.Timestamp.utcnow()
+
+        tz = self._get_ticker_tz(debug_mode=False, proxy=None, timeout=10)
 
         # Implement some smart caching, only requesting data from Yahoo if not 
         # in self._shares_full:
         if start is None and end is None:
             start = dt_now - _datetime.timedelta(days=365)
         if start is not None:
-            tz = self._get_ticker_tz()
             start_ts = utils._parse_user_dt(start, tz)
-            start = _pd.Timestamp.fromtimestamp(start_ts).tz_localize("UTC").tz_convert(tz)
+            start = _pd.Timestamp.fromtimestamp(start_ts).tz_localize("UTC").tz_convert(tz).floor("D")
             start_d = start.date()
         if end is not None:
-            tz = self._get_ticker_tz()
             end_ts = utils._parse_user_dt(end, tz)
-            end = _pd.Timestamp.fromtimestamp(end_ts).tz_localize("UTC").tz_convert(tz)
+            end = _pd.Timestamp.fromtimestamp(end_ts).tz_localize("UTC").tz_convert(tz).ceil("D")
             end_d = end.date()
 
         if self._shares_full is None:
@@ -1160,8 +1161,8 @@ class TickerBase:
                     start_d = inception_d
                     start = _pd.Timestamp(inception_d).tz_localize(tz)
 
-            start_later = start_d >= self._shares_full.index[0]
-            end_earlier = (end is not None) and end_d <= self._shares_full.index[-1]
+            start_later = start_d >= self._shares_full.index[0].date()
+            end_earlier = (end is not None) and end_d <= self._shares_full.index[-1].date()
             if start_later and end_earlier:
                 return self._shares_full
 
@@ -1171,39 +1172,35 @@ class TickerBase:
         if self._shares_full is None:
             range1 = (start, end)
         else:
-            if (start is not None) and start_d < self._shares_full.index[0]:
-                range1 = (start, _pd.Timestamp(self._shares_full.index[0]).tz_localize(tz))
+            if (start is not None) and start_d < self._shares_full.index[0].date():
+                range1 = (start, self._shares_full.index[0])
             if (end is not None) and end_d > self._shares_full.index[-1]:
                 range1 = (end, dt_now)
-
-        session = self.session or _requests
 
         # Using this url without populating 'type' parameter returns full share count history
         ts_url_base = "https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/{0}?symbol={0}".format(self.ticker)
 
         def fetch_range(start, end):
-            print("fetch_range(start={}, end={})".format(start, end))
+            start = start.floor("D") ; end = end.ceil("D")
             shares_url = ts_url_base + "&period1={}&period2={}".format(int(start.timestamp()), int(end.timestamp()))
             try:
-                json_str = session.get(url=shares_url, proxies=proxy, headers=utils.user_agent_headers).text
+                json_str = self._data.cache_get(shares_url).text
                 json_data = _json.loads(json_str)
             except:
                 raise Exception("Yahoo web request for share count failed")
-            fail = False
             try:
                 fail = json_data["finance"]["error"]["code"] == "Bad Request"
             except:
-                pass
+                fail = False
             if fail:
-                # from pprint import pprint
-                # print("shares_url:")
-                # print(shares_url)
-                # print("json_data:")
-                # pprint(json_data)
-                raise Exception("Problem in json data")
+                raise Exception("Failed to parse shares count data")
+
             shares_data = json_data["timeseries"]["result"]
             df = _pd.DataFrame(data={"count":shares_data[0]["shares_out"]}, index=_pd.to_datetime(shares_data[0]["timestamp"], unit="s"))
-            df.index = df.index.date
+            f_dup = df.index.duplicated(keep='first')
+            if f_dup.any():
+                df = df[~f_dup]
+            df.index = df.index.tz_localize(tz)
             return df
 
         inception_d = None
@@ -1215,7 +1212,7 @@ class TickerBase:
         if range1 is not None:
             df = fetch_range(range1[0], range1[1])
 
-            if range1[0].date() < (df.index[0]-_datetime.timedelta(days=700)):
+            if range1[0].date() < (df.index[0].date()-_datetime.timedelta(days=700)):
                 inception_d = df.index[0]
 
             if self._shares_full is None:
@@ -1231,7 +1228,9 @@ class TickerBase:
                 self._shares_full = _pd.concat([self._shares_full, df])
 
         self._shares_full = self._shares_full.sort_index()
-        self._shares_full = self._shares_full[~self._shares_full.index.duplicated(keep='first')]
+        f_dup = self._shares_full.index.duplicated(keep='first')
+        if f_dup.any():
+            self._shares_full = self._shares_full[~f_dup]
 
         if not inception_d is None:
             print("inception_d =", inception_d)

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -132,6 +132,9 @@ class Ticker(TickerBase):
     @property
     def shares(self) -> _pd.DataFrame :
         return self.get_shares()
+    @property
+    def shares_full(self):
+        return self.get_shares_full()
 
     @property
     def info(self) -> dict:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -132,9 +132,9 @@ class Ticker(TickerBase):
     @property
     def shares(self) -> _pd.DataFrame :
         return self.get_shares()
-    @property
-    def shares_full(self):
-        return self.get_shares_full()
+    # @property
+    def shares_full(self, start=None, end=None):
+        return self.get_shares_full(start, end)
 
     @property
     def info(self) -> dict:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -132,9 +132,6 @@ class Ticker(TickerBase):
     @property
     def shares(self) -> _pd.DataFrame :
         return self.get_shares()
-    # @property
-    def shares_full(self, start=None, end=None):
-        return self.get_shares_full(start, end)
 
     @property
     def info(self) -> dict:


### PR DESCRIPTION
New API function `Ticker.get_shares_full(start=None, end=None, proxy=None)`. Gets much longer share count history than `Ticker.shares`, although no obvious pattern to dates returned. A few users have tried and provided no feedback so I guess this is perfect.

Helps with #1300 - better way to get market cap (2x faster)