### PR TITLE
fix: Readme cache-ratelimit. Limiter parenthesis was never closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
     pass
 
 session = CachedLimiterSession(
-    limiter=Limiter(RequestRate(2, Duration.SECOND*5),  # max 2 requests per 5 seconds
+    limiter=Limiter(RequestRate(2, Duration.SECOND*5)),  # max 2 requests per 5 seconds
     bucket_class=MemoryQueueBucket,
     backend=SQLiteCache("yfinance.cache"),
 )


### PR DESCRIPTION
The example in the docs will not work out of the box due to a syntax error.