### PR TITLE
Deprecate 'pandas_datareader', remove a deprecated argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,23 +228,6 @@ yfinance?](https://stackoverflow.com/questions/63107801)
         -   How to download single or multiple tickers into a single
             dataframe with single level column names and a ticker column
 
-### `pandas_datareader` override
-
-If your code uses `pandas_datareader` and you want to download data
-faster, you can "hijack" `pandas_datareader.data.get_data_yahoo()`
-method to use **yfinance** while making sure the returned data is in the
-same format as **pandas\_datareader**'s `get_data_yahoo()`.
-
-```python
-from pandas_datareader import data as pdr
-
-import yfinance as yf
-yf.pdr_override() # <== that's all it takes :-)
-
-# download dataframe
-data = pdr.get_data_yahoo("SPY", start="2017-01-01", end="2017-04-30")
-```
-
 ### Persistent cache store
 
 To reduce Yahoo, yfinance store some data locally: timezones to localize dates, and cookie. Cache location is:

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -35,6 +35,8 @@ def pdr_override():
     make pandas datareader optional
     otherwise can be called via fix_yahoo_finance.download(...)
     """
+    from .utils import print_once
+    print_once("yfinance: pandas_datareader support is deprecated & semi-broken so will be removed in a future verison. Just use yfinance.")
     try:
         import pandas_datareader
         pandas_datareader.data.get_data_yahoo = download

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -36,7 +36,7 @@ from . import shared
 @utils.log_indent_decorator
 def download(tickers, start=None, end=None, actions=False, threads=True, ignore_tz=None,
              group_by='column', auto_adjust=False, back_adjust=False, repair=False, keepna=False,
-             progress=True, period="max", show_errors=None, interval="1d", prepost=False,
+             progress=True, period="max", interval="1d", prepost=False,
              proxy=None, rounding=False, timeout=10, session=None):
     """Download yahoo tickers
     :Parameters:
@@ -80,9 +80,6 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             Optional. Proxy server URL scheme. Default is None
         rounding: bool
             Optional. Round values to 2 decimal places?
-        show_errors: bool
-            Optional. Doesn't print errors if False
-            DEPRECATED, will be removed in future version
         timeout: None or float
             If not None stops waiting for a response after given number of
             seconds. (Can also be a fraction of a second e.g. 0.01)
@@ -90,14 +87,6 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             Optional. Pass your own session object to be used for all requests
     """
     logger = utils.get_yf_logger()
-
-    if show_errors is not None:
-        if show_errors:
-            utils.print_once(f"yfinance: download(show_errors={show_errors}) argument is deprecated and will be removed in future version. Do this instead: logging.getLogger('yfinance').setLevel(logging.ERROR)")
-            logger.setLevel(logging.ERROR)
-        else:
-            utils.print_once(f"yfinance: download(show_errors={show_errors}) argument is deprecated and will be removed in future version. Do this instead to suppress error messages: logging.getLogger('yfinance').setLevel(logging.CRITICAL)")
-            logger.setLevel(logging.CRITICAL)
 
     if logger.isEnabledFor(logging.DEBUG):
         if threads:


### PR DESCRIPTION
Drop official support for 'pandas_datareader', tag pdr_override() as deprecated. Implements #1192.

Also removed deprecated argument 'download(show_errors)'.
