### PR TITLE
Ticker.history() to raise HTTP request excs if raise_errors args is True

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -218,7 +218,8 @@ class TickerBase:
 
             data = data.json()
         except Exception:
-            pass
+            if raise_errors:
+                raise
 
         # Store the meta data that gets retrieved simultaneously
         try:


### PR DESCRIPTION
I'd like to be able to handle any exception that might happen while `Ticker.history()` performs the HTTP request.
I currently do it in a hackish way using a monkey patch.
With this PR I'd like to introduce a hook for a custom function that, when given, it is invoked when such exception happens.

Most basic example I can think of:
```py
import requests
import yfinance as yf
from pandas import DataFrame

def reraise(exc):
    raise exc

ticker = yf.Ticker("AAPL")

try:
    data: DataFrame = ticker.history(
        interval="1m",
        start=...,
        end=...,
        timeout=10,
        raise_errors=True,
        request_exc_hook=reraise,
    )
except requests.ConnectTimeout as exc:
    ...
```

Note that my actual case a bit more complex to explain and boring (meaning not really useful for this proposal).