### PR TITLE
Catch TypeError Exception

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,9 @@ assignees: ''
 
 ---
 
-# READ BEFORE POSTING
+# IMPORTANT
+
+If you want help, you got to read this first. All of it.
 
 ### Are you up-to-date?
 
@@ -25,18 +27,17 @@ and comparing against [PIP](https://pypi.org/project/yfinance/#history).
 
 Are spelling ticker *exactly* same as Yahoo?
 
-Visit `finance.yahoo.com` and confim they have your data. Maybe your ticker was delisted.
+Visit `finance.yahoo.com` and confim they have the data you want. Maybe your ticker was delisted, or your expectations of `yfinance` are wrong.
 
 ### Are you spamming Yahoo?
 
-Yahoo Finance free service has limit on query rate dependent on request - roughly 500/minute for prices, 10/minute for info. Them delaying or blocking your spam is not a bug.
+Yahoo Finance free service has rate-limiting depending on request type - roughly 60/minute for prices, 10/minute for info. Once limit hit, Yahoo can delay, block, or return bad data. Not a `yfinance` bug.
 
 ### Still think it's a bug?
 
-Delete this default message and submit your bug report here, providing the following as best you can:
+Delete this default message (all of it) and submit your bug report here, providing the following as best you can:
 
-- Simple code that reproduces your problem
-- Error message, with traceback if shown
-- Info about your system:
-  - yfinance version
-  - operating system
+- Simple code that reproduces your problem, that we can copy-paste-run
+- Exception message with full traceback
+- `yfinance` version and Python version
+- Operating system type

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # IMPORTANT
 
-If you want help, you got to read this first. All of it.
+If you want help, you got to read this first, follow the instructions.
 
 ### Are you up-to-date?
 
@@ -25,9 +25,9 @@ and comparing against [PIP](https://pypi.org/project/yfinance/#history).
 
 ### Does Yahoo actually have the data?
 
-Are spelling ticker *exactly* same as Yahoo?
+Are you spelling ticker *exactly* same as Yahoo?
 
-Visit `finance.yahoo.com` and confim they have the data you want. Maybe your ticker was delisted, or your expectations of `yfinance` are wrong.
+Then visit `finance.yahoo.com` and confirm they have the data you want. Maybe your ticker was delisted, or your expectations of `yfinance` are wrong.
 
 ### Are you spamming Yahoo?
 
@@ -38,6 +38,6 @@ Yahoo Finance free service has rate-limiting depending on request type - roughly
 Delete this default message (all of it) and submit your bug report here, providing the following as best you can:
 
 - Simple code that reproduces your problem, that we can copy-paste-run
-- Exception message with full traceback
+- Exception message with full traceback, or proof `yfinance` returning bad data
 - `yfinance` version and Python version
 - Operating system type

--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ tickers.tickers['AAPL'].history(period="1mo")
 tickers.tickers['GOOG'].actions
 ```
 
+### API documentation
+
+`yf.download()` and `Ticker.history()` have many options for configuring fetching and processing, e.g.:
+
+```python
+yf.download(tickers = "SPY AAPL MSFT",  # list of tickers
+            period = "1y",              # time period
+            interval = "1d",            # trading interval
+            ignore_tz = True,           # ignore timezone when aligning data from different exchanges?
+            prepost = False)            # download pre/post market hours data?
+```
+
+Review the [Wiki](https://github.com/ranaroussi/yfinance/wiki) for more options and detail. Work in progress.
+
 ### Smarter scraping
 
 To use a custom `requests` session (for example to cache calls to the
@@ -202,52 +216,6 @@ session = CachedLimiterSession(
 ```python
 import yfinance as yf
 data = yf.download("SPY AAPL", start="2017-01-01", end="2017-04-30")
-```
-
-I've also added some options to make life easier :)
-
-```python
-data = yf.download(  # or pdr.get_data_yahoo(...
-        # tickers list or string as well
-        tickers = "SPY AAPL MSFT",
-
-        # use "period" instead of start/end
-        # valid periods: 1d,5d,1mo,3mo,6mo,1y,2y,5y,10y,ytd,max
-        # (optional, default is '1mo')
-        period = "ytd",
-
-        # fetch data by interval (including intraday if period < 60 days)
-        # valid intervals: 1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo
-        # (optional, default is '1d')
-        interval = "5d",
-
-        # Whether to ignore timezone when aligning ticker data from 
-        # different timezones. Default is False.
-        ignore_tz = False,
-
-        # group by ticker (to access via data['SPY'])
-        # (optional, default is 'column')
-        group_by = 'ticker',
-
-        # adjust all OHLC automatically
-        # (optional, default is False)
-        auto_adjust = True,
-
-        # attempt repair of missing data or currency mixups e.g. $/cents
-        repair = False,
-
-        # download pre/post regular market hours data
-        # (optional, default is False)
-        prepost = True,
-
-        # use threads for mass downloading? (True/False/Integer)
-        # (optional, default is True)
-        threads = True,
-
-        # proxy URL scheme use use when downloading?
-        # (optional, default is None)
-        proxy = None
-    )
 ```
 
 ### Managing Multi-Level Columns

--- a/README.md
+++ b/README.md
@@ -167,19 +167,24 @@ tickers.tickers['AAPL'].history(period="1mo")
 tickers.tickers['GOOG'].actions
 ```
 
-### API documentation
+### Fetching data for multiple tickers
+
+```python
+import yfinance as yf
+data = yf.download("SPY AAPL", start="2017-01-01", end="2017-04-30")
+```
 
 `yf.download()` and `Ticker.history()` have many options for configuring fetching and processing, e.g.:
 
 ```python
-yf.download(tickers = "SPY AAPL MSFT",  # list of tickers
-            period = "1y",              # time period
-            interval = "1d",            # trading interval
-            ignore_tz = True,           # ignore timezone when aligning data from different exchanges?
-            prepost = False)            # download pre/post market hours data?
+yf.download(tickers = "SPY AAPL",  # list of tickers
+            period = "1y",         # time period
+            interval = "1d",       # trading interval
+            ignore_tz = True,      # ignore timezone when aligning data from different exchanges?
+            prepost = False)       # download pre/post market hours data?
 ```
 
-Review the [Wiki](https://github.com/ranaroussi/yfinance/wiki) for more options and detail. Work in progress.
+Review the [Wiki](https://github.com/ranaroussi/yfinance/wiki) for more options and detail.
 
 ### Smarter scraping
 
@@ -209,13 +214,6 @@ session = CachedLimiterSession(
     bucket_class=MemoryQueueBucket,
     backend=SQLiteCache("yfinance.cache"),
 )
-```
-
-### Fetching data for multiple tickers
-
-```python
-import yfinance as yf
-data = yf.download("SPY AAPL", start="2017-01-01", end="2017-04-30")
 ```
 
 ### Managing Multi-Level Columns

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -283,11 +283,14 @@ class Quote:
 
             json_str = self._data.cache_get(url=url, proxy=proxy).text
             json_data = json.loads(json_str)
-            key_stats = json_data["timeseries"]["result"][0]
-            if k not in key_stats:
-                # Yahoo website prints N/A, indicates Yahoo lacks necessary data to calculate
+            try:
+                key_stats = json_data["timeseries"]["result"][0]
+                if k not in key_stats:
+                    # Yahoo website prints N/A, indicates Yahoo lacks necessary data to calculate
+                    v = None
+                else:
+                    # Select most recent (last) raw value in list:
+                    v = key_stats[k][-1]["reportedValue"]["raw"]
+            except Exception:
                 v = None
-            else:
-                # Select most recent (last) raw value in list:
-                v = key_stats[k][-1]["reportedValue"]["raw"]
             self._info[k] = v


### PR DESCRIPTION
Addresses recent issue where calling Ticker.info would occasionally result in a TypeError Exception at line 287. 

Issue:
[https://github.com/ranaroussi/yfinance/issues/1395](url)

Fix: 
Wrapped key_stats statement  in a Try block and set variable "v" to "None" on Exception.
