### PR TITLE
Fetch 'info' dict from API instead of scraping

### DIFF
--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -15,6 +15,8 @@ else:
 import requests as requests
 import re
 from bs4 import BeautifulSoup
+import random
+import time
 
 from frozendict import frozendict
 
@@ -201,6 +203,11 @@ class TickerData:
                 proxy = proxy["https"]
             proxy = {"https": proxy}
         return proxy
+
+    def get_raw_json(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30):
+        response = self.get(url, user_agent_headers=user_agent_headers, params=params, proxy=proxy, timeout=timeout)
+        response.raise_for_status()
+        return response.json()
 
     def _get_decryption_keys_from_yahoo_js(self, soup):
         result = None

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -19,6 +19,7 @@ info_retired_keys = info_retired_keys_price | info_retired_keys_exchange | info_
 
 PRUNE_INFO = True
 # PRUNE_INFO = False
+_BASIC_URL_ = "https://query1.finance.yahoo.com/v7/finance/quote"
 
 
 from collections.abc import MutableMapping
@@ -87,13 +88,16 @@ class Quote:
         self._calendar = None
 
         self._already_scraped = False
-        self._already_scraped_complementary = False
+        self._already_fetched = False
+        self._already_fetched_complementary = False
 
     @property
     def info(self) -> dict:
         if self._info is None:
-            self._scrape(self.proxy)
-            self._scrape_complementary(self.proxy)
+            # self._scrape(self.proxy)  # decrypt broken
+            self._fetch(self.proxy)
+
+            self._fetch_complementary(self.proxy)
 
         return self._info
 
@@ -236,12 +240,34 @@ class Quote:
         except Exception:
             pass
 
-    def _scrape_complementary(self, proxy):
-        if self._already_scraped_complementary:
+    def _fetch(self, proxy):
+        if self._already_fetched:
             return
-        self._already_scraped_complementary = True
+        self._already_fetched = True
 
-        self._scrape(proxy)
+        result = self._data.get_raw_json(
+            _BASIC_URL_, params={"formatted": "true", "lang": "en-US", "symbols": self._data.ticker}, proxy=proxy
+        )
+        query1_info = next(
+            (info for info in result.get("quoteResponse", {}).get("result", []) if info["symbol"] == self._data.ticker),
+            None,
+        )
+        for k, v in query1_info.items():
+            if isinstance(v, dict) and "raw" in v and "fmt" in v:
+                query1_info[k] = v["fmt"] if k in {"regularMarketTime", "postMarketTime"} else v["raw"]
+            elif isinstance(v, str):
+                query1_info[k] = v.replace("\xa0", " ")
+            elif isinstance(v, (int, bool)):
+                query1_info[k] = v
+        self._info = query1_info
+
+    def _fetch_complementary(self, proxy):
+        if self._already_fetched_complementary:
+            return
+        self._already_fetched_complementary = True
+
+        # self._scrape(proxy)  # decrypt broken
+        self._fetch(proxy)
         if self._info is None:
             return
 


### PR DESCRIPTION
Due to the persistent failure of info property of Tickers due to decryption error of yahoo finance web pages, I added a failback to get some information from unofficial api https://query1.finance.yahoo.com/v7/finance/quote. which can get the ticker short/long name, listed date, exchange, timezone etc.

