### PR TITLE
`Ticker.basic_info` - fast but minimal alternative to `info[]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ msft.capital_gains
 msft.shares
 msft.get_shares_full()
 
+# calculate market cap
+msft.market_cap
+
 # show financials:
 # - income statement
 msft.income_stmt

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ import yfinance as yf
 
 msft = yf.Ticker("MSFT")
 
-# get stock info
+# fast access to subset of stock info
+msft.basic_info
+# slow access to all stock info
 msft.info
 
 # get historical market data
@@ -85,9 +87,6 @@ msft.capital_gains
 # show share count
 msft.shares
 msft.get_shares_full()
-
-# calculate market cap
-msft.market_cap
 
 # show financials:
 # - income statement

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -9,6 +9,7 @@ Specific test class:
 
 """
 import pandas as pd
+import numpy as np
 
 from .context import yfinance as yf
 
@@ -660,14 +661,104 @@ class TestTickerMiscFinancials(unittest.TestCase):
         self.assertIsInstance(data, pd.Series, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 
+    def test_bad_freq_value_raises_exception(self):
+        self.assertRaises(ValueError, lambda: self.ticker.get_cashflow(freq="badarg"))
+
+
+class TestTickerInfo(unittest.TestCase):
+    session = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.session = requests_cache.CachedSession(backend='memory')
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.session is not None:
+            cls.session.close()
+
+    def setUp(self):
+        # self.ticker = yf.Ticker("GOOGL", session=self.session)
+        # self.ticker = yf.Ticker("BP.L", session=self.session)
+        self.ticker = yf.Ticker("AAU.L", session=self.session)
+
+    def tearDown(self):
+        self.ticker = None
+
     def test_info(self):
         data = self.ticker.info
         self.assertIsInstance(data, dict, "data has wrong type")
         self.assertIn("symbol", data.keys(), "Did not find expected key in info dict")
         self.assertEqual("GOOGL", data["symbol"], "Wrong symbol value in info dict")
 
-    def test_bad_freq_value_raises_exception(self):
-        self.assertRaises(ValueError, lambda: self.ticker.get_cashflow(freq="badarg"))
+    def test_basic_info(self):
+        yf.scrapers.quote.PRUNE_INFO = False
+
+        bi = self.ticker.basic_info
+
+        key_rename_map = {}
+        key_rename_map["last_price"] = "currentPrice"
+        key_rename_map["fifty_day_average"] = "fiftyDayAverage"
+        key_rename_map["two_hundred_day_average"] = "twoHundredDayAverage"
+        key_rename_map["year_change"] = "52WeekChange"
+        key_rename_map["year_high"] = "fiftyTwoWeekHigh"
+        key_rename_map["year_low"] = "fiftyTwoWeekLow"
+
+        key_rename_map["last_volume"] = "regularMarketVolume"
+        key_rename_map["ten_day_average_volume"] = ["averageVolume10days", "averageDailyVolume10Day"]
+        key_rename_map["three_month_average_volume"] = "averageVolume"
+
+        key_rename_map["market_cap"] = "marketCap"
+        key_rename_map["shares"] = "floatShares"
+        key_rename_map["timezone"] = "exchangeTimezoneName"
+
+        approximate_keys = {"fifty_day_average", "ten_day_average_volume"}
+        approximate_keys.update({"market_cap"})
+
+        # bad_keys = []
+        bad_keys = {"shares"}
+
+        custom_tolerances = {}
+        # custom_tolerances["ten_day_average_volume"] = 1e-3
+        custom_tolerances["ten_day_average_volume"] = 1e-1
+        custom_tolerances["three_month_average_volume"] = 1e-2
+        custom_tolerances["fifty_day_average"] = 1e-2
+        custom_tolerances["two_hundred_day_average"] = 1e-2
+
+        for k in bi.keys():
+            if k in key_rename_map:
+                k2 = key_rename_map[k]
+            else:
+                k2 = k
+
+            if not isinstance(k2, list):
+                k2 = [k2]
+
+            for m in k2:
+                if not m in self.ticker.info:
+                    print(sorted(list(self.ticker.info.keys())))
+                    raise Exception("Need to add/fix mapping for basic_info key", k)
+
+                if k in bad_keys:
+                    # Doesn't match, investigate why
+                    continue
+
+                if k in custom_tolerances:
+                    rtol = custom_tolerances[k]
+                else:
+                    # rtol = 1e-3
+                    # rtol = 5e-3
+                    rtol = 1e-4
+
+                print(f"Testing key {k} -> {m}")
+                # if k in approximate_keys:
+                v1 = self.ticker.basic_info[k]
+                v2 = self.ticker.info[m]
+                if isinstance(v1, float) or isinstance(v2, int):
+                    self.assertTrue(np.isclose(v1, v2, rtol=rtol), f"{k}: {v1} != {v2}")
+                else:
+                    self.assertEqual(v1, v2, f"{k}: {v1} != {v2}")
+
 
 
 def suite():

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -77,6 +77,11 @@ class BasicInfo:
         return k in self.keys()
     def __iter__(self):
         return iter(self.keys())
+
+    def __str__(self):
+        return "lazy-loading dict with keys = " + str(self.keys())
+    def __repr__(self):
+        return self.__str__()
     
     @property
     def currency(self):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -63,13 +63,20 @@ class BasicInfo:
         self._shares = None
         self._mcap = None
 
+        self._open = None
+        self._day_high = None
+        self._day_low = None
         self._last_price = None
         self._last_volume = None
+
+        self._prev_close = None
+
         self._50d_day_average = None
         self._200d_day_average = None
         self._year_high = None
         self._year_low = None
         self._year_change = None
+
         self._10d_avg_vol = None
         self._3mo_avg_vol = None
 
@@ -150,7 +157,7 @@ class BasicInfo:
 
         # print("_exchange_open_now() returning", r)
         return r
-    
+
     @property
     def currency(self):
         if self._currency is not None:
@@ -163,7 +170,7 @@ class BasicInfo:
         return self._currency
 
     def _currency_is_cents(self):
-        return self.currency in ["GBp"]
+        return self.currency in ["GBp", "ILA"]
 
     @property
     def exchange(self):
@@ -201,21 +208,49 @@ class BasicInfo:
     def last_price(self):
         if self._last_price is not None:
             return self._last_price
-
-        self._last_price = self._get_exchange_metadata()["regularMarketPrice"]
+        # self._last_price = self._get_exchange_metadata()["regularMarketPrice"]
+        prices = self._get_1y_prices()
+        self._last_price = _np.nan if prices.empty else prices["Close"].iloc[-1]
         return self._last_price
+
+    @property
+    def previous_close(self):
+        if self._prev_close is not None:
+            return self._prev_close
+        prices = self._get_1y_prices()
+        self._prev_close = _np.nan if prices.empty else prices["Close"].iloc[-2]
+        return self._prev_close
+
+    @property
+    def open(self):
+        if self._open is not None:
+            return self._open
+        prices = self._get_1y_prices()
+        self._open = _np.nan if prices.empty else prices["Open"].iloc[-1]
+        return self._open
+
+    @property
+    def day_high(self):
+        if self._day_high is not None:
+            return self._day_high
+        prices = self._get_1y_prices()
+        self._day_high = _np.nan if prices.empty else prices["High"].iloc[-1]
+        return self._day_high
+
+    @property
+    def day_low(self):
+        if self._day_low is not None:
+            return self._day_low
+        prices = self._get_1y_prices()
+        self._day_low = _np.nan if prices.empty else prices["Low"].iloc[-1]
+        return self._day_low
 
     @property
     def last_volume(self):
         if self._last_volume is not None:
             return self._last_volume
-
         prices = self._get_1y_prices()
-        if prices.empty:
-            self._last_volume = 0
-        else:
-            self._last_volume = prices["Volume"].iloc[-1]
-
+        self._last_volume = 0 if prices.empty else prices["Volume"].iloc[-1]
         return self._last_volume
 
     @property

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -8,7 +8,8 @@ from yfinance.data import TickerData
 
 
 info_retired_keys_price = {"currentPrice", "dayHigh", "dayLow", "open", "previousClose"}
-info_retired_keys_price.update({"regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price"]})
+info_retired_keys_price.update({"regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price", "Volume"]})
+info_retired_keys_price.update({"fiftyTwoWeekLow", "fiftyTwoWeekHigh"})
 info_retired_keys_exchange = {"currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"}
 info_retired_keys_marketCap = {"marketCap"}
 info_retired_keys_symbol = {"symbol"}
@@ -17,11 +18,21 @@ info_retired_keys = info_retired_keys_price | info_retired_keys_exchange | info_
 
 from collections.abc import MutableMapping
 class InfoDictWrapper(MutableMapping):
-    """ Simple wrapper around info dict, to print messages for specific keys
-    instructing how to retrieve with new methods"""
+    """ Simple wrapper around info dict, intercepting 'gets' to 
+    print how-to-migrate messages for specific keys. Requires
+    override dict API"""
 
     def __init__(self, info):
         self.info = info
+
+    def keys(self):
+        return self.info.keys()
+
+    def __str__(self):
+        return self.info.__str__()
+
+    def __repr__(self):
+        return self.info.__repr__()
 
     def __contains__(self, k):
         return k in self.info.keys()

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -9,12 +9,18 @@ from yfinance.data import TickerData
 
 info_retired_keys_price = {"currentPrice", "dayHigh", "dayLow", "open", "previousClose", "volume"}
 info_retired_keys_price.update({"regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price", "Volume"]})
-info_retired_keys_price.update({"fiftyTwoWeekLow", "fiftyTwoWeekHigh", "fiftyDayAverage", "twoHundredDayAverage"})
+info_retired_keys_price.update({"fiftyTwoWeekLow", "fiftyTwoWeekHigh", "fiftyTwoWeekChange", "fiftyDayAverage", "twoHundredDayAverage"})
 info_retired_keys_price.update({"averageDailyVolume10Day", "averageVolume10days", "averageVolume"})
 info_retired_keys_exchange = {"currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"}
 info_retired_keys_marketCap = {"marketCap"}
 info_retired_keys_symbol = {"symbol"}
 info_retired_keys = info_retired_keys_price | info_retired_keys_exchange | info_retired_keys_marketCap | info_retired_keys_symbol
+#
+info_retired_keys = []
+
+
+PRUNE_INFO = True
+# PRUNE_INFO = False
 
 
 from collections.abc import MutableMapping
@@ -195,11 +201,12 @@ class Quote:
 
         # Delete redundant info[] keys, because values can be accessed faster
         # elsewhere - e.g. price keys. Hope is reduces Yahoo spam effect.
-        for k in info_retired_keys:
-            if k in self._info:
-                del self._info[k]
-        # InfoDictWrapper will explain how to access above data elsewhere
-        self._info = InfoDictWrapper(self._info)
+        if PRUNE_INFO:
+            for k in info_retired_keys:
+                if k in self._info:
+                    del self._info[k]
+            # InfoDictWrapper will explain how to access above data elsewhere
+            self._info = InfoDictWrapper(self._info)
 
         # events
         try:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -28,13 +28,13 @@ class InfoDictWrapper(MutableMapping):
 
     def __getitem__(self, k):
         if k in info_retired_keys_price:
-            print(f"Price data removed from info. Use Ticker.history(period='1wk') instead")
+            print(f"Price data removed from info. Use Ticker.basic_info or history() instead")
             return None
         elif k in info_retired_keys_exchange:
-            print(f"Exchange data removed from info. Use Ticker.get_history_metadata() instead")
+            print(f"Exchange data removed from info. Use Ticker.basic_info or Ticker.get_history_metadata() instead")
             return None
         elif k in info_retired_keys_marketCap:
-            print(f"Market cap removed from info. Calculate using new Ticker.get_shares_full() * price")
+            print(f"Market cap removed from info. Use Ticker.basic_info instead")
             return None
         elif k in info_retired_keys_symbol:
             print(f"Symbol removed from info. You know this already")

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -22,25 +22,25 @@ class InfoDictWrapper(MutableMapping):
         self.redundant_keys_marketCap = ["marketCap"]
 
     def __contains__(self, k):
-        if k in self.redundant_keys_price:
-            print(f"Price data removed from info. Use Ticker.history(period='1wk') instead")
-            return False
-        elif k in self.redundant_keys_exchange:
-            print(f"Exchange data removed from info. Use Ticker.get_history_metadata() instead")
-            return False
-        elif k in self.redundant_keys_marketCap:
-            print(f"Market cap removed from info. Calculate using new Ticker.get_shares_full() * price")
-            return False
         return k in self.info.keys()
 
-    def __getitem__(self, key):
-        return self.info[self._keytransform(key)]
+    def __getitem__(self, k):
+        if k in self.redundant_keys_price:
+            print(f"Price data removed from info. Use Ticker.history(period='1wk') instead")
+            return None
+        elif k in self.redundant_keys_exchange:
+            print(f"Exchange data removed from info. Use Ticker.get_history_metadata() instead")
+            return None
+        elif k in self.redundant_keys_marketCap:
+            print(f"Market cap removed from info. Calculate using new Ticker.get_shares_full() * price")
+            return None
+        return self.info[self._keytransform(k)]
 
-    def __setitem__(self, key, value):
-        self.info[self._keytransform(key)] = value
+    def __setitem__(self, k, value):
+        self.info[self._keytransform(k)] = value
 
-    def __delitem__(self, key):
-        del self.info[self._keytransform(key)]
+    def __delitem__(self, k):
+        del self.info[self._keytransform(k)]
 
     def __iter__(self):
         return iter(self.info)
@@ -48,8 +48,8 @@ class InfoDictWrapper(MutableMapping):
     def __len__(self):
         return len(self.info)
 
-    def _keytransform(self, key):
-        return key
+    def _keytransform(self, k):
+        return k
 
 
 

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -7,9 +7,10 @@ from yfinance import utils
 from yfinance.data import TickerData
 
 
-info_retired_keys_price = {"currentPrice", "dayHigh", "dayLow", "open", "previousClose"}
+info_retired_keys_price = {"currentPrice", "dayHigh", "dayLow", "open", "previousClose", "volume"}
 info_retired_keys_price.update({"regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price", "Volume"]})
-info_retired_keys_price.update({"fiftyTwoWeekLow", "fiftyTwoWeekHigh"})
+info_retired_keys_price.update({"fiftyTwoWeekLow", "fiftyTwoWeekHigh", "fiftyDayAverage", "twoHundredDayAverage"})
+info_retired_keys_price.update({"averageDailyVolume10Day", "averageVolume10days", "averageVolume"})
 info_retired_keys_exchange = {"currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"}
 info_retired_keys_marketCap = {"marketCap"}
 info_retired_keys_symbol = {"symbol"}

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -7,32 +7,37 @@ from yfinance import utils
 from yfinance.data import TickerData
 
 
+info_retired_keys_price = {"currentPrice", "dayHigh", "dayLow", "open", "previousClose"}
+info_retired_keys_price.update({"regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price"]})
+info_retired_keys_exchange = {"currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"}
+info_retired_keys_marketCap = {"marketCap"}
+info_retired_keys_symbol = {"symbol"}
+info_retired_keys = info_retired_keys_price | info_retired_keys_exchange | info_retired_keys_marketCap | info_retired_keys_symbol
+
+
 from collections.abc import MutableMapping
 class InfoDictWrapper(MutableMapping):
     """ Simple wrapper around info dict, to print messages for specific keys
     instructing how to retrieve with new methods"""
 
-
     def __init__(self, info):
         self.info = info
-
-        self.redundant_keys_price = ["currentPrice", "dayHigh", "dayLow", "open", "previousClose"]
-        self.redundant_keys_price += ["regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price"]]
-        self.redundant_keys_exchange = ["currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"]
-        self.redundant_keys_marketCap = ["marketCap"]
 
     def __contains__(self, k):
         return k in self.info.keys()
 
     def __getitem__(self, k):
-        if k in self.redundant_keys_price:
+        if k in info_retired_keys_price:
             print(f"Price data removed from info. Use Ticker.history(period='1wk') instead")
             return None
-        elif k in self.redundant_keys_exchange:
+        elif k in info_retired_keys_exchange:
             print(f"Exchange data removed from info. Use Ticker.get_history_metadata() instead")
             return None
-        elif k in self.redundant_keys_marketCap:
+        elif k in info_retired_keys_marketCap:
             print(f"Market cap removed from info. Calculate using new Ticker.get_shares_full() * price")
+            return None
+        elif k in info_retired_keys_symbol:
+            print(f"Symbol removed from info. You know this already")
             return None
         return self.info[self._keytransform(k)]
 
@@ -178,11 +183,7 @@ class Quote:
 
         # Delete redundant info[] keys, because values can be accessed faster
         # elsewhere - e.g. price keys. Hope is reduces Yahoo spam effect.
-        redundant_keys = ["currentPrice", "dayHigh", "dayLow", "open", "previousClose"]
-        redundant_keys += ["regularMarket"+s for s in ["DayHigh", "DayLow", "Open", "PreviousClose", "Price"]]
-        redundant_keys += ["currency", "exchange", "exchangeTimezoneName", "exchangeTimezoneShortName"]
-        redundant_keys += ["marketCap"]
-        for k in redundant_keys:
+        for k in info_retired_keys:
             if k in self._info:
                 del self._info[k]
         # InfoDictWrapper will explain how to access above data elsewhere

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -134,6 +134,10 @@ class Ticker(TickerBase):
         return self.get_shares()
 
     @property
+    def market_cap(self) -> float:
+        return self.calc_market_cap()
+
+    @property
     def info(self) -> dict:
         return self.get_info()
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -49,6 +49,18 @@ user_agent_headers = {
     'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
 
 
+# From https://stackoverflow.com/a/59128615
+from types import FunctionType
+from inspect import getmembers
+def attributes(obj):
+    disallowed_names = {
+      name for name, value in getmembers(type(obj)) 
+        if isinstance(value, FunctionType)}
+    return {
+      name: getattr(obj, name) for name in dir(obj) 
+        if name[0] != '_' and name not in disallowed_names and hasattr(obj, name)}
+
+
 def is_isin(string):
     return bool(_re.match("^([A-Z]{2})([A-Z0-9]{9})([0-9]{1})$", string))
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -322,6 +322,8 @@ def _interval_to_timedelta(interval):
         return _dateutil.relativedelta.relativedelta(months=1)
     elif interval == "3mo":
         return _dateutil.relativedelta.relativedelta(months=3)
+    elif interval == "1y":
+        return _dateutil.relativedelta.relativedelta(years=1)
     elif interval == "1wk":
         return _pd.Timedelta(days=7, unit='d')
     else: 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -319,7 +319,9 @@ def _parse_user_dt(dt, exchange_tz):
 
 def _interval_to_timedelta(interval):
     if interval == "1mo":
-        return _dateutil.relativedelta(months=1)
+        return _dateutil.relativedelta.relativedelta(months=1)
+    elif interval == "3mo":
+        return _dateutil.relativedelta.relativedelta(months=3)
     elif interval == "1wk":
         return _pd.Timedelta(days=7, unit='d')
     else: 


### PR DESCRIPTION
Draft implementation for #1300 so feedback wanted. See that Issue for discussion of why ...

`Ticker.basic_info` provides fast access to ~25 values of `Ticker.info[]`, e.g. last close price. To encourage users to switch, these keys are removed from `info`. If user is using affected keys, then `yfinance` will print migration instructions eg:

`dat.info["open"]`
> Price data removed from info. Use Ticker.basic_info or history() instead