### PR TITLE
implement support for funds data

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,31 @@ opt = msft.option_chain('YYYY-MM-DD')
 # data available via: opt.calls, opt.puts
 ```
 
+For tickers that are ETFs/Mutual Funds, `Ticker.funds_data` provides access to fund related data. 
+
+Funds' Top Holdings and other data with category average is returned as `pd.DataFrame`.
+
+```python
+import yfinance as yf
+spy = yf.Ticker('SPY')
+data = spy.funds_data
+
+# show fund description
+data.description
+
+# show operational information
+data.fund_overview
+data.fund_operations
+
+# show holdings related information
+data.asset_classes
+data.top_holdings
+data.equity_holdings
+data.bond_holdings
+data.bond_ratings
+data.sector_weightings
+```
+
 If you want to use a proxy server for downloading data, use:
 
 ```python

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -38,6 +38,7 @@ from .scrapers.fundamentals import Fundamentals
 from .scrapers.holders import Holders
 from .scrapers.quote import Quote, FastInfo
 from .scrapers.history import PriceHistory
+from .scrapers.funds import FundsData
 
 from .const import _BASE_URL_, _ROOT_URL_
 
@@ -70,6 +71,7 @@ class TickerBase:
         self._holders = Holders(self._data, self.ticker)
         self._quote = Quote(self._data, self.ticker)
         self._fundamentals = Fundamentals(self._data, self.ticker)
+        self._funds_data = None
 
         self._fast_info = None
 
@@ -647,3 +649,9 @@ class TickerBase:
 
     def get_history_metadata(self, proxy=None) -> dict:
         return self._lazy_load_price_history().get_history_metadata(proxy)
