### PR TITLE
Feature proposal for ticker.calendar

### DIFF
--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -13,6 +13,8 @@ import pandas as pd
 from .context import yfinance as yf
 from .context import session_gbl
 from yfinance.exceptions import YFNotImplementedError
+from yfinance.scrapers.quote import  CalendarData
+
 
 
 import unittest
@@ -27,7 +29,7 @@ ticker_attributes = (
     ("actions", pd.DataFrame),
     ("shares", pd.DataFrame),
     ("info", dict),
-    ("calendar", pd.DataFrame),
+    ("calendar", CalendarData),
     ("recommendations", Union[pd.DataFrame, dict]),
     ("earnings", pd.DataFrame),
     ("quarterly_earnings", pd.DataFrame),

--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -13,7 +13,7 @@ import pandas as pd
 from .context import yfinance as yf
 from .context import session_gbl
 from yfinance.exceptions import YFNotImplementedError
-from yfinance.scrapers.quote import  CalendarData
+from yfinance.scrapers.quote import EarningsData 
 
 
 
@@ -29,10 +29,8 @@ ticker_attributes = (
     ("actions", pd.DataFrame),
     ("shares", pd.DataFrame),
     ("info", dict),
-    ("calendar", CalendarData),
+    ("earnings", EarningsData),
     ("recommendations", Union[pd.DataFrame, dict]),
-    ("earnings", pd.DataFrame),
-    ("quarterly_earnings", pd.DataFrame),
     ("recommendations_summary", Union[pd.DataFrame, dict]),
     ("quarterly_cashflow", pd.DataFrame),
     ("cashflow", pd.DataFrame),
@@ -46,7 +44,6 @@ ticker_attributes = (
     ("options", tuple),
     ("news", Any),
     ("earnings_trend", pd.DataFrame),
-    ("earnings_dates", pd.DataFrame),
     ("earnings_forecasts", pd.DataFrame),
 )
 

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -28,12 +28,6 @@ class Fundamentals:
         return self._financials
 
     @property
-    def earnings(self) -> dict:
-        if self._earnings is None:
-            raise YFNotImplementedError('earnings')
-        return self._earnings
-
-    @property
     def shares(self) -> pd.DataFrame:
         if self._shares is None:
             raise YFNotImplementedError('shares')

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -705,10 +705,12 @@ class CalendarData:
     def __init__(self, ticker: str):
         self.ticker = ticker
         self.offset = 0
+        # Batch request for a single request (probably shouldn't be overwritten)
         self.size = 100
         self.params = {"symbol": ticker}
         self.url = "https://finance.yahoo.com/calendar/earnings"
         self.data = None
+        # toggle when the endpoint returns an html without <table>
         self.has_no_tables = False
 
 
@@ -730,10 +732,13 @@ class CalendarData:
         table["EPS Estimate"] = table["EPS Estimate"].apply(CalendarData.parse_numeric_col)
         table["Reported EPS"] = table["EPS Estimate"].apply(CalendarData.parse_numeric_col)
         table["Surprise(%)"] = table["Surprise(%)"].apply(CalendarData.parse_numeric_col)
-        self.data = table
+        if self.data is None:
+            self.data = table
+        else:
+            # index must be reset as self.data and table will have conflicting indexes 
+            self.data = pd.concat([self.data, table]).reset_index()
 
-
-    def get_calendar(self):
+    def get(self):
         return self.data
 
     def _get_calendar(self):

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -3,9 +3,13 @@ import json
 import logging
 import warnings
 from collections.abc import MutableMapping
+from io import StringIO
 
 import numpy as _np
 import pandas as pd
+
+import urllib.parse
+import requests
 
 from yfinance import utils
 from yfinance.data import TickerData
@@ -559,7 +563,7 @@ class Quote:
         self._retired_info = None
         self._sustainability = None
         self._recommendations = None
-        self._calendar = None
+        self._calendar = CalendarData(data.ticker)
 
         self._already_scraped = False
         self._already_fetched = False
@@ -586,10 +590,11 @@ class Quote:
         return self._recommendations
 
     @property
-    def calendar(self) -> pd.DataFrame:
-        if self._calendar is None:
-            raise YFNotImplementedError('calendar')
-        return self._calendar
+    def calendar(self):
+        return self.get_calendar()
+
+    def get_calendar(self):
+        return self._calendar._get_calendar()
 
     def _fetch(self, proxy):
         if self._already_fetched:
@@ -693,3 +698,71 @@ class Quote:
             except Exception:
                 v = None
             self._info[k] = v
+
+
+class CalendarData:
+
+    def __init__(self, ticker: str):
+        self.ticker = ticker
+        self.offset = 0
+        self.size = 100
+        self.params = {"symbol": ticker}
+        self.url = "https://finance.yahoo.com/calendar/earnings"
+        self.data = None
+        self.has_no_tables = False
+
+
+    @staticmethod
+    def parse_date_string_column(entry: str):
+        date_format = "%b %d, %Y"
+        split_date = entry.split(", ")
+        date_string = ", ".join(split_date[:-1])
+        return datetime.datetime.strptime(date_string, date_format)
+
+    @staticmethod
+    def parse_numeric_col(entry: str):
+        if entry == "-":
+            return _np.nan
+        return float(entry)
+
+    def parse_table(self, table: pd.DataFrame):
+        table['Earnings Date'] = table['Earnings Date'].apply(CalendarData.parse_date_string_column)
+        table["EPS Estimate"] = table["EPS Estimate"].apply(CalendarData.parse_numeric_col)
+        table["Reported EPS"] = table["EPS Estimate"].apply(CalendarData.parse_numeric_col)
+        table["Surprise(%)"] = table["Surprise(%)"].apply(CalendarData.parse_numeric_col)
+        self.data = table
+
+
+    def get_calendar(self):
+        return self.data
+
+    def _get_calendar(self):
+        if self.has_no_tables:
+            return self
+        try:
+            url = self.url + "?" + urllib.parse.urlencode(self.params)
+            res = requests.get(url, headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/117.0.0.0 Safari/537.36"})
+            if not res.ok or len(res.text) == 0:
+                return self
+            tables = pd.read_html(StringIO(res.text))
+            if len(tables) == 0:
+                # len(tables) should technically be 1 or else
+                # pandas would throw an error, but index checking might still be needed
+                return self
+            self.parse_table(tables[0])
+        except ValueError:
+            #Theres no table to be parsed
+            self.has_no_tables = True
+        return self
+
+    def get_next(self):
+        # set parameter size for the first time get_next is called
+        if "size" not in self.params.keys():
+            self.params['size'] = self.size
+
+        if "offset" in self.params.keys():
+            self.params['offset'] = self.params['offset'] + self.size 
+        else:
+            self.params['offset'] = self.size
+
+        return self._get_calendar()

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -146,7 +146,7 @@ class Ticker(TickerBase):
         return self.get_fast_info()
 
     @property
-    def calendar(self) -> _pd.DataFrame:
+    def calendar(self):
         return self.get_calendar()
 
     @property

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -146,20 +146,11 @@ class Ticker(TickerBase):
         return self.get_fast_info()
 
     @property
-    def calendar(self):
-        return self.get_calendar()
-
-    @property
     def recommendations(self):
         return self.get_recommendations()
-
     @property
-    def earnings(self) -> _pd.DataFrame:
-        return self.get_earnings()
-
-    @property
-    def quarterly_earnings(self) -> _pd.DataFrame:
-        return self.get_earnings(freq='quarterly')
+    def earnings(self):
+        return self._quote.earnings
 
     @property
     def income_stmt(self) -> _pd.DataFrame:


### PR DESCRIPTION
## Feature proposal

This is a feature proposal for `Ticker.calendar`.  the table is scraped from `https://finance.yahoo.com/calendar/earnings?symbol=<ticker>` , since the calendar is an html table, we can parse that with `pandas.read_html`

## Usage
I am somewhat skeptical about the way I structured the calendar API, better suggestions to handle `get_next` are welcome

```python
import yfinance as yf

ticker = yf.Ticker("AAPL")

# Returns an instance of CalendarData
calendar = ticker.calendar


earnings_calendar = calendar.get_calendar()  # Returns None | DataFrame

# get_next returns CalendarData and get_calendar returns None | DataFrame
next_earnings = calendar.get_next().get_calendar()

print("earnings: ")
if earnings_calendar is not None:
    print(earnings_calendar.tail(10))
print("\nnext earnings")
if next_earnings is not None:
    print(next_earnings.tail(10))

next_earnings = calendar.get_next()
print("\nnext earnings")
if next_earnings is not None:
    print(next_earnings.get_calendar().tail(10))
```

when `get_next`, which calls `_get_calendar` raises a `ValueError` then we know that there are not tables to be parsed. 

In the example above if `get_next()` reaches the end of the earnings list, then  we keep returning the last batch