### PR TITLE
explicitly name the column levels

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -217,11 +217,11 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
 
     try:
         data = _pd.concat(shared._DFS.values(), axis=1, sort=True,
-                          keys=shared._DFS.keys())
+                          keys=shared._DFS.keys(), names=['Ticker', 'Price'])
     except Exception:
         _realign_dfs()
         data = _pd.concat(shared._DFS.values(), axis=1, sort=True,
-                          keys=shared._DFS.keys())
+                          keys=shared._DFS.keys(), names=['Ticker', 'Price'])
     data.index = _pd.to_datetime(data.index)
     # switch names back to isins if applicable
     data.rename(columns=shared._ISINS, inplace=True)


### PR DESCRIPTION
This pull request is related to an edge case posted on Stack Overflow (https://stackoverflow.com/q/74835912/19123103) whose cause was that when data for multiple tickers is downloaded, the column levels did not have names. This pull request edits the call to `pandas.concat()` by passing level names ('Ticker' and `Price`) to it.

So a call such as 
```python
import yfinance as yf
df = yf.download("GOOGL,AMZN", start='2023-12-01', end='2023-12-07')
```
will produce
```none
Price        Adj Close                   Close                    High  
Ticker            AMZN       GOOGL        AMZN       GOOGL        AMZN   
Date                                                                     
2023-12-01  147.029999  131.860001  147.029999  131.860001  147.250000   
2023-12-04  144.839996  129.270004  144.839996  129.270004  145.350006   
2023-12-05  146.880005  130.990005  146.880005  130.990005  148.570007   
2023-12-06  144.520004  130.020004  144.520004  130.020004  147.850006   
```
instead of 
```none
             Adj Close                   Close                    High  
                  AMZN       GOOGL        AMZN       GOOGL        AMZN   
Date                                                                     
2023-12-01  147.029999  131.860001  147.029999  131.860001  147.250000   
2023-12-04  144.839996  129.270004  144.839996  129.270004  145.350006   
2023-12-05  146.880005  130.990005  146.880005  130.990005  148.570007   
2023-12-06  144.520004  130.020004  144.520004  130.020004  147.850006   
```