### PR TITLE
Missing info for ETFs

### DIFF
--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -594,7 +594,7 @@ class Quote:
         if self._already_fetched:
             return
         self._already_fetched = True
-        modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
+        modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail', 'fundProfile']
         params_dict = {"modules": modules, "ssl": "true"}
         result = self._data.get_raw_json(
             _BASIC_URL_ + f"/{self._data.ticker}", params=params_dict, proxy=proxy


### PR DESCRIPTION
Fixes #244.

Some ETF information was not being pulled, because it was being stored at a different place. After reading #248, #557, and playing around with the URL endpoint, I noticed that the parameter `fundProfile` was not being pulled.

This fix simply adds the parameter to the `fetch` method, which will pull the data.

Here's the response sample for the contents of `fundProfile` for the VTI ticker:

```json
"fundProfile": {
	"maxAge": 1,
	"styleBoxUrl": "https://s.yimg.com/lq/i/fi/3_0stylelargeeq2.gif",
	"family": "Vanguard",
	"categoryName": "Large Blend",
	"legalType": "Exchange Traded Fund",
	"managementInfo": {
		"managerName": null,
		"managerBio": null,
		"startdate": {}
	},
	"feesExpensesInvestment": {
		"annualReportExpenseRatio": {
			"raw": 4.0E-4,
			"fmt": "0.04%"
		},
		"frontEndSalesLoad": {},
		"deferredSalesLoad": {},
		"twelveBOne": {},
		"netExpRatio": {},
		"grossExpRatio": {},
		"annualHoldingsTurnover": {
			"raw": 0.03,
			"fmt": "3.00%"
		},
		"totalNetAssets": {
			"raw": 134308.94,
			"fmt": "134,308.94"
		},
		"projectionValues": {}
	},
	"feesExpensesInvestmentCat": {
		"annualReportExpenseRatio": {
			"raw": 0.0036000002,
			"fmt": "0.36%"
		},
		"frontEndSalesLoad": {},
		"deferredSalesLoad": {},
		"twelveBOne": {},
		"annualHoldingsTurnover": {
			"raw": 50.76,
			"fmt": "5,076.00%"
		},
		"totalNetAssets": {
			"raw": 134308.94,
			"fmt": "134,308.94"
		},
		"projectionValuesCat": {}
	},
	"initInvestment": {},
	"initIraInvestment": {},
	"initAipInvestment": {},
	"subseqInvestment": {},
	"subseqIraInvestment": {},
	"subseqAipInvestment": {},
	"brokerages": []
}

```

As I mentioned above, this will simply pull the data; at this point, the question would be whether to add or not some feature that handles the data above in any specific way after detecting that a given ticker is an ETF, which I think would just add more complexity to the way data is being handled in this module.

With this fix, calling `ticker.info['feesExpensesInvestment']['annualReportExpenseRatio']` would yield the desired return.