### PR TITLE
Fix to enable fetching all (including last) rows of intraday data

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -195,6 +195,9 @@ class TickerBase:
         #if the ticker is MUTUALFUND or ETF, then get capitalGains events
         params["events"] = "div,splits,capitalGains"
 
+        # Fetch all data
+        params["useYfid"] = True
+        
         params_pretty = dict(params)
         tz = self._get_ticker_tz(proxy, timeout)
         for k in ["period1", "period2"]:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -585,7 +585,6 @@ class Quote:
     def _fetch(self, proxy):
         if self._already_fetched:
             return
-        self._already_fetched = True
         modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
         params_dict = {}
         params_dict["modules"] = modules
@@ -593,6 +592,7 @@ class Quote:
         result = self._data.get_raw_json(
             _BASIC_URL_ + f"/{self._data.ticker}", params=params_dict, proxy=proxy
         )
+        self._already_fetched = True
         result["quoteSummary"]["result"][0]["symbol"] = self._data.ticker
         query1_info = next(
             (info for info in result.get("quoteSummary", {}).get("result", []) if info["symbol"] == self._data.ticker),

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -579,7 +579,7 @@ def fix_Yahoo_returning_prepost_unrequested(quotes, interval, tradingPeriods):
     quotes = quotes.merge(tps_df, how="left")
     quotes.index = idx
     # "end" = end of regular trading hours (including any auction)
-    f_drop = quotes.index >= quotes["end"]
+    f_drop = quotes.index > quotes["end"]
     f_drop = f_drop | (quotes.index < quotes["start"])
     if f_drop.any():
         # When printing report, ignore rows that were already NaNs:


### PR DESCRIPTION
This pull request enables fetching all intraday data, even the last, or "close" row, which was previously not fetched or dropped.

I don't know why, but without useYfid=true, the last row is dropped from the server response.