### PR TITLE
Feat/adding extra dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,21 +50,15 @@ Install `yfinance` using `pip`:
 $ pip install yfinance --upgrade --no-cache-dir
 ```
 
-To install `yfinance` using `conda`, see
-[this](https://anaconda.org/ranaroussi/yfinance). 
+[With Conda](https://anaconda.org/ranaroussi/yfinance).
 
-Test new features by installing betas, provide feedback in [corresponding Discussion](https://github.com/ranaroussi/yfinance/discussions):
+To install with optional dependencies, replace `optional` with: `nospam` for [caching-requests](#smarter-scraping), `repair` for [price repair](https://github.com/ranaroussi/yfinance/wiki/Price-repair), or `nospam,repair` for both:
+
 ``` {.sourceCode .bash}
-$ pip install yfinance --upgrade --no-cache-dir --pre
+$ pip install yfinance[optional]
 ```
 
-To install with extra dependencies, replace `extra` with `nospam` for custom requests or `repair` for price repairing functionality:
-``` {.sourceCode .bash}
-$ pip install yfinance[extra]
-```
-
-To view the full list of [required dependencies](https://github.com/ranaroussi/yfinance/blob/main/requirements.txt) and extra packages, see [this](https://github.com/ranaroussi/yfinance/blob/f08fe83290136d103d46d67524f5b6e7b6b827ff/setup.py#L62).
-
+[Required dependencies](./requirements.txt) , [all dependencies](./setup.py#L62).
 
 ---
 
@@ -256,26 +250,6 @@ yf.set_tz_cache_location("custom/cache/location")
 ```
 
 ---
