### PR TITLE
Fix 404 Error for Holders

### DIFF
--- a/yfinance/scrapers/holders.py
+++ b/yfinance/scrapers/holders.py
@@ -73,8 +73,8 @@ class Holders:
     def _fetch(self, proxy):
         modules = ','.join(
             ["institutionOwnership", "fundOwnership", "majorDirectHolders", "majorHoldersBreakdown", "insiderTransactions", "insiderHolders", "netSharePurchaseActivity"])
-        params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "symbol": self._symbol, "formatted": "false"}
-        result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_, user_agent_headers=self._data.user_agent_headers, params=params_dict, proxy=proxy)
+        params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "formatted": "false"}
+        result = self._data.get_raw_json(f"{_QUOTE_SUMMARY_URL_}/{self._symbol}", user_agent_headers=self._data.user_agent_headers, params=params_dict, proxy=proxy)
         return result
 
     def _fetch_and_parse(self):


### PR DESCRIPTION
Fix for the issue #1904, the ticker symbol has been moved from the parameters to the end of the base URL.