### PR TITLE
Solves #2026 

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -227,7 +227,9 @@ class PriceHistory:
         # 2) fix weired bug with Yahoo! - returning 60m for 30m bars
         if interval.lower() == "30m":
             logger.debug(f'{self.ticker}: resampling 30m OHLC from 15m')
-            quotes2 = quotes.resample('30min')
+            exchangeStartTime = pd.Timestamp(self._history_metadata["tradingPeriods"][0][0]["start"], unit='s')
+            offset = str(exchangeStartTime.minute % 30)+"min"
+            quotes2 = quotes.resample('30min', offset=offset)
             quotes = pd.DataFrame(index=quotes2.last().index, data={
                 'Open': quotes2['Open'].first(),
                 'High': quotes2['High'].max(),


### PR DESCRIPTION
# Solves #2026 to fix interval offset of the indian stock exchange

Solution that checks the offset of the opening time of the stock exchange (mod 30 minutes) and adds it to the quotes

That issue addresses  #1436 and #1447.

-----------

### Solution

The only change lies in `yfinance/scrapers/history.py`. 

If ìnterval='30m'`, we find the time that the stock exchange opens. If it opens at a time `t.minutes % 30 != 0` we add that offset to the quote.