### PR TITLE
fix keyerror with single element list passed to Tickers

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -200,10 +200,6 @@ def download(tickers, start=None, end=None, actions=False, threads=True, ignore_
             if (shared._DFS[tkr] is not None) and (shared._DFS[tkr].shape[0] > 0):
                 shared._DFS[tkr].index = shared._DFS[tkr].index.tz_localize(None)
 
-    if len(tickers) == 1:
-        ticker = tickers[0]
-        return shared._DFS[ticker]
-
     try:
         data = _pd.concat(shared._DFS.values(), axis=1, sort=True,
                           keys=shared._DFS.keys(), names=['Ticker', 'Price'])


### PR DESCRIPTION
Remade this to fix issue #899 

From previous PR,

> I don't see any good reason to treat single element symbol lists passed to yfinance.Tickers as something special, instead perform the pandas.concat like you would normally (with multiple tickers).

Avoids a KeyError raised here,
https://github.com/ranaroussi/yfinance/blob/9e2252e4516304efbd52d05ad66a5beb9a900e5e/yfinance/tickers.py#L83