### PR TITLE
Handle faulty response object when getting news.

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -512,11 +512,16 @@ class TickerBase:
         # Getting data from json
         url = f"{_BASE_URL_}/v1/finance/search?q={self.ticker}"
         data = self._data.cache_get(url=url, proxy=proxy)
-        if "Will be right back" in data.text:
+        if data is None or "Will be right back" in data.text:
             raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                "Our engineers are working quickly to resolve "
                                "the issue. Thank you for your patience.")
-        data = data.json()
+        try:
+            data = data.json()
+        except (_json.JSONDecodeError): 
+            logger = utils.get_yf_logger()
+            logger.error(f"{self.ticker}: Failed to retrieve the news and received faulty response instead.")
+            data = {}
 
         # parse news
         self._news = data.get("news", [])


### PR DESCRIPTION
- Fixes: https://github.com/ranaroussi/yfinance/issues/2015
  - The trace provided in the issue shows the exception occurs due to trying to parse faulty response object `JSONDecodeError: Expecting value: line 1 column 1 (char 0)`
  - try except catches the error and returns empty set instead of raising the exception. 
  - The error is logged and the API user sees empty list of news instead of the raised exception.
- Add check if returned value is None before accessing its text to avoid AttributeError