### PR TITLE
Fix error on empty options chain

### DIFF
--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -92,6 +92,11 @@ class Ticker(TickerBase):
             date = self._expirations[date]
             options = self._download_options(date)
 
+        if not options:
+            return _namedtuple('Options', ['calls', 'puts', 'underlying'])(**{
+                "calls": None, "puts": None, "underlying": None
+            })
+
         return _namedtuple('Options', ['calls', 'puts', 'underlying'])(**{
             "calls": self._options2df(options['calls'], tz=tz),
             "puts": self._options2df(options['puts'], tz=tz),


### PR DESCRIPTION
Fixes #1969 

Error occurs when Yahoo has no calls or puts for a ticker. I wasn't sure whether y'all would prefer an exception in this case instead (first pull request!), but I chose to return an "empty" Options namedtuple since _download_options() returns an empty dict.