### PR TITLE
Deprecate Ticker.earnings

### DIFF
--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -29,21 +29,7 @@ from .cache import set_tz_cache_location
 __version__ = version.version
 __author__ = "Ran Aroussi"
 
+import warnings
+warnings.filterwarnings('default', category=DeprecationWarning, module='^yfinance')
 
-def pdr_override():
-    """
-    make pandas datareader optional
-    otherwise can be called via fix_yahoo_finance.download(...)
-    """
-    from .utils import print_once
-    print_once("yfinance: pandas_datareader support is deprecated & semi-broken so will be removed in a future verison. Just use yfinance.")
-    try:
-        import pandas_datareader
-        pandas_datareader.data.get_data_yahoo = download
-        pandas_datareader.data.get_data_yahoo_actions = download
-        pandas_datareader.data.DataReader = download
-    except Exception:
-        pass
-
-
-__all__ = ['download', 'Ticker', 'Tickers', 'pdr_override', 'enable_debug_mode', 'set_tz_cache_location']
+__all__ = ['download', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location']

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -230,7 +230,7 @@ class TickerBase:
 
     @property
     def basic_info(self):
-        warnings.warn("'Ticker.basic_info' is renamed to 'Ticker.fast_info', hopefully purpose is clearer", DeprecationWarning)
+        warnings.warn("'Ticker.basic_info' is deprecated and will be removed in future, Switch to 'Ticker.fast_info'", DeprecationWarning)
         return self.fast_info
 
     def get_sustainability(self, proxy=None, as_dict=False):

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -289,6 +289,8 @@ class TickerBase:
                 Default is None
         """
         self._fundamentals.proxy = proxy or self.proxy
+        if self._fundamentals.earnings is None:
+            return None
         data = self._fundamentals.earnings[freq]
         if as_dict:
             dict_data = data.to_dict()

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -1,14 +1,12 @@
 import datetime
 import json
+import warnings
 
 import pandas as pd
 
 from yfinance import utils, const
 from yfinance.data import YfData
 from yfinance.exceptions import YFException, YFNotImplementedError
-
-import warnings
-warnings.simplefilter('once', DeprecationWarning)
 
 class Fundamentals:
 
@@ -32,7 +30,7 @@ class Fundamentals:
 
     @property
     def earnings(self) -> dict:
-        utils.print_once("'Ticker.earnings' is deprecated as not available via API. Look for \"Net Income\" in Ticker.income_stmt.")
+        warnings.warn("'Ticker.earnings' is deprecated as not available via API. Look for \"Net Income\" in Ticker.income_stmt.", DeprecationWarning)
         return None
 
     @property

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -7,6 +7,8 @@ from yfinance import utils, const
 from yfinance.data import YfData
 from yfinance.exceptions import YFException, YFNotImplementedError
 
+import warnings
+warnings.simplefilter('once', DeprecationWarning)
 
 class Fundamentals:
 
@@ -30,9 +32,8 @@ class Fundamentals:
 
     @property
     def earnings(self) -> dict:
-        if self._earnings is None:
-            raise YFNotImplementedError('earnings')
-        return self._earnings
+        utils.print_once("'Ticker.earnings' is deprecated as not available via API. Look for \"Net Income\" in Ticker.income_stmt.")
+        return None
 
     @property
     def shares(self) -> pd.DataFrame:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -1,7 +1,5 @@
 import datetime
 import json
-import warnings
-from collections.abc import MutableMapping
 
 import numpy as _np
 import pandas as pd
@@ -23,57 +21,6 @@ info_retired_keys = info_retired_keys_price | info_retired_keys_exchange | info_
 
 
 _QUOTE_SUMMARY_URL_ = f"{_BASE_URL_}/v10/finance/quoteSummary"
-
-
-class InfoDictWrapper(MutableMapping):
-    """ Simple wrapper around info dict, intercepting 'gets' to
-    print how-to-migrate messages for specific keys. Requires
-    override dict API"""
-
-    def __init__(self, info):
-        self.info = info
-
-    def keys(self):
-        return self.info.keys()
-
-    def __str__(self):
-        return self.info.__str__()
-
-    def __repr__(self):
-        return self.info.__repr__()
-
-    def __contains__(self, k):
-        return k in self.info.keys()
-
-    def __getitem__(self, k):
-        if k in info_retired_keys_price:
-            warnings.warn(f"Price data removed from info (key='{k}'). Use Ticker.fast_info or history() instead", DeprecationWarning)
-            return None
-        elif k in info_retired_keys_exchange:
-            warnings.warn(f"Exchange data removed from info (key='{k}'). Use Ticker.fast_info or Ticker.get_history_metadata() instead", DeprecationWarning)
-            return None
-        elif k in info_retired_keys_marketCap:
-            warnings.warn(f"Market cap removed from info (key='{k}'). Use Ticker.fast_info instead", DeprecationWarning)
-            return None
-        elif k in info_retired_keys_symbol:
-            warnings.warn(f"Symbol removed from info (key='{k}'). You know this already", DeprecationWarning)
-            return None
-        return self.info[self._keytransform(k)]
-
-    def __setitem__(self, k, value):
-        self.info[self._keytransform(k)] = value
-
-    def __delitem__(self, k):
-        del self.info[self._keytransform(k)]
-
-    def __iter__(self):
-        return iter(self.info)
-
-    def __len__(self):
-        return len(self.info)
-
-    def _keytransform(self, k):
-        return k
 
 
 class FastInfo:


### PR DESCRIPTION
The earnings chart on Yahoo website not available directly via API, have to get from income statement. Resolve #1948 

Also remove some old deprecated code.