### PR TITLE
Fix timedelta bug

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -353,7 +353,7 @@ def _interval_to_timedelta(interval):
     elif interval == "1y":
         return _dateutil.relativedelta.relativedelta(years=1)
     elif interval == "1wk":
-        return _pd.Timedelta(days=7, unit='d')
+        return _pd.Timedelta(days=7)
     else: 
         return _pd.Timedelta(interval)
 


### PR DESCRIPTION
Fix for exception using `_pd.Timedelta()` function with `unit='d'` parameter for  Pandas v1.4.4. Just removed the parameter as it was unnecessary.