### PR TITLE
Fixed f-string syntax in screener.py to avoid unmatched parenthesis

### DIFF
--- a/yfinance/screener/screener.py
+++ b/yfinance/screener/screener.py
@@ -98,7 +98,7 @@ class Screener:
             self._response = response['finance']['result'][0]
         except Exception as e:
             logger = utils.get_yf_logger()
-            logger.error(f"Failed to get screener data for '{self._body.get('query', "query not set")}' reason: {e}")
+            logger.error(f"Failed to get screener data for '{self._body.get('query', 'query not set')}' reason: {e}")
             logger.debug("Got response: ")
             logger.debug("-------------")
             logger.debug(f" {response}")


### PR DESCRIPTION
This pull request fixes an unmatched parenthesis in the f-string in the screener.py file. The current implementation causes a syntax error due to the improper nesting of single and double quotes. This fix ensures that the quotes are properly handled within the f-string.