### PR TITLE
Bump requests to 2.31 and removes cryptography.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,14 +251,13 @@ To install `yfinance` using `conda`, see
 -   [Python](https://www.python.org) \>= 2.7, 3.4+
 -   [Pandas](https://github.com/pydata/pandas) \>= 1.3.0
 -   [Numpy](http://www.numpy.org) \>= 1.16.5
--   [requests](http://docs.python-requests.org/en/master) \>= 2.26
+-   [requests](http://docs.python-requests.org/en/master) \>= 2.31
 -   [lxml](https://pypi.org/project/lxml) \>= 4.9.1
 -   [appdirs](https://pypi.org/project/appdirs) \>= 1.4.4
 -   [pytz](https://pypi.org/project/pytz) \>=2022.5
 -   [frozendict](https://pypi.org/project/frozendict) \>= 2.3.4
 -   [beautifulsoup4](https://pypi.org/project/beautifulsoup4) \>= 4.11.1
 -   [html5lib](https://pypi.org/project/html5lib) \>= 1.1
--   [cryptography](https://pypi.org/project/cryptography) \>= 3.3.2
 
 #### Optional (if you want to use `pandas_datareader`)
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - pandas >=1.3.0
     - numpy >=1.16.5
-    - requests >=2.26
+    - requests >=2.31
     - multitasking >=0.0.7
     - lxml >=4.9.1
     - appdirs >=1.4.4
@@ -27,14 +27,13 @@ requirements:
     - beautifulsoup4 >=4.11.1
     - html5lib >=1.1
     # - pycryptodome >=3.6.6
-    - cryptography >=3.3.2
     - pip
     - python
 
   run:
     - pandas >=1.3.0
     - numpy >=1.16.5
-    - requests >=2.26
+    - requests >=2.31
     - multitasking >=0.0.7
     - lxml >=4.9.1
     - appdirs >=1.4.4
@@ -43,7 +42,6 @@ requirements:
     - beautifulsoup4 >=4.11.1
     - html5lib >=1.1
     # - pycryptodome >=3.6.6
-    - cryptography >=3.3.2
     - python
 
 test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas>=1.3.0
 numpy>=1.16.5
-requests>=2.26
+requests>=2.31
 multitasking>=0.0.7
 lxml>=4.9.1
 appdirs>=1.4.4
@@ -8,4 +8,3 @@ pytz>=2022.5
 frozendict>=2.3.4
 beautifulsoup4>=4.11.1
 html5lib>=1.1
-cryptography>=3.3.2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     keywords='pandas, yahoo finance, pandas datareader',
     packages=find_packages(exclude=['contrib', 'docs', 'tests', 'examples']),
     install_requires=['pandas>=1.3.0', 'numpy>=1.16.5',
-                      'requests>=2.26', 'multitasking>=0.0.7',
+                      'requests>=2.31', 'multitasking>=0.0.7',
                       'lxml>=4.9.1', 'appdirs>=1.4.4', 'pytz>=2022.5',
                       'frozendict>=2.3.4', 
                       'beautifulsoup4>=4.11.1', 'html5lib>=1.1'],


### PR DESCRIPTION
As suggested in #1616. I messed up something here and reverted the whole thing.

- Bumps requests to 2.31
- Removes cryptography (unnecessary)