### PR TITLE
Fix syntax error in logger error message in _fetch_and_parse method

### DIFF
--- a/yfinance/screener/screener.py
+++ b/yfinance/screener/screener.py
@@ -98,7 +98,7 @@ class Screener:
             self._response = response['finance']['result'][0]
         except Exception as e:
             logger = utils.get_yf_logger()
-            logger.error(f"Failed to get screener data for '{self._body.get('query', "query not set")}' reason: {e}")
+            logger.error(f"Failed to get screener data for '{self._body.get('query', 'query not set')}' reason: {e}")
             logger.debug("Got response: ")
             logger.debug("-------------")
             logger.debug(f" {response}")


### PR DESCRIPTION
Fixed a syntax error in the `_fetch_and_parse` method. The logger.error call had mixed single and double quotes, which caused a syntax issue.

Updated the line to:
```python
logger.error(f"Failed to get screener data for '{self._body.get('query', 'query not set')}' reason: {e}")
