### PR TITLE
fix: update unsupported operand in request_args

### DIFF
--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -358,7 +358,7 @@ class YfData(metaclass=SingletonMeta):
 
         request_args = {
             'url': url,
-            'params': params | crumbs,
+            'params': {**params, **crumbs},
             'cookies': cookies,
             'proxies': proxy,
             'timeout': timeout,


### PR DESCRIPTION
address an issue where operand `|` is not supported in python. 