### PR TITLE
fixed a bug throwing an error when trying to get a ticker from certain isin

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -199,7 +199,7 @@ def get_all_by_isin(isin, proxy=None, session=None):
             'ticker': {
                 'symbol': ticker['symbol'],
                 'shortname': ticker['shortname'],
-                'longname': ticker['longname'],
+                'longname': ticker.get('longname',''),
                 'type': ticker['quoteType'],
                 'exchange': ticker['exchDisp'],
             },


### PR DESCRIPTION
When making a request to "{_BASE_URL_}/v1/finance/search?q={isin}", the response doesn't always has a 'longname' field and this throws an error.
Example with this isin : IE00BDBRDM35