+
+    def get_funds_data(self, proxy=None) -> Optional[FundsData]:
+        if not self._funds_data:
+            self._funds_data = FundsData(self._data, self.ticker)
+        
+        return self._funds_data

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -1,0 +1,231 @@
+import pandas as pd
+
+from yfinance.data import YfData
+from yfinance.const import _BASE_URL_
+from yfinance.exceptions import YFDataException
+from yfinance import utils
+
+from typing import Dict, Optional
+
+_QUOTE_SUMMARY_URL_ = f"{_BASE_URL_}/v10/finance/quoteSummary/"
+
+'''
+Supports ETF and Mutual Funds Data
+Queried Modules: quoteType, summaryProfile, fundProfile, topHoldings
+
+Notes: 
+- fundPerformance module is not implemented as better data is queriable using history
+'''
+class FundsData:
+    def __init__(self, data: YfData, symbol: str, proxy=None):
+        self._data = data
+        self._symbol = symbol
+        self.proxy = proxy
+        
+        # quoteType
+        self._quote_type = None
+
+        # summaryProfile
+        self._description = None
+
+        # fundProfile
+        self._fund_overview = None
+        self._fund_operations = None
+
+        # topHoldings
+        self._asset_classes = None
+        self._top_holdings = None
+        self._equity_holdings = None
+        self._bond_holdings = None
+        self._bond_ratings = None
+        self._sector_weightings = None
+
+    def quote_type(self) -> str:
+        if self._quote_type is None:
+            self._fetch_and_parse()
+        return self._quote_type
+    
+    @property
+    def description(self) -> str:
+        if self._description is None:
+            self._fetch_and_parse()
+        return self._description
+    
+    @property
+    def fund_overview(self) -> Dict[str, Optional[str]]:
+        if self._fund_overview is None:
+            self._fetch_and_parse()
+        return self._fund_overview
+
+    @property
+    def fund_operations(self) -> pd.DataFrame:
+        if self._fund_operations is None:
+            self._fetch_and_parse()
+        return self._fund_operations
+
+    @property
+    def asset_classes(self) -> Dict[str, float]:
+        if self._asset_classes is None:
+            self._fetch_and_parse()
+        return self._asset_classes
+
+    @property
+    def top_holdings(self) -> pd.DataFrame:
+        if self._top_holdings is None:
+            self._fetch_and_parse()
+        return self._top_holdings
+
+    @property
+    def equity_holdings(self) -> pd.DataFrame:
+        if self._equity_holdings is None:
+            self._fetch_and_parse()
+        return self._equity_holdings
+
+    @property
+    def bond_holdings(self) -> pd.DataFrame:
+        if self._bond_holdings is None:
+            self._fetch_and_parse()
+        return self._bond_holdings
+
+    @property
+    def bond_ratings(self) -> Dict[str, float]:
+        if self._bond_ratings is None:
+            self._fetch_and_parse()
+        return self._bond_ratings
+
+    @property
+    def sector_weightings(self) -> Dict[str,float]:
+        if self._sector_weightings is None:
+            self._fetch_and_parse()
+        return self._sector_weightings
+
+    def _fetch(self, proxy):
+        modules = ','.join(["quoteType", "summaryProfile", "topHoldings", "fundProfile"])
+        params_dict = {"modules": modules, "corsDomain": "finance.yahoo.com", "symbol": self._symbol, "formatted": "false"}
+        result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_+self._symbol, user_agent_headers=self._data.user_agent_headers, params=params_dict, proxy=proxy)
+        return result
+
+    def _fetch_and_parse(self) -> None:
+        result = self._fetch(self.proxy)
+        try:
+            data = result["quoteSummary"]["result"][0]
+            # check quote type
+            self._quote_type = data["quoteType"]["quoteType"]
+            
+            # parse "summaryProfile", "topHoldings", "fundProfile"
+            self._parse_description(data["summaryProfile"])
+            self._parse_top_holdings(data["topHoldings"])
+            self._parse_fund_profile(data["fundProfile"])
+        except KeyError:
+            raise YFDataException("No Fund data found.")
+        except Exception as e:
+            logger = utils.get_yf_logger()
+            logger.error(f"Failed to get fund data for '{self._symbol}' reason: {e}")
+            logger.debug("Got response: ")
+            logger.debug("-------------")
+            logger.debug(f" {data}")
+            logger.debug("-------------")
+
+    @staticmethod
+    def _parse_raw_values(data, default=None):
+        if not isinstance(data, dict):
+            return data
+        
+        return data.get("raw", default)
+
+    def _parse_description(self, data) -> None:
+        self._description = data.get("longBusinessSummary", "")
+
+    def _parse_top_holdings(self, data) -> None:  # done
+        # asset classes
+        self._asset_classes = {
+            "cashPosition": self._parse_raw_values(data.get("cashPosition", None)),
+            "stockPosition": self._parse_raw_values(data.get("stockPosition", None)),
+            "bondPosition": self._parse_raw_values(data.get("bondPosition", None)),
+            "preferredPosition": self._parse_raw_values(data.get("preferredPosition", None)),
+            "convertiblePosition": self._parse_raw_values(data.get("convertiblePosition", None)),
+            "otherPosition": self._parse_raw_values(data.get("otherPosition", None))
+        }
+
+        # top holdings
+        _holdings = data.get("holdings", [])
+        _symbol, _name, _holding_percent = [], [], []
+
+        for item in _holdings:
+            _symbol.append(item["symbol"])
+            _name.append(item["holdingName"])
+            _holding_percent.append(item["holdingPercent"])
+        
+        self._top_holdings = pd.DataFrame({
+            "Symbol": _symbol,
+            "Name": _name,
+            "Holding Percent": _holding_percent
+        }).set_index("Symbol")
+
+        # equity holdings
+        _equity_holdings = data.get("equityHoldings", {})
+        self._equity_holdings = pd.DataFrame({
+            "Average": ["Price/Earnings", "Price/Book", "Price/Sales", "Price/Cashflow", "Median Market Cap", "3 Year Earnings Growth"],
+            self._symbol: [
+                self._parse_raw_values(_equity_holdings.get("priceToEarnings", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToBook", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToSales", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToCashflow", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("medianMarketCap", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("threeYearEarningsGrowth", pd.NA)),
+            ],
+            "Category Average": [
+                self._parse_raw_values(_equity_holdings.get("priceToEarningsCat", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToBookCat", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToSalesCat", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("priceToCashflowCat", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("medianMarketCapCat", pd.NA)),
+                self._parse_raw_values(_equity_holdings.get("threeYearEarningsGrowthCat", pd.NA)),
+            ]
+        }).set_index("Average")
+        
+        # bond holdings
+        _bond_holdings = data.get("bondHoldings", {})
+        self._bond_holdings = pd.DataFrame({
+            "Average": ["Duration", "Maturity", "Credit Quality"],
+            self._symbol: [
+                self._parse_raw_values(_bond_holdings.get("duration", pd.NA)),
+                self._parse_raw_values(_bond_holdings.get("maturity", pd.NA)),
+                self._parse_raw_values(_bond_holdings.get("creditQuality", pd.NA)),
+            ],
+            "Category Average": [
+                self._parse_raw_values(_bond_holdings.get("durationCat", pd.NA)),
+                self._parse_raw_values(_bond_holdings.get("maturityCat", pd.NA)),
+                self._parse_raw_values(_bond_holdings.get("creditQualityCat", pd.NA)),
+            ]
+        }).set_index("Average")
+
+        # bond ratings
+        self._bond_ratings = dict((key, d[key]) for d in data.get("bondRatings", []) for key in d)
+
+        # sector weightings
+        self._sector_weightings = dict((key, d[key]) for d in data.get("sectorWeightings", []) for key in d)
+        
+    def _parse_fund_profile(self, data):
+        self._fund_overview = {
+            "categoryName": data.get("categoryName", None), 
+            "family":       data.get("family", None), 
+            "legalType":    data.get("legalType", None)
+        }
+        
+        _fund_operations = data.get("feesExpensesInvestment", {})
+        _fund_operations_cat = data.get("feesExpensesInvestmentCat", {})
+
+        self._fund_operations = pd.DataFrame({
+            "Attributes": ["Annual Report Expense Ratio", "Annual Holdings Turnover", "Total Net Assets"],
+            self._symbol: [
+                self._parse_raw_values(_fund_operations.get("annualReportExpenseRatio", pd.NA)),
+                self._parse_raw_values(_fund_operations.get("annualHoldingsTurnover", pd.NA)),
+                self._parse_raw_values(_fund_operations.get("totalNetAssets", pd.NA))
+            ],
+            "Category Average": [
+                self._parse_raw_values(_fund_operations_cat.get("annualReportExpenseRatio", pd.NA)),
+                self._parse_raw_values(_fund_operations_cat.get("annualHoldingsTurnover", pd.NA)),
+                self._parse_raw_values(_fund_operations_cat.get("totalNetAssets", pd.NA))
+            ]
+        }).set_index("Attributes")

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -22,6 +22,7 @@
 from __future__ import print_function
 
 from collections import namedtuple as _namedtuple
+from .scrapers.funds import FundsData
 
 import pandas as _pd
 
@@ -297,3 +298,7 @@ class Ticker(TickerBase):
     @property
     def history_metadata(self) -> dict:
         return self.get_history_metadata()
+
+    @property
+    def funds_data(self) -> FundsData:
+        return self.get_funds_data()


### PR DESCRIPTION
Changes:
- adding to scraper a new class `FundsData`.
- Ticker can now reference the data via `ticker.funds_data` when appropriate. When the ticker symbol is not that of a fund's, the code will throw an error when a parameter of `funds_data` is called. i.e. `yf.Ticker('AAPL').funds_data.description`
- Add unit tests in `test_ticker.py` for the funds data
- minor change to `test_ticker.py` as `YFChartError` was removed from code in https://github.com/ranaroussi/yfinance/pull/2000

Resolves:
- https://github.com/ranaroussi/yfinance/issues/244
- https://github.com/ranaroussi/yfinance/issues/422
- https://github.com/ranaroussi/yfinance/issues/684
- https://github.com/ranaroussi/yfinance/discussions/1761
- https://github.com/ranaroussi/yfinance/discussions/2012

Sample Code:
``` python
import yfinance as yf
spy_ticker = yf.Ticker('SPY')
spy_funds_data = spy_ticker.funds_data

spy_funds_data.description
spy_funds_data.fund_overview
spy_funds_data.fund_operations
spy_funds_data.asset_classes
spy_funds_data.top_holdings
spy_funds_data.equity_holdings
spy_funds_data.bond_holdings
spy_funds_data.bond_ratings
spy_funds_data.sector_weightings
```

Credits to https://github.com/ranaroussi/yfinance/pull/1784 for the idea