-
-
-<!-- ### Requirements
-
--   [Python](https://www.python.org) \>= 2.7, 3.4+
--   [Pandas](https://github.com/pydata/pandas) \>= 1.3.0
--   [Numpy](http://www.numpy.org) \>= 1.16.5
--   [requests](http://docs.python-requests.org/en/master) \>= 2.31
--   [lxml](https://pypi.org/project/lxml) \>= 4.9.1
--   [appdirs](https://pypi.org/project/appdirs) \>= 1.4.4
--   [pytz](https://pypi.org/project/pytz) \>=2022.5
--   [frozendict](https://pypi.org/project/frozendict) \>= 2.3.4
--   [beautifulsoup4](https://pypi.org/project/beautifulsoup4) \>= 4.11.1
--   [html5lib](https://pypi.org/project/html5lib) \>= 1.1
--   [peewee](https://pypi.org/project/peewee)  \>= 3.16.2
-
-#### Optional (if you want to use `pandas_datareader`)
-
--   [pandas\_datareader](https://github.com/pydata/pandas-datareader)
-    \>= 0.4.0 -->
 
 ## Developers: want to contribute?
 

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ data = yf.download("SPY AAPL", period="1mo")
 
 ### Smarter scraping
 
-Install the `nospam` packages for smarter scraping using `pip` (see [Installation](#installation)). 
+Install the `nospam` packages for smarter scraping using `pip` (see [Installation](#installation)). These packages help cache calls such that Yahoo is not spammed with requests. 
 
-To use a custom `requests` session (for example to cache calls to the API or customize the `User-agent` header), pass a `session=` argument to
-the Ticker constructor.
+To use a custom `requests` session, pass a `session=` argument to
+the Ticker constructor. This allows for caching calls to the API as well as a custom way to modify requests via  the `User-agent` header.
 
 ```python
 import requests_cache
@@ -195,7 +195,7 @@ ticker = yf.Ticker('msft', session=session)
 ticker.actions
 ```
 
-Combine a `requests_cache` with rate-limiting to avoid triggering Yahoo's rate-limiter/blocker that can corrupt data.
+Combine `requests_cache` with rate-limiting to avoid triggering Yahoo's rate-limiter/blocker that can corrupt data.
 ```python
 from requests import Session
 from requests_cache import CacheMixin, SQLiteCache

--- a/README.md
+++ b/README.md
@@ -42,6 +42,32 @@ Yahoo! finance API is intended for personal use only.**
 
 ---
 
+## Installation
+
+Install `yfinance` using `pip`:
+
+``` {.sourceCode .bash}
+$ pip install yfinance --upgrade --no-cache-dir
+```
+
+To install `yfinance` using `conda`, see
+[this](https://anaconda.org/ranaroussi/yfinance). 
+
+Test new features by installing betas, provide feedback in [corresponding Discussion](https://github.com/ranaroussi/yfinance/discussions):
+``` {.sourceCode .bash}
+$ pip install yfinance --upgrade --no-cache-dir --pre
+```
+
+To install with extra dependencies, replace `extra` with `nospam` for custom requests or `repair` for price repairing functionality:
+``` {.sourceCode .bash}
+$ pip install yfinance[extra]
+```
+
+To view the full list of [required dependencies](https://github.com/ranaroussi/yfinance/blob/main/requirements.txt) and extra packages, see [this](https://github.com/ranaroussi/yfinance/blob/f08fe83290136d103d46d67524f5b6e7b6b827ff/setup.py#L62).
+
+
+---
+
 ## Quick Start
 
 ### The Ticker module
@@ -155,8 +181,9 @@ data = yf.download("SPY AAPL", period="1mo")
 
 ### Smarter scraping
 
-To use a custom `requests` session (for example to cache calls to the
-API or customize the `User-agent` header), pass a `session=` argument to
+Install the `nospam` packages for smarter scraping using `pip` (see [Installation](#installation)). 
+
+To use a custom `requests` session (for example to cache calls to the API or customize the `User-agent` header), pass a `session=` argument to
 the Ticker constructor.
 
 ```python
@@ -230,23 +257,8 @@ yf.set_tz_cache_location("custom/cache/location")
 
 ---
 
-## Installation
 
-Install `yfinance` using `pip`:
-
-``` {.sourceCode .bash}
-$ pip install yfinance --upgrade --no-cache-dir
-```
-
-Test new features by installing betas, provide feedback in [corresponding Discussion](https://github.com/ranaroussi/yfinance/discussions):
-``` {.sourceCode .bash}
-$ pip install yfinance --upgrade --no-cache-dir --pre
-```
-
-To install `yfinance` using `conda`, see
-[this](https://anaconda.org/ranaroussi/yfinance).
-
-### Requirements
+<!-- ### Requirements
 
 -   [Python](https://www.python.org) \>= 2.7, 3.4+
 -   [Pandas](https://github.com/pydata/pandas) \>= 1.3.0
@@ -263,7 +275,7 @@ To install `yfinance` using `conda`, see
 #### Optional (if you want to use `pandas_datareader`)
 
 -   [pandas\_datareader](https://github.com/pydata/pandas-datareader)
-    \>= 0.4.0
+    \>= 0.4.0 -->
 
 ## Developers: want to contribute?
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
                       'beautifulsoup4>=4.11.1', 'html5lib>=1.1'],
     extras_require={
         'nospam': ['requests_cache>=1.1.1', 'requests_ratelimiter>=0.4.2'],
-        'repair': ['scipy>=1.10.1'],
+        'repair': ['scipy>=1.6.3'],
     },
     # Note: Pandas.read_html() needs html5lib & beautifulsoup4
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,10 @@ setup(
                       'lxml>=4.9.1', 'appdirs>=1.4.4', 'pytz>=2022.5',
                       'frozendict>=2.3.4', 'peewee>=3.16.2',
                       'beautifulsoup4>=4.11.1', 'html5lib>=1.1'],
+    extras_require={
+        'nospam': ['requests_cache>=1.1.1', 'requests_ratelimiter>=0.4.2'],
+        'repair': ['scipy>=1.10.1'],
+    },
     # Note: Pandas.read_html() needs html5lib & beautifulsoup4
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Implemented extra dependencies as discussed in #1766.

This can be tested locally via the command `pip install -e .[extras]` by replacing extras with:
- `nospam`: requests dependencies for custom requests and testing
    -  requests_cache, requests_ratelimiter
- `repair`: for price repairing functionality 
    - scipy

Maybe also add to #1084 that `nospam` is required to run tests and link the Installation instructions in the readme. 