Quick test
```
Type "help", "copyright", "credits" or "license" for more information.
>>> import yfinance as yf
>>> ticker = yf.Ticker("KWEB")
>>> ticker.history()
                                Open       High        Low      Close    Volume  Dividends  Stock Splits  Capital Gains
Date
2023-02-23 00:00:00-05:00  31.150000  31.170000  29.785000  30.030001  21059600        0.0           0.0            0.0
2023-02-24 00:00:00-05:00  29.040001  29.350000  28.670000  28.910000  24900400        0.0           0.0            0.0
2023-02-27 00:00:00-05:00  29.559999  29.674999  29.230000  29.379999  16049700        0.0           0.0            0.0
2023-02-28 00:00:00-05:00  29.100000  29.620001  28.990000  29.190001  14846200        0.0           0.0            0.0
2023-03-01 00:00:00-05:00  30.790001  30.940001  30.344000  30.500000  26761200        0.0           0.0            0.0
2023-03-02 00:00:00-05:00  30.379999  31.545000  30.260000  31.490000  25618400        0.0           0.0            0.0
2023-03-03 00:00:00-05:00  31.420000  31.785000  31.420000  31.650000  15196500        0.0           0.0            0.0
2023-03-06 00:00:00-05:00  31.370001  31.469999  30.915001  30.959999  15815100        0.0           0.0            0.0
2023-03-07 00:00:00-05:00  30.570000  30.590000  29.920000  30.049999  17186600        0.0           0.0            0.0
2023-03-08 00:00:00-05:00  29.570000  29.834999  29.350000  29.740000  14574100        0.0           0.0            0.0
2023-03-09 00:00:00-05:00  28.950001  29.010000  28.030001  28.110001  29801100        0.0           0.0            0.0
2023-03-10 00:00:00-05:00  28.080000  28.615999  27.889999  28.219999  21822800        0.0           0.0            0.0
2023-03-13 00:00:00-04:00  28.190001  29.010000  28.059999  28.670000  21528700        0.0           0.0            0.0
2023-03-14 00:00:00-04:00  28.510000  28.980000  28.309999  28.930000  16422800        0.0           0.0            0.0
2023-03-15 00:00:00-04:00  28.180000  28.400000  27.684999  28.180000  22224000        0.0           0.0            0.0
2023-03-16 00:00:00-04:00  28.080000  29.020000  28.010000  28.950001  18518400        0.0           0.0            0.0
2023-03-17 00:00:00-04:00  29.330000  29.500000  28.639999  28.940001  19655600        0.0           0.0            0.0
2023-03-20 00:00:00-04:00  28.340000  29.115000  27.950001  28.709999  16119100        0.0           0.0            0.0
2023-03-21 00:00:00-04:00  29.049999  29.320000  28.790001  29.139999  13043800        0.0           0.0            0.0
2023-03-22 00:00:00-04:00  29.469999  29.500000  28.900000  28.920000  10900300        0.0           0.0            0.0
>>> ticker.info
{'symbol': 'KWEB', 'dividendDate': 1513900800, 'twoHundredDayAverageChangePercent': -0.0001659751, 'trailingThreeMonthNavReturns': -5.51232, 'fiftyTwoWeekLowChangePercent': 0.6794426, 'language': 'en-US', 'regularMarketDayRange': '28.9 - 29.5', 'regularMarketDayHigh': 29.5, 'twoHundredDayAverageChange': -0.0048007965, 'askSize': 280, 'twoHundredDayAverage': 28.9248, 'fiftyTwoWeekHighChange': -7.2699986, 'fiftyTwoWeekRange': '17.22 - 36.19', 'fiftyDayAverageChange': -3.018999, 'averageDailyVolume3Month': 18945966, 'exchangeDataDelayedBy': 0, 'firstTradeDateMilliseconds': Timestamp('2013-08-01 09:30:00-0400', tz='America/New_York'), 'trailingAnnualDividendRate': 0.0, 'fiftyTwoWeekLow': 17.22, 'market': 'us_market', 'regularMarketVolume': 10891543, 'postMarketPrice': 28.86, 'quoteSourceName': 'Nasdaq Real Time Price', 'messageBoardId': 'finmb_243136794', 'priceHint': 2, 'exchange': 'PCX', 'regularMarketDayLow': 28.9, 'ytdReturn': -3.50993, 'sourceInterval': 15, 'shortName': 'KraneShares Trust KraneShares C', 'region': 'US', 'fiftyDayAverageChangePercent': -0.094523914, 'fullExchangeName': 'NYSEArca', 'gmtOffSetMilliseconds': -14400000, 'regularMarketOpen': 29.47, 'regularMarketTime': '4:00PM EDT', 'regularMarketChangePercent': -0.7549736, 'quoteType': 'ETF', 'trailingAnnualDividendYield': 0.0, 'fiftyTwoWeekLowChange': 11.700001, 'averageDailyVolume10Day': 19003660, 'fiftyTwoWeekHighChangePercent': -0.2008842, 'typeDisp': 'ETF', 'trailingPE': 20.814081, 'tradeable': False, 'postMarketTime': '7:59PM EDT', 'currency': 'USD', 'fiftyTwoWeekHigh': 36.19, 'regularMarketPreviousClose': 29.14, 'postMarketChangePercent': -0.207467, 'trailingThreeMonthReturns': -5.51232, 'exchangeTimezoneName': 'America/New_York', 'regularMarketChange': -0.21999931, 'bidSize': 32, 'cryptoTradeable': False, 'fiftyDayAverage': 31.939, 'exchangeTimezoneShortName': 'EDT', 'marketState': 'POSTPOST', 'customPriceAlertConfidence': 'HIGH', 'regularMarketPrice': 28.92, 'postMarketChange': -0.0599995, 'ask': 29.09, 'epsTrailingTwelveMonths': 1.389444, 'bid': 28.84, 'triggerable': True, 'longName': 'KraneShares CSI China Internet ETF'}
>>> exit()

```