### PR TITLE
Feature/added financials plot

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1856,15 +1856,15 @@ class TickerBase:
         if as_dict:
             return data.to_dict()
         return data
-    
-    def get_financials_plot(self, proxy=None, freq="yearly"):
-        return self._fundamentals.financials.get_financials_plot_from_ics(freq=freq, proxy=proxy)
 
     def get_incomestmt(self, proxy=None, as_dict=False, pretty=False, freq="yearly"):
         return self.get_income_stmt(proxy, as_dict, pretty, freq)
 
     def get_financials(self, proxy=None, as_dict=False, pretty=False, freq="yearly"):
         return self.get_income_stmt(proxy, as_dict, pretty, freq)
+    
+    def get_financials_plot(self, proxy=None, freq="yearly"):
+        return self._fundamentals.financials.get_financials_plot_from_ics(freq=freq, proxy=proxy)
 
     def get_balance_sheet(self, proxy=None, as_dict=False, pretty=False, freq="yearly"):
         """

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1856,6 +1856,9 @@ class TickerBase:
         if as_dict:
             return data.to_dict()
         return data
+    
+    def get_financials_plot(self, proxy=None, freq="yearly"):
+        return self._fundamentals.financials.get_financials_plot_from_ics(freq=freq, proxy=proxy)
 
     def get_incomestmt(self, proxy=None, as_dict=False, pretty=False, freq="yearly"):
         return self.get_income_stmt(proxy, as_dict, pretty, freq)

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -69,7 +69,7 @@ class Financials:
             res[freq] = self._fetch_time_series("cash-flow", freq, proxy)
         return res[freq]
     
-    def get_financials_plot_from_ics(self, freq="yearly", proxy=None) -> plt.figure:
+    def get_financials_plot_from_ics(self, freq="yearly", proxy=None) -> None:
         if len(self._income_time_series) == 0:
             self._income_time_series = self.get_income_time_series(freq, proxy)
         

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -72,7 +72,8 @@ class Financials:
     def get_financials_plot_from_ics(self, freq="yearly", proxy=None) -> plt.figure:
         if len(self._income_time_series) == 0:
             self._income_time_series = self.get_income_time_series(freq, proxy)
-        data = self._income_time_series[freq]
+        
+        data = self._income_time_series
 
         if "Total Revenue" in data.index:
             revenue_data = data.loc["Total Revenue"]


### PR DESCRIPTION
Fixes issue #1737 , the plot should be the same as the one seen on the [yahoo financials page](https://finance.yahoo.com/quote/AAPL/financials?p=AAPL).

This can be tested by running the below function and switching between yearly and quarterly.
```
apple = yf.Ticker('AAPL')
apple.get_financials_plot(freq='yearly')
```

Note:
- This does use matplotlib which needs to be added to the dependencies for whoever wants to use it. We could also add this as optional via `pip install yfinance[optional]`, let me know if you need me to add that into setup.py 
- I decided against developing another get request to yahoo for the plot (as mentioned in the issue) since we already have the data for it which can be extracted from the income statement we already have developed. 
- I also decided against returning the plot and just using `plt.show()` directly in the function. This is because I'm unsure that users will know to call `plt.show()` on the output if it was just the figure, and I personally find it more user-friendly just have the figure open after running the function. Open to other people's opinions though!