### PR TITLE
Add Annual Net Expense Ratio to Ticker Info

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1751,6 +1751,12 @@ class TickerBase:
     def get_info(self, proxy=None) -> dict:
         self._quote.proxy = proxy or self.proxy
         data = self._quote.info
+        try:
+            holders = self.get_institutional_holders()
+            expenseRatio = holders[holders[0] == 'Expense Ratio (net)'][1].values[0]
+            data['annualNetExpenseRatio'] = expenseRatio
+        except Exception:
+            pass
         return data
 
     def get_fast_info(self, proxy=None):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1751,12 +1751,10 @@ class TickerBase:
     def get_info(self, proxy=None) -> dict:
         self._quote.proxy = proxy or self.proxy
         data = self._quote.info
-        try:
+        if data['quoteType'] == 'ETF':
             holders = self.get_institutional_holders()
             expenseRatio = holders[holders[0] == 'Expense Ratio (net)'][1].values[0]
-            data['annualNetExpenseRatio'] = expenseRatio
-        except Exception:
-            pass
+            data['annualReportExpenseRatio'] = float(expenseRatio.strip('%'))/100
         return data
 
     def get_fast_info(self, proxy=None):


### PR DESCRIPTION
Checks for existence of 'Expense Ratio (net)' of mutual funds and ETF tickers and adds metric retroactively to `Ticker.info` attribute through `TickerBase.get_info()` method as `'annualNetExpenseRatio'` as requested and resolves #801. 

Change uses `TickerBase.get_institutional_holders()` which returns a dictionary with row info `['Net Assets', 'NAV', 'PE Ratio (TTM)', 'Yield', 'YTD Daily Total Return', 'Beta (5Y Monthly)', 'Expense Ratio (net)', 'Inception Date']` for mutual funds and ETF tickers. 

This may be a bug, as these dictionary contents have nothing to do with institutional holders of mutual funds and ETFs as they do not have any listed under Holdings. These stats are located on the summary page of mutual funds and ETFs on [finance.yahoo.com](https://finance.yahoo.com/quote/VOO?p=VOO&.tsrc=fin-srch) see Vanguard 500 Index Fund (VOO) as example, Holdings tab of mutual funds and ETFs show Overall Portfolio Composition (%), Sector Weightings (%), Equity Holdings, Bond Ratings, and Top 9 Holdings.

From testing it shows that `TickerBase` class methods `get_major_holders()` returns information from the first column of the summary page and `get_institutional_holders()` returns information from the second column of the summary page for mutual funds and ETFs.

This is a temporary fix, but further action will likely require a code refactor of considerable scale.