### PR TITLE
Fix growth_estimates for new key `LTG`

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -838,7 +838,7 @@ class TestTickerAnalysts(unittest.TestCase):
         columns = ['stock', 'industry', 'sector', 'index']
         self.assertEqual(data.columns.values.tolist(), columns, "data has wrong column names")
 
-        index = ['0q', '+1q', '0y', '+1y', '+5y', '-5y']
+        index = ['0q', '+1q', '0y', '+1y']
         self.assertEqual(data.index.values.tolist(), index, "data has wrong row names")
 
         data_cached = self.ticker.growth_estimates

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -205,13 +205,18 @@ class Analysis:
             self._growth_estimates = pd.DataFrame()
             return self._growth_estimates
 
+        # LTG is not defined in yahoo finance front-end as at 2024-11-14.
+        # But its addition is breaking the retrieval of growth estimates.
+        # Also, support for 5 year seem to have dropped.
+        # TODO: Revisit this change and consider permanently removing these keys.
         data_dict = {
             '0q': [],
             '+1q': [],
             '0y': [],
             '+1y': [],
-            '+5y': [],
-            '-5y': []
+            # 'LTG': [],
+            # '+5y': [],
+            # '-5y': []
         }
 
         # make sure no column is empty
@@ -222,19 +227,23 @@ class Analysis:
 
         for item in self._earnings_trend:
             period = item['period']
-            data_dict[period].append(item.get('growth', {}).get('raw', None))
+            if period in data_dict:
+                data_dict[period].append(item.get('growth', {}).get('raw', None))
 
         for item in industry_trend:
             period = item['period']
-            data_dict[period].append(item.get('growth', None))
+            if period in data_dict:
+                data_dict[period].append(item.get('growth', None))
 
         for item in sector_trend:
             period = item['period']
-            data_dict[period].append(item.get('growth', None))
+            if period in data_dict:
+                data_dict[period].append(item.get('growth', None))
 
         for item in index_trend:
             period = item['period']
-            data_dict[period].append(item.get('growth', None))
+            if period in data_dict:
+                data_dict[period].append(item.get('growth', None))
 
         cols = ['stock', 'industry', 'sector', 'index']
         self._growth_estimates = pd.DataFrame(data_dict, index=cols).T


### PR DESCRIPTION
Summary
- LTG (long-term growth ?) is new to the API but its meaning is not shown on yahoo yet.
- Support for 5 year numbers seem to have been removed. so commenting it out.
- Fixes: https://github.com/ranaroussi/yfinance/issues/2126

Examples: LTG row and 5 year numbers are not shown in the links below.
- https://finance.yahoo.com/quote/MSFT/analysis/
- https://finance.yahoo.com/quote/AAPL/analysis/
- https://finance.yahoo.com/quote/TSLA/analysis/

Sample:
import yfinance as yahooFinance

```Python
msft = yahooFinance.Ticker("MSFT")
print(msft.growth_estimates) # now works
```