### PR TITLE
Set sensible min versions for optional 'nospam' reqs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
                       'frozendict>=2.3.4', 'peewee>=3.16.2',
                       'beautifulsoup4>=4.11.1', 'html5lib>=1.1'],
     extras_require={
-        'nospam': ['requests_cache>=1.1.1', 'requests_ratelimiter>=0.4.2'],
+        'nospam': ['requests_cache>=1.0', 'requests_ratelimiter>=0.3.1'],
         'repair': ['scipy>=1.6.3'],
     },
     # Note: Pandas.read_html() needs html5lib & beautifulsoup4


### PR DESCRIPTION
Set sensible minimum versions for optional `nospam` reqs:
- requests_cache >= 1.0 , first defined `DO_NOT_CACHE` - resolve #1751