### PR TITLE
Add type info.

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -1988,42 +1988,42 @@ class TickerBase:
             return data.to_dict()
         return data
 
-    def get_earnings_estimate(self, proxy=None, as_dict=False):
+    def get_earnings_estimate(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.earnings_estimate
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_revenue_estimate(self, proxy=None, as_dict=False):
+    def get_revenue_estimate(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.revenue_estimate
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_earnings_history(self, proxy=None, as_dict=False):
+    def get_earnings_history(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.earnings_history
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_eps_trend(self, proxy=None, as_dict=False):
+    def get_eps_trend(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.eps_trend
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_eps_revisions(self, proxy=None, as_dict=False):
+    def get_eps_revisions(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.eps_revisions
         if as_dict:
             return data.to_dict()
         return data
 
-    def get_growth_estimates(self, proxy=None, as_dict=False):
+    def get_growth_estimates(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._analysis.proxy = proxy or self.proxy
         data = self._analysis.growth_estimates
         if as_dict:


### PR DESCRIPTION
Is this what people want.. r.e type info?

feature/growth-estimate removes some unimplemented fields from Analysis do we want to remove this stuff all the way up to the tests?, or is this info supposed to come from somewhere else and we should leave the hooks?

```
         self._earnings_trend = None
        self._analyst_trend_details = None
        self._analyst_price_target = None
        self._rev_est = None
        self._eps_est = None
```