### PR TITLE
Fix error when calling enable_debug_mode twice

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -169,14 +169,15 @@ def setup_debug_formatting():
         yf_logger.warning("logging mode not set to 'DEBUG', so not setting up debug formatting")
         return
 
-    if yf_logger.handlers is None or len(yf_logger.handlers) == 0:
-        h = logging.StreamHandler()
-        # Ensure different level strings don't interfere with indentation
-        formatter = MultiLineFormatter(fmt='%(levelname)-8s %(message)s')
-        h.setFormatter(formatter)
-        yf_logger.addHandler(h)
-
     global yf_log_indented
+    if not yf_log_indented:
+        if yf_logger.handlers is None or len(yf_logger.handlers) == 0:
+            h = logging.StreamHandler()
+            # Ensure different level strings don't interfere with indentation
+            formatter = MultiLineFormatter(fmt='%(levelname)-8s %(message)s')
+            h.setFormatter(formatter)
+            yf_logger.addHandler(h)
+
     yf_log_indented = True
 
 


### PR DESCRIPTION
When call `enable_debug_mode` twice, It makes error.
```
Traceback (most recent call last):
  File "/home/arduinocc04/Documents/GitHub/yfinance/test_yfinance.py", line 75, in <module>
    yf.enable_debug_mode()
  File "/home/arduinocc04/Documents/GitHub/yfinance/yfinance/utils.py", line 185, in enable_debug_mode
    setup_debug_formatting()
  File "/home/arduinocc04/Documents/GitHub/yfinance/yfinance/utils.py", line 172, in setup_debug_formatting
    if yf_logger.handlers is None or len(yf_logger.handlers) == 0:
       ^^^^^^^^^^^^^^^^^^
AttributeError: 'IndentLoggerAdapter' object has no attribute 'handlers'. Did you mean: 'hasHandlers'?
```

This error is so annoying when using jupyter and rerun code block.