### PR TITLE
Rename 'basic_info' -> 'fast_info'

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -47,7 +47,7 @@ _SCRAPE_URL_ = 'https://finance.yahoo.com/quote'
 _ROOT_URL_ = 'https://finance.yahoo.com'
 
 
-class BasicInfo:
+class FastInfo:
     # Contain small subset of info[] items that can be fetched faster elsewhere.
     # Imitates a dict.
     def __init__(self, tickerBaseObject):
@@ -99,7 +99,7 @@ class BasicInfo:
         if not isinstance(k, str):
             raise KeyError(f"key must be a string")
         if not k in self.keys():
-            raise KeyError(f"'{k}' not valid key. Examine 'BasicInfo.keys()'")
+            raise KeyError(f"'{k}' not valid key. Examine 'FastInfo.keys()'")
         return getattr(self, k)
     def __contains__(self, k):
         return k in self.keys()
@@ -177,9 +177,6 @@ class BasicInfo:
         md = self._tkr.get_history_metadata()
         self._currency = md["currency"]
         return self._currency
-
-    def _currency_is_cents(self):
-        return self.currency in ["GBp", "ILA"]
 
     @property
     def exchange(self):
@@ -365,8 +362,6 @@ class BasicInfo:
             return self._mcap
 
         self._mcap = self.shares * self.last_price
-        if self._currency_is_cents():
-            self._mcap *= 0.01
         return self._mcap
 
 
@@ -400,7 +395,7 @@ class TickerBase:
         self._quote = Quote(self._data)
         self._fundamentals = Fundamentals(self._data)
 
-        self._basic_info = BasicInfo(self)
+        self._fast_info = FastInfo(self)
 
     def stats(self, proxy=None):
         ticker_url = "{}/{}".format(self._scrape_url, self.ticker)
@@ -1146,7 +1141,7 @@ class TickerBase:
         return tz
 
     def _fetch_ticker_tz(self, debug_mode, proxy, timeout):
-        # Query Yahoo for basic price data just to get returned timezone
+        # Query Yahoo for fast price data just to get returned timezone
 
         params = {"range": "1d", "interval": "1d"}
 
@@ -1221,8 +1216,13 @@ class TickerBase:
         return data
 
     @property
+    def fast_info(self):
+        return self._fast_info
+
+    @property
     def basic_info(self):
-        return self._basic_info
+        print("WARNING: 'Ticker.basic_info' is renamed to 'Ticker.fast_info', hopefully purpose is clearer")
+        return self.fast_info
 
     def get_sustainability(self, proxy=None, as_dict=False):
         self._quote.proxy = proxy

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -46,13 +46,13 @@ class InfoDictWrapper(MutableMapping):
 
     def __getitem__(self, k):
         if k in info_retired_keys_price:
-            print(f"Price data removed from info. Use Ticker.basic_info or history() instead")
+            print(f"Price data removed from info. Use Ticker.fast_info or history() instead")
             return None
         elif k in info_retired_keys_exchange:
-            print(f"Exchange data removed from info. Use Ticker.basic_info or Ticker.get_history_metadata() instead")
+            print(f"Exchange data removed from info. Use Ticker.fast_info or Ticker.get_history_metadata() instead")
             return None
         elif k in info_retired_keys_marketCap:
-            print(f"Market cap removed from info. Use Ticker.basic_info instead")
+            print(f"Market cap removed from info. Use Ticker.fast_info instead")
             return None
         elif k in info_retired_keys_symbol:
             print(f"Symbol removed from info. You know this already")


### PR DESCRIPTION
Name `basic_info` was misleading users of purpose (see later discussion in #1300). `fast_info` should convey better.

Also fixed some info test issues.

Clarify "no share count" error handling.