### PR TITLE
Implement Analysis (no scraping)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ msft.recommendations
 msft.recommendations_summary
 msft.upgrades_downgrades
 
+# show analysts data
+msft.analyst_price_targets
+msft.earnings_estimate
+msft.revenue_estimate
+msft.earnings_history
+msft.eps_trend
+msft.eps_revisions
+msft.growth_estimates
+
 # Show future and historic earnings dates, returns at most next 4 quarters and last 8 quarters by default.
 # Note: If more are needed use msft.get_earnings_dates(limit=XX) with increased limit argument.
 msft.earnings_dates

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -240,40 +240,67 @@ class TickerBase:
             return data.to_dict()
         return data
 
-    def get_analyst_price_target(self, proxy=None, as_dict=False):
+    def get_analyst_price_targets(self, proxy=None) -> dict:
+        """
+        Keys:   current  low  high  mean  median
+        """
         self._analysis.proxy = proxy or self.proxy
-        data = self._analysis.analyst_price_target
-        if as_dict:
-            return data.to_dict()
+        data = self._analysis.analyst_price_targets
         return data
 
-    def get_rev_forecast(self, proxy=None, as_dict=False):
+    def get_earnings_estimate(self, proxy=None, as_dict=False):
+        """
+        Index:      0q  +1q  0y  +1y
+        Columns:    numberOfAnalysts  avg  low  high  yearAgoEps  growth
+        """
         self._analysis.proxy = proxy or self.proxy
-        data = self._analysis.rev_est
-        if as_dict:
-            return data.to_dict()
-        return data
+        data = self._analysis.earnings_estimate
+        return data.to_dict() if as_dict else data
 
-    def get_earnings_forecast(self, proxy=None, as_dict=False):
+    def get_revenue_estimate(self, proxy=None, as_dict=False):
+        """
+        Index:      0q  +1q  0y  +1y
+        Columns:    numberOfAnalysts  avg  low  high  yearAgoRevenue  growth
+        """
         self._analysis.proxy = proxy or self.proxy
-        data = self._analysis.eps_est
-        if as_dict:
-            return data.to_dict()
-        return data
+        data = self._analysis.revenue_estimate
+        return data.to_dict() if as_dict else data
 
-    def get_trend_details(self, proxy=None, as_dict=False):
+    def get_earnings_history(self, proxy=None, as_dict=False):
+        """
+        Index:      pd.DatetimeIndex
+        Columns:    epsEstimate  epsActual  epsDifference  surprisePercent
+        """
         self._analysis.proxy = proxy or self.proxy
-        data = self._analysis.analyst_trend_details
-        if as_dict:
-            return data.to_dict()
-        return data
+        data = self._analysis.earnings_history
+        return data.to_dict() if as_dict else data
 
-    def get_earnings_trend(self, proxy=None, as_dict=False):
+    def get_eps_trend(self, proxy=None, as_dict=False):
+        """
+        Index:      0q  +1q  0y  +1y
+        Columns:    current  7daysAgo  30daysAgo  60daysAgo  90daysAgo
+        """
         self._analysis.proxy = proxy or self.proxy
-        data = self._analysis.earnings_trend
-        if as_dict:
-            return data.to_dict()
-        return data
+        data = self._analysis.eps_trend
+        return data.to_dict() if as_dict else data
+
+    def get_eps_revisions(self, proxy=None, as_dict=False):
+        """
+        Index:      0q  +1q  0y  +1y
+        Columns:    upLast7days  upLast30days  downLast7days  downLast30days
+        """
+        self._analysis.proxy = proxy or self.proxy
+        data = self._analysis.eps_revisions
+        return data.to_dict() if as_dict else data
+
+    def get_growth_estimates(self, proxy=None, as_dict=False):
+        """
+        Index:      0q  +1q  0y  +1y +5y -5y
+        Columns:    stock  industry  sector  index
+        """
+        self._analysis.proxy = proxy or self.proxy
+        data = self._analysis.growth_estimates
+        return data.to_dict() if as_dict else data
 
     def get_earnings(self, proxy=None, as_dict=False, freq="yearly"):
         """

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -1,7 +1,11 @@
 import pandas as pd
+import requests
 
+from yfinance import utils
 from yfinance.data import YfData
-from yfinance.exceptions import YFNotImplementedError
+from yfinance.const import quote_summary_valid_modules
+from yfinance.scrapers.quote import _QUOTE_SUMMARY_URL_
+from yfinance.exceptions import YFException
 
 
 class Analysis:
@@ -11,39 +15,250 @@ class Analysis:
         self._symbol = symbol
         self.proxy = proxy
 
+        # In quoteSummary the 'earningsTrend' module contains most of the data below.
+        # The format of data is not optimal so each function will process it's part of the data.
+        # This variable works as a cache.
         self._earnings_trend = None
-        self._analyst_trend_details = None
-        self._analyst_price_target = None
-        self._rev_est = None
-        self._eps_est = None
-        self._already_scraped = False
+
+        self._analyst_price_targets = None
+        self._earnings_estimate = None
+        self._revenue_estimate = None
+        self._earnings_history = None
+        self._eps_trend = None
+        self._eps_revisions = None
+        self._growth_estimates = None
 
     @property
-    def earnings_trend(self) -> pd.DataFrame:
+    def analyst_price_targets(self) -> dict:
+        if self._analyst_price_targets is not None:
+            return self._analyst_price_targets
+
+        try:
+            data = self._fetch(['financialData'])
+            data = data['quoteSummary']['result'][0]['financialData']
+        except:
+            self._analyst_price_targets = {}
+            return self._analyst_price_targets
+
+        keys = [
+            ('currentPrice', 'current'),
+            ('targetLowPrice', 'low'),
+            ('targetHighPrice', 'high'),
+            ('targetMeanPrice', 'mean'),
+            ('targetMedianPrice', 'median'),
+        ]
+
+        self._analyst_price_targets = {newKey: data.get(oldKey, None) for oldKey, newKey in keys}
+        return self._analyst_price_targets
+
+    @property
+    def earnings_estimate(self) -> pd.DataFrame:
+        if self._earnings_estimate is not None:
+            return self._earnings_estimate
+
         if self._earnings_trend is None:
-            raise YFNotImplementedError('earnings_trend')
-        return self._earnings_trend
+            self._fetch_earnings_trend()
+
+        data_dict = {
+            'numberOfAnalysts': [],
+            'avg': [],
+            'low': [],
+            'high': [],
+            'yearAgoEps': [],
+            'growth': []
+        }
+        periods = []
+
+        for item in self._earnings_trend[:4]:
+            periods.append(item['period'])
+            earnings_estimate = item.get('earningsEstimate', {})
+
+            for key in data_dict.keys():
+                data_dict[key].append(earnings_estimate.get(key, {}).get('raw', None))
+
+        self._earnings_estimate = pd.DataFrame(data_dict, index=periods)
+        return self._earnings_estimate
 
     @property
-    def analyst_trend_details(self) -> pd.DataFrame:
-        if self._analyst_trend_details is None:
-            raise YFNotImplementedError('analyst_trend_details')
-        return self._analyst_trend_details
+    def revenue_estimate(self) -> pd.DataFrame:
+        if self._revenue_estimate is not None:
+            return self._revenue_estimate
+
+        if self._earnings_trend is None:
+            self._fetch_earnings_trend()
+
+        data_dict = {
+            'numberOfAnalysts': [],
+            'avg': [],
+            'low': [],
+            'high': [],
+            'yearAgoRevenue': [],
+            'growth': []
+        }
+        periods = []
+
+        for item in self._earnings_trend[:4]:
+            periods.append(item['period'])
+            revenue_estimate = item.get('revenueEstimate', {})
+
+            for key in data_dict.keys():
+                data_dict[key].append(revenue_estimate.get(key, {}).get('raw', None))
+
+        self._revenue_estimate = pd.DataFrame(data_dict, index=periods)
+        return self._revenue_estimate
 
     @property
-    def analyst_price_target(self) -> pd.DataFrame:
-        if self._analyst_price_target is None:
-            raise YFNotImplementedError('analyst_price_target')
-        return self._analyst_price_target
+    def earnings_history(self) -> pd.DataFrame:
+        if self._earnings_history is not None:
+            return self._earnings_history
+
+        try:
+            data = self._fetch(['earningsHistory'])
+            data = data['quoteSummary']['result'][0]['earningsHistory']['history']
+        except:
+            self._earnings_history = pd.DataFrame()
+            return self._earnings_history
+
+        data_dict = {
+            'epsEstimate': [],
+            'epsActual': [],
+            'epsDifference': [],
+            'surprisePercent': []
+        }
+        quarters = []
+
+        for item in data:
+            quarters.append(item.get('quarter', {}).get('fmt', None))
+
+            for key in data_dict.keys():
+                data_dict[key].append(item.get(key, {}).get('raw', None))
+        
+        datetime_index = pd.to_datetime(quarters, format='%Y-%m-%d')
+        self._earnings_history = pd.DataFrame(data_dict, index=datetime_index)
+        return self._earnings_history
 
     @property
-    def rev_est(self) -> pd.DataFrame:
-        if self._rev_est is None:
-            raise YFNotImplementedError('rev_est')
-        return self._rev_est
+    def eps_trend(self) -> pd.DataFrame:
+        if self._eps_trend is not None:
+            return self._eps_trend
+
+        if self._earnings_trend is None:
+            self._fetch_earnings_trend()
+
+        data_dict = {
+            'current': [],
+            '7daysAgo': [],
+            '30daysAgo': [],
+            '60daysAgo': [],
+            '90daysAgo': []
+        }
+        periods = []
+
+        for item in self._earnings_trend[:4]:
+            periods.append(item['period'])
+            eps_trend = item.get('epsTrend', {})
+
+            for key in data_dict.keys():
+                data_dict[key].append(eps_trend.get(key, {}).get('raw', None))
+
+        self._eps_trend = pd.DataFrame(data_dict, index=periods)
+        return self._eps_trend
 
     @property
-    def eps_est(self) -> pd.DataFrame:
-        if self._eps_est is None:
-            raise YFNotImplementedError('eps_est')
-        return self._eps_est
+    def eps_revisions(self) -> pd.DataFrame:
+        if self._eps_revisions is not None:
+            return self._eps_revisions
+
+        if self._earnings_trend is None:
+            self._fetch_earnings_trend()
+
+        data_dict = {
+            'upLast7days': [],
+            'upLast30days': [],
+            'downLast7days': [],
+            'downLast30days': []
+        }
+        periods = []
+
+        for item in self._earnings_trend[:4]:
+            periods.append(item['period'])
+            eps_revisions = item.get('epsRevisions', {})
+
+            for key in data_dict.keys():
+                data_dict[key].append(eps_revisions.get(key, {}).get('raw', None))
+
+        self._eps_revisions = pd.DataFrame(data_dict, index=periods)
+        return self._eps_revisions
+
+    @property
+    def growth_estimates(self) -> pd.DataFrame:
+        if self._growth_estimates is not None:
+            return self._growth_estimates
+
+        if self._earnings_trend is None:
+            self._fetch_earnings_trend()
+
+        try:
+            trends = self._fetch(['industryTrend', 'sectorTrend', 'indexTrend'])
+            trends = trends['quoteSummary']['result'][0]
+        except:
+            self._growth_estimates = pd.DataFrame()
+            return self._growth_estimates
+
+        data_dict = {
+            '0q': [],
+            '+1q': [],
+            '0y': [],
+            '+1y': [],
+            '+5y': [],
+            '-5y': []
+        }
+
+        # make sure no column is empty
+        dummy_trend = [{'period': key, 'growth': None} for key in data_dict.keys()]
+        industry_trend = trends['industryTrend']['estimates'] or dummy_trend
+        sector_trend = trends['sectorTrend']['estimates'] or dummy_trend
+        index_trend = trends['indexTrend']['estimates'] or dummy_trend
+
+        for item in self._earnings_trend:
+            period = item['period']
+            data_dict[period].append(item.get('growth', {}).get('raw', None))
+
+        for item in industry_trend:
+            period = item['period']
+            data_dict[period].append(item.get('growth', None))
+
+        for item in sector_trend:
+            period = item['period']
+            data_dict[period].append(item.get('growth', None))
+
+        for item in index_trend:
+            period = item['period']
+            data_dict[period].append(item.get('growth', None))
+
+        cols = ['stock', 'industry', 'sector', 'index']
+        self._growth_estimates = pd.DataFrame(data_dict, index=cols).T
+        return self._growth_estimates
+
+    # modified version from quote.py
+    def _fetch(self, modules: list):
+        if not isinstance(modules, list):
+            raise YFException("Should provide a list of modules, see available modules using `valid_modules`")
+
+        modules = ','.join([m for m in modules if m in quote_summary_valid_modules])
+        if len(modules) == 0:
+            raise YFException("No valid modules provided, see available modules using `valid_modules`")
+        params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "formatted": "false", "symbol": self._symbol}
+        try:
+            result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_ + f"/{self._symbol}", user_agent_headers=self._data.user_agent_headers, params=params_dict, proxy=self.proxy)
+        except requests.exceptions.HTTPError as e:
+            utils.get_yf_logger().error(str(e))
+            return None
+        return result
+
+    def _fetch_earnings_trend(self) -> None:
+        try:
+            data = self._fetch(['earningsTrend'])
+            self._earnings_trend = data['quoteSummary']['result'][0]['earningsTrend']['trend']
+        except:
+            self._earnings_trend = []

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -36,7 +36,7 @@ class Analysis:
         try:
             data = self._fetch(['financialData'])
             data = data['quoteSummary']['result'][0]['financialData']
-        except:
+        except (TypeError, KeyError):
             self._analyst_price_targets = {}
             return self._analyst_price_targets
 
@@ -115,7 +115,7 @@ class Analysis:
         try:
             data = self._fetch(['earningsHistory'])
             data = data['quoteSummary']['result'][0]['earningsHistory']['history']
-        except:
+        except (TypeError, KeyError):
             self._earnings_history = pd.DataFrame()
             return self._earnings_history
 
@@ -201,7 +201,7 @@ class Analysis:
         try:
             trends = self._fetch(['industryTrend', 'sectorTrend', 'indexTrend'])
             trends = trends['quoteSummary']['result'][0]
-        except:
+        except (TypeError, KeyError):
             self._growth_estimates = pd.DataFrame()
             return self._growth_estimates
 
@@ -260,5 +260,5 @@ class Analysis:
         try:
             data = self._fetch(['earningsTrend'])
             self._earnings_trend = data['quoteSummary']['result'][0]['earningsTrend']['trend']
-        except:
+        except (TypeError, KeyError):
             self._earnings_trend = []

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -240,12 +240,32 @@ class Ticker(TickerBase):
         return self.quarterly_cash_flow
 
     @property
-    def analyst_price_target(self) -> _pd.DataFrame:
-        return self.get_analyst_price_target()
+    def analyst_price_targets(self) -> dict:
+        return self.get_analyst_price_targets()
 
     @property
-    def revenue_forecasts(self) -> _pd.DataFrame:
-        return self.get_rev_forecast()
+    def earnings_estimate(self) -> _pd.DataFrame:
+        return self.get_earnings_estimate()
+
+    @property
+    def revenue_estimate(self) -> _pd.DataFrame:
+        return self.get_revenue_estimate()
+
+    @property
+    def earnings_history(self) -> _pd.DataFrame:
+        return self.get_earnings_history()
+
+    @property
+    def eps_trend(self) -> _pd.DataFrame:
+        return self.get_eps_trend()
+
+    @property
+    def eps_revisions(self) -> _pd.DataFrame:
+        return self.get_eps_revisions()
+
+    @property
+    def growth_estimates(self) -> _pd.DataFrame:
+        return self.get_growth_estimates()
 
     @property
     def sustainability(self) -> _pd.DataFrame:
@@ -262,20 +282,8 @@ class Ticker(TickerBase):
         return self.get_news()
 
     @property
-    def trend_details(self) -> _pd.DataFrame:
-        return self.get_trend_details()
-
-    @property
-    def earnings_trend(self) -> _pd.DataFrame:
-        return self.get_earnings_trend()
-
-    @property
     def earnings_dates(self) -> _pd.DataFrame:
         return self.get_earnings_dates()
-
-    @property
-    def earnings_forecasts(self) -> _pd.DataFrame:
-        return self.get_earnings_forecast()
 
     @property
     def history_metadata(self) -> dict:


### PR DESCRIPTION
I implemented most of the analysis page (https://finance.yahoo.com/quote/AAPL/analysis/). As the URL suggests, analysis is just a part of the `quoteSummary` API endpoint, which means all the data can be fetched from there. I saw some attempts at scraping the data (#1668 #1778), but that can be  inefficient and slower.


## Preview

I was trying to follow the table layouts on the website. So far the outputs look like this (for AAPL):

### Analyst Price Targets
```
{'current': 216.24, 'low': 183.86, 'high': 300.0, 'mean': 235.47, 'median': 240.0}
```

### Earnings Estimate
```
      numberOfAnalysts   avg   low  high  yearAgoEps  growth
0q                 25  1.59  1.53  1.63        1.36   0.169
+1q                20  2.40  2.21  2.61        2.04   0.176
0y                 36  6.70  6.64  6.75        5.73   0.169
+1y                37  7.49  6.88  8.00        6.70   0.118
```

### Revenue Estimate
```
      numberOfAnalysts           avg           low          high  yearAgoRevenue  growth
0q                 23   94242200000   93653000000   95311000000     83600100000   0.127
+1q                19  128626000000  123883000000  136387000000    111695000000   0.152
0y                 34  390237000000  389030000000  391416000000    358027000000   0.090
+1y                34  421632000000  401691000000  441882000000    390237000000   0.080
```

### Earnings History
```
             epsEstimate  epsActual  epsDifference  surprisePercent
2023-09-30         1.30       1.36           0.06            0.046
2023-12-31         1.96       2.04           0.08            0.041
2024-03-31         1.50       1.53           0.03            0.020
2024-06-30         1.35       1.40           0.05            0.037
```

### EPS Trend
```
      current  7daysAgo  30daysAgo  60daysAgo  90daysAgo
0q      1.59      1.59       1.42       1.43       1.53
+1q     2.40      2.39       2.16       2.15       2.30
0y      6.70      6.68       6.07       6.13       6.59
+1y     7.49      7.43       6.72       6.74       7.23
```

### EPS Revisions
```
      upLast7days  upLast30days downLast7days  downLast30days
0q             0            16          None               0
+1q            6             8          None               7
0y             1            32          None               0
+1y            2            29          None               0
```

### Growth Estimates
```
        stock  industry  sector     index
0q   0.16900       NaN     NaN  0.080000
+1q  0.17600       NaN     NaN  0.126000
0y   0.16900       NaN     NaN  0.045000
+1y  0.11800       NaN     NaN  0.126000
+5y  0.11100       NaN     NaN  0.116768
-5y  0.20446       NaN     NaN       NaN
```

## Related to:
- PRs: 
  - #1668
  - #1778
  - #1828
- Issues: 
  - #575
  - #1280
  - #1968
  - #722
  - #1856
  - #678