### PR TITLE
Remove _empty_series leftovers

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -45,9 +45,6 @@ from .scrapers.quote import Quote, FastInfo
 from .const import _BASE_URL_, _ROOT_URL_, price_colnames
 
 
-_empty_series = pd.Series()
-
-
 class TickerBase:
     def __init__(self, ticker, session=None, proxy=None):
         self.ticker = ticker.upper()
@@ -1965,7 +1962,7 @@ class TickerBase:
         if self._history is not None and "Capital Gains" in self._history:
             capital_gains = self._history["Capital Gains"]
             return capital_gains[capital_gains != 0]
-        return _empty_series
+        return pd.Series()
 
     def get_splits(self, proxy=None) -> pd.Series:
         if self._history is None:
@@ -1984,7 +1981,7 @@ class TickerBase:
                 action_columns.append("Capital Gains")
             actions = self._history[action_columns]
             return actions[actions != 0].dropna(how='all').fillna(0)
-        return _empty_series
+        return pd.Series()
 
     def get_shares(self, proxy=None, as_dict=False) -> Union[pd.DataFrame, dict]:
         self._fundamentals.proxy = proxy or self.proxy


### PR DESCRIPTION
Removed leftovers of module-wide initialized `pd.Series()`, which makes it easier to disable `FutureWarning` logs in pandas versions lower than 2. May fixe #1836