### PR TITLE
Omit of params of the get_fn

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -644,7 +644,8 @@ class TickerBase:
 
         # Getting data from json
         url = "{}/v8/finance/chart/{}".format(self._base_url, self.ticker)
-
+        user_agent_headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.95 Safari/537.36'}
         data = None
 
         try:
@@ -659,7 +660,10 @@ class TickerBase:
             data = get_fn(
                 url=url,
                 params=params,
-                timeout=timeout
+                timeout=timeout,
+                proxy=proxy,
+                user_agent_headers=user_agent_headers
+                
             )
             if "Will be right back" in data.text or data is None:
                 raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"


### PR DESCRIPTION
I've tried a lot of time to change my params in method .history, but the result is always"No data found for this date range, symbol may be delisted". I don't know if the reason is that I use a proxy because I'm not in America. But when I add param: {proxy and user_agent_headers}, the problem is soluted. Hope this will be helpful.