### PR TITLE
Fix JSON error handling

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -45,6 +45,9 @@ from .scrapers.quote import Quote, FastInfo
 from .const import _BASE_URL_, _ROOT_URL_
 
 
+_empty_series = pd.Series()
+
+
 class TickerBase:
     def __init__(self, ticker, session=None, proxy=None):
         self.ticker = ticker.upper()
@@ -1960,7 +1963,7 @@ class TickerBase:
         if self._history is not None and "Capital Gains" in self._history:
             capital_gains = self._history["Capital Gains"]
             return capital_gains[capital_gains != 0]
-        return pd.Series()
+        return _empty_series
 
     def get_splits(self, proxy=None) -> pd.Series:
         if self._history is None:
@@ -1970,7 +1973,7 @@ class TickerBase:
             return splits[splits != 0]
         return pd.Series()
 
-    def get_actions(self, proxy=None) -> pd.DataFrame:
+    def get_actions(self, proxy=None) -> pd.Series:
         if self._history is None:
             self.history(period="max", proxy=proxy)
         if self._history is not None and "Dividends" in self._history and "Stock Splits" in self._history:
@@ -1979,7 +1982,7 @@ class TickerBase:
                 action_columns.append("Capital Gains")
             actions = self._history[action_columns]
             return actions[actions != 0].dropna(how='all').fillna(0)
-        return pd.DataFrame()
+        return _empty_series
 
     def get_shares(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._fundamentals.proxy = proxy or self.proxy


### PR DESCRIPTION
Fix to prevent KeyError on 'timeseries'. 

If requested symbol is incorrect/null, Yahoo Finance API returns this response : 
```
{'finance': {'result': None, 'error': {'code': 'Not Found', 'description': 'HTTP 404 Not Found'}}} 
```

Hence raising a KeyError exception instead of the YFinanceException one, with an explicit error message.

You can re-create the case this PR fixes by trying an incorrect ISIN code, e.g. ` yf.Ticker("FR0000000000").info `