### PR TITLE
Fix some errors.

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -852,6 +852,7 @@ class PriceHistory:
         if f_zeroes.any():
             df2_zeroes = df2[f_zeroes]
             df2 = df2[~f_zeroes]
+            df = df[~f_zeroes]  # all row slicing must be applied to both df and df2
         else:
             df2_zeroes = None
         if df2.shape[0] <= 1:
@@ -958,7 +959,7 @@ class PriceHistory:
             if "Repaired?" not in df2_zeroes.columns:
                 df2_zeroes["Repaired?"] = False
             df2 = pd.concat([df2, df2_zeroes]).sort_index()
-            df2.index = pd.to_datetime()
+            df2.index = pd.to_datetime(df2.index)
 
         return df2
 


### PR DESCRIPTION
Seems like some typos or part of the code never been hit before.

df and df2 must be same shape.

pd.to_datetime() had no argument?

```python
yf.Ticker('rshn').history(start='2000-01-01', end='2024-02-18', repair=True, auto_adjust=True, actions=True)


File ~/anaconda3/envs/3.11/lib/python3.11/site-packages/pandas/core/indexing.py:1414, in _LocIndexer._getitem_axis(self, key, axis)
   1412     return self._get_slice_axis(key, axis=axis)
   1413 elif com.is_bool_indexer(key):
-> 1414     return self._getbool_axis(key, axis=axis)
   1415 elif is_list_like_indexer(key):
   1416     # an iterable multi-selection
   1417     if not (isinstance(key, tuple) and isinstance(labels, MultiIndex)):

File ~/anaconda3/envs/3.11/lib/python3.11/site-packages/pandas/core/indexing.py:1210, in _LocationIndexer._getbool_axis(self, key, axis)
   1206 @final
   1207 def _getbool_axis(self, key, axis: AxisInt):
   1208     # caller is responsible for ensuring non-None axis
   1209     labels = self.obj._get_axis(axis)
-> 1210     key = check_bool_indexer(labels, key)
   1211     inds = key.nonzero()[0]
   1212     return self.obj._take_with_is_copy(inds, axis=axis)

File ~/anaconda3/envs/3.11/lib/python3.11/site-packages/pandas/core/indexing.py:2674, in check_bool_indexer(index, key)
   2670 elif not is_array_like(result):
   2671     # GH 33924
   2672     # key may contain nan elements, check_array_indexer needs bool array
   2673     result = pd_array(result, dtype=bool)
-> 2674 return check_array_indexer(index, result)

File ~/anaconda3/envs/3.11/lib/python3.11/site-packages/pandas/core/indexers/utils.py:539, in check_array_indexer(array, indexer)
    537     # GH26658
    538     if len(indexer) != len(array):
--> 539         raise IndexError(
    540             f"Boolean index has wrong length: "
    541             f"{len(indexer)} instead of {len(array)}"
    542         )
    543 elif is_integer_dtype(dtype):
    544     try:

IndexError: Boolean index has wrong length: 6069 instead of 6070
```