### PR TITLE
Fix for Key Error Issue on Date column when one of the symbols is no longer valid (delisted/not available)

### DIFF
--- a/tests/prices.py
+++ b/tests/prices.py
@@ -43,6 +43,18 @@ class TestPriceHistory(unittest.TestCase):
 
             df_tkrs = df.columns.levels[1]
             self.assertEqual(sorted(tkrs), sorted(df_tkrs))
+    
+    def test_download_with_invalid_ticker(self):
+        #Checks if using an invalid symbol gives the same output as not using an invalid symbol in combination with a valid symbol (AAPL)
+        #Checks to make sure that invalid symbol handling for the date column is the same as the base case (no invalid symbols)
+
+        invalid_tkrs = ["AAPL", "ATVI"] #AAPL exists and ATVI does not exist
+        valid_tkrs = ["AAPL", "INTC"] #AAPL and INTC both exist
+        
+        data_invalid_sym = yf.download(invalid_tkrs, start='2023-11-16', end='2023-11-17')
+        data_valid_sym = yf.download(valid_tkrs, start='2023-11-16', end='2023-11-17')
+
+        self.assertEqual(data_invalid_sym['Close']['AAPL']['2023-11-16'],data_valid_sym['Close']['AAPL']['2023-11-16'])
 
     def test_duplicatingHourly(self):
         tkrs = ["IMP.JO", "BHG.JO", "SSW.JO", "BP.L", "INTC"]

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -222,7 +222,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
         _realign_dfs()
         data = _pd.concat(shared._DFS.values(), axis=1, sort=True,
                           keys=shared._DFS.keys())
-
+    data.index = _pd.to_datetime(data.index)
     # switch names back to isins if applicable
     data.rename(columns=shared._ISINS, inplace=True)
 


### PR DESCRIPTION
This is to address Issue #1743 

This PR has a simple one line fix where I convert the time column from an Index.base type to a datetime object in the download function (in multi.py). 

This error was occurring due to the pd.concat function and how it handles empty dataframes. 

I also added a unit test for this based off of the issue. 