### PR TITLE
Fix corrupt tkr-tz-csv halting code (again)

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -930,8 +930,10 @@ class _TzCache:
         except TypeError:
             _os.remove(old_cache_file_path)
         else:
+            # Discard corrupt data:
             df = df[~df["Tz"].isna().to_numpy()]
             df = df[~(df["Tz"]=='').to_numpy()]
+            df = df[~df.index.isna()]
             if not df.empty:
                 try:
                     self.tz_db.bulk_set(df.to_dict()['Tz'])


### PR DESCRIPTION
When discarding corrupt data from old CSV-cache, was checking second column but not first column aka index. Now check both columns. Fixes #1526