### PR TITLE
fix start date on history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 yfinance.egg-info
 *.pyc
 .coverage
+.idea/
 .vscode/
 build/
 *.html

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -170,8 +170,8 @@ class TickerBase:
                 if interval == "1m":
                     start = end - 604800  # Subtract 7 days
                 else:
-                    _UNIX_TIMESTAMP_1900 = -2208994789
-                    start = _UNIX_TIMESTAMP_1900
+                    max_start_datetime = pd.Timestamp.utcnow().floor("D") - _datetime.timedelta(days=99 * 365)
+                    start = int(max_start_datetime.timestamp())
             else:
                 start = utils._parse_user_dt(start, tz)
             params = {"period1": start, "period2": end}


### PR DESCRIPTION
> ticker.basic_info["last_price"]

sometimes raises:

GDEVW: 1d data not available for startTime=-2208994789 and endTime=1687780922. Only 100 years worth of day granularity data are allowed to be fetched per request.