### PR TITLE
Add cookies as a workaround to fix earnings dates

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -557,7 +557,7 @@ class TickerBase:
         return self._news
 
     @utils.log_indent_decorator
-    def get_earnings_dates(self, limit=12, proxy=None) -> Optional[pd.DataFrame]:
+    def get_earnings_dates(self, limit=12, proxy=None, add_cookies=None) -> Optional[pd.DataFrame]:
         """
         Get earning dates (future and historic)
         
@@ -566,6 +566,7 @@ class TickerBase:
                 Default value 12 should return next 4 quarters and last 8 quarters.
                 Increase if more history is needed.
             proxy: requests proxy to use.
+            add_cookies: additional cookies to use
         
         Returns:
             pd.DataFrame
@@ -580,7 +581,7 @@ class TickerBase:
         dates = None
         while True:
             url = f"{_ROOT_URL_}/calendar/earnings?symbol={self.ticker}&offset={page_offset}&size={page_size}"
-            data = self._data.cache_get(url=url, proxy=proxy).text
+            data = self._data.cache_get(url=url, proxy=proxy, add_cookies=add_cookies).text
 
             if "Will be right back" in data:
                 raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -329,15 +329,15 @@ class YfData(metaclass=SingletonMeta):
         return cookie, crumb, strategy
 
     @utils.log_indent_decorator
-    def get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30):
-        return self._make_request(url, request_method = self._session.get, user_agent_headers=user_agent_headers, params=params, proxy=proxy, timeout=timeout)
+    def get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30, add_cookies=None):
+        return self._make_request(url, request_method = self._session.get, user_agent_headers=user_agent_headers, params=params, proxy=proxy, timeout=timeout, add_cookies=add_cookies)
     
     @utils.log_indent_decorator
     def post(self, url, body, user_agent_headers=None, params=None, proxy=None, timeout=30):
         return self._make_request(url, request_method = self._session.post, user_agent_headers=user_agent_headers, body=body, params=params, proxy=proxy, timeout=timeout)
     
     @utils.log_indent_decorator
-    def _make_request(self, url, request_method, user_agent_headers=None, body=None, params=None, proxy=None, timeout=30):
+    def _make_request(self, url, request_method, user_agent_headers=None, body=None, params=None, proxy=None, timeout=30, add_cookies=None):
         # Important: treat input arguments as immutable.
 
         if len(url) > 200:
@@ -362,6 +362,10 @@ class YfData(metaclass=SingletonMeta):
             cookies = {cookie.name: cookie.value}
         else:
             cookies = None
+        if cookies is None:
+            cookies = add_cookies
+        elif add_cookies is not None:
+            cookies.update(add_cookies)
 
         request_args = {
             'url': url,
@@ -394,8 +398,8 @@ class YfData(metaclass=SingletonMeta):
 
     @lru_cache_freezeargs
     @lru_cache(maxsize=cache_maxsize)
-    def cache_get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30):
-        return self.get(url, user_agent_headers, params, proxy, timeout)
+    def cache_get(self, url, user_agent_headers=None, params=None, proxy=None, timeout=30, add_cookies=None):
+        return self.get(url, user_agent_headers, params, proxy, timeout, add_cookies)
 
     def _get_proxy(self, proxy):
         # setup proxy in requests format


### PR DESCRIPTION
As discussed in #1932 , it seems we need to login to apply the filter, so the idea is to add additional cookies to the API. Usage:
```
yf.Ticker(symbol).get_earnings_dates(add_cookies={
        'T': Your_cookies1,
        'Y': Your_cookies2})
```
I tested that if we supply `T` and `Y` cookies to the `requests.get`, we can successfully get the desired response.

I asked ChatGPT to see how to get my cookies manually: https://chatgpt.com/share/67453e22-bba0-8013-9d97-b8d320b7e24f in Chrome.