### PR TITLE
Fixed incorrect code for ticker complementary info retrieval

### DIFF
--- a/tests/ticker.py
+++ b/tests/ticker.py
@@ -720,6 +720,18 @@ class TestTickerInfo(unittest.TestCase):
             self.assertIn("symbol", data.keys(), f"Did not find expected key '{k}' in info dict")
         self.assertEqual(self.symbols[0], data["symbol"], "Wrong symbol value in info dict")
 
+    def test_complementary_info(self):
+        # This test is to check that we can successfully retrieve the trailing PEG ratio
+
+        # We don't expect this one to have a trailing PEG ratio
+        data1 = self.tickers[0].info
+        self.assertEqual(data1['trailingPegRatio'], None)
+
+        # This one should have a trailing PEG ratio
+        data2 = self.tickers[2].info
+        self.assertEqual(data2['trailingPegRatio'], 1.2713)
+        pass
+
     # def test_fast_info_matches_info(self):
     #     fast_info_keys = set()
     #     for ticker in self.tickers:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -701,7 +701,7 @@ class Quote:
             json_str = self._data.cache_get(url=url, proxy=proxy).text
             json_data = json.loads(json_str)
             if json_data["timeseries"]["error"] is not None:
-                raise YFinanceException(f"Failed to parse json response from Yahoo Finance: " + json_data["error"])
+                raise YFinanceException("Failed to parse json response from Yahoo Finance: " + json_data["error"])
             for k in keys:
                 keydict = json_data["timeseries"]["result"][0]
                 if k in keydict:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -700,14 +700,12 @@ class Quote:
 
             json_str = self._data.cache_get(url=url, proxy=proxy).text
             json_data = json.loads(json_str)
-            try:
-                key_stats = json_data["timeseries"]["result"][0]
-                if k not in key_stats:
-                    # Yahoo website prints N/A, indicates Yahoo lacks necessary data to calculate
-                    v = None
+            if json_data["timeseries"]["error"] is not None:
+                raise YFinanceException(f"Failed to parse json response from Yahoo Finance: " + json_data["error"])
+            for k in keys:
+                keydict = json_data["timeseries"]["result"][0]
+                if k in keydict:
+                    self._info[k] = keydict[k][-1]["reportedValue"]["raw"]
                 else:
-                    # Select most recent (last) raw value in list:
-                    v = key_stats[k][-1]["reportedValue"]["raw"]
-            except Exception:
-                v = None
-            self._info[k] = v
+                    self.info[k] = None
+


### PR DESCRIPTION
This PR is meant to fix #1305. The old version of the code incorrectly checked for the "trailingPegRatio" complementary statistic which caused the data associated with that key to always be None. The parsing for this key has been fixed and the scheme has been modified to allow for other complementary stats to seamlessly be added to the "keys" dictionary.

A test case has been added to verify that this statistic is properly being retrieved.