### PR TITLE
Fix: datetime.datetime.utcnow() is deprecated ...

### DIFF
--- a/tests/prices.py
+++ b/tests/prices.py
@@ -62,7 +62,7 @@ class TestPriceHistory(unittest.TestCase):
             dat = yf.Ticker(tkr, session=self.session)
             tz = dat._get_ticker_tz(proxy=None, timeout=None)
 
-            dt_utc = _tz.timezone("UTC").localize(_dt.datetime.utcnow())
+            dt_utc = _pd.Timestamp.utcnow()
             dt = dt_utc.astimezone(_tz.timezone(tz))
             start_d = dt.date() - _dt.timedelta(days=7)
             df = dat.history(start=start_d, interval="1h")
@@ -82,7 +82,7 @@ class TestPriceHistory(unittest.TestCase):
             dat = yf.Ticker(tkr, session=self.session)
             tz = dat._get_ticker_tz(proxy=None, timeout=None)
 
-            dt_utc = _tz.timezone("UTC").localize(_dt.datetime.utcnow())
+            dt_utc = _pd.Timestamp.utcnow()
             dt = dt_utc.astimezone(_tz.timezone(tz))
             if dt.time() < _dt.time(17, 0):
                 continue

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -210,7 +210,7 @@ class PriceHistory:
             quotes = utils.parse_quotes(data["chart"]["result"][0])
             # Yahoo bug fix - it often appends latest price even if after end date
             if end and not quotes.empty:
-                endDt = pd.to_datetime(_datetime.datetime.utcfromtimestamp(end))
+                endDt = pd.to_datetime(end, unit='s')
                 if quotes.index[quotes.shape[0] - 1] >= endDt:
                     quotes = quotes.iloc[0:quotes.shape[0] - 1]
         except Exception:


### PR DESCRIPTION
I upgraded Python 3.11 -> 3.12 and get this new warning:

> DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

Simple to fix.