### PR TITLE
updated bookValue to be TangibleBookValue

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1751,6 +1751,9 @@ class TickerBase:
     def get_info(self, proxy=None) -> dict:
         self._quote.proxy = proxy or self.proxy
         data = self._quote.info
+        data['bookValuePerShare'] = data['bookValue']
+        bal_sheet = self.get_balance_sheet()
+        data['bookValue'] = bal_sheet.loc['TangibleBookValue'][0]
         return data
 
     def get_fast_info(self, proxy=None):


### PR DESCRIPTION
Resolves #936 by retroactively changing `bookValue` from book value per share to `TangibleBookValue` from `get_balance_sheet()` and changed original `bookValue` to `bookValuePerShare`