### PR TITLE
Fix datetime conversion with mixed timezones when ignore_tz is False

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -1,13 +1,13 @@
-from .context import yfinance as yf
-from .context import session_gbl
-
+import datetime as _dt
+import os
 import unittest
 
-import os
-import datetime as _dt
-import pytz as _tz
 import numpy as _np
 import pandas as _pd
+import pytz as _tz
+
+from .context import session_gbl
+from .context import yfinance as yf
 
 
 class TestPriceHistory(unittest.TestCase):
@@ -32,17 +32,23 @@ class TestPriceHistory(unittest.TestCase):
                 f = df.index.time == _dt.time(0)
                 self.assertTrue(f.all())
 
-    def test_download(self):
+    def test_download_multi_large_interval(self):
         tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
         intervals = ["1d", "1wk", "1mo"]
         for interval in intervals:
-            df = yf.download(tkrs, period="5y", interval=interval)
+            with self.subTest(interval):
+                df = yf.download(tkrs, period="5y", interval=interval)
 
-            f = df.index.time == _dt.time(0)
-            self.assertTrue(f.all())
+                f = df.index.time == _dt.time(0)
+                self.assertTrue(f.all())
 
-            df_tkrs = df.columns.levels[1]
-            self.assertEqual(sorted(tkrs), sorted(df_tkrs))
+                df_tkrs = df.columns.levels[1]
+                self.assertEqual(sorted(tkrs), sorted(df_tkrs))
+
+    def test_download_multi_small_interval(self):
+        use_tkrs = ["AAPL", "0Q3.DE", "ATVI"]
+        df = yf.download(use_tkrs, period="1d", interval="5m")
+        self.assertEqual(df.index.tz, _dt.timezone.utc)
 
     def test_download_with_invalid_ticker(self):
         #Checks if using an invalid symbol gives the same output as not using an invalid symbol in combination with a valid symbol (AAPL)

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -211,7 +211,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
         _realign_dfs()
         data = _pd.concat(shared._DFS.values(), axis=1, sort=True,
                           keys=shared._DFS.keys(), names=['Ticker', 'Price'])
-    data.index = _pd.to_datetime(data.index)
+    data.index = _pd.to_datetime(data.index, utc=True)
     # switch names back to isins if applicable
     data.rename(columns=shared._ISINS, inplace=True)
 


### PR DESCRIPTION
When querying multi symbols at the same time, the Pandas Timestamp to datetime64 conversion will fail, when `utc=False`.
It looks like this is the most stable implementation, because Pandas suggests to use this feature in the future.
Downside: The original timezones are lost. But every datetime has now `tz=timezone.utc`
Upside: `ignore_tz` may be obsolete.

I added a test for testing Pandas datetime conversion as well.