### PR TITLE
Remove erroneous print statement

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -225,7 +225,6 @@ class PriceHistory:
                     quotes = quotes.iloc[0:quotes.shape[0] - 1]
         except Exception:
             shared._DFS[self.ticker] = utils.empty_df()
-            print(err_msg)
             shared._ERRORS[self.ticker] = err_msg.split(': ', 1)[1]
             if raise_errors:
                 raise _exception


### PR DESCRIPTION
Was debugging my code today and it appears that all of the `possibly delisted` errors were being printed twice, once from the logger and once from this print statement. You're already logging any errors, so this print statement doesn't need to be here.

Closes #1997 