### PR TITLE
make nan as float

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -2167,7 +2167,7 @@ class TickerBase:
 
         # Convert types
         for cn in ["EPS Estimate", "Reported EPS", "Surprise(%)"]:
-            dates.loc[dates[cn] == '-', cn] = "NaN"
+            dates.loc[dates[cn] == '-', cn] = float("nan")
             dates[cn] = dates[cn].astype(float)
 
         # Convert % to range 0->1:


### PR DESCRIPTION
/usr/local/lib/python3.9/site-packages/yfinance/base.py:2126: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise in a future error of pandas. Value 'NaN' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.

dates.loc[dates[cn] == '-', cn] = "NaN"