### PR TITLE
Raise Exception if Rate Limited

### DIFF
--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -10,6 +10,8 @@ from frozendict import frozendict
 from . import utils, cache
 import threading
 
+from .exceptions import YFRateLimitError
+
 cache_maxsize = 64
 
 
@@ -389,6 +391,10 @@ class YfData(metaclass=SingletonMeta):
                 request_args['cookies'] = {cookie.name: cookie.value}
             response = request_method(**request_args)
             utils.get_yf_logger().debug(f'response code={response.status_code}')
+
+            # Raise exception if rate limited
+            if response.status_code == 429:
+                raise YFRateLimitError()
 
         return response
 

--- a/yfinance/exceptions.py
+++ b/yfinance/exceptions.py
@@ -45,3 +45,8 @@ class YFInvalidPeriodError(YFException):
         self.invalid_period = invalid_period
         self.valid_ranges = valid_ranges
         super().__init__(f"{self.ticker}: Period '{invalid_period}' is invalid, must be one of {valid_ranges}")
+
+
+class YFRateLimitError(YFException):
+    def __init__(self):
+        super().__init__("Too Many Requests. Rate limited. Try after a while.")

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -9,7 +9,7 @@ import bisect
 
 from yfinance import shared, utils
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_
-from yfinance.exceptions import YFInvalidPeriodError, YFPricesMissingError, YFTzMissingError
+from yfinance.exceptions import YFInvalidPeriodError, YFPricesMissingError, YFTzMissingError, YFRateLimitError
 
 class PriceHistory:
     def __init__(self, data, ticker, tz, session=None, proxy=None):
@@ -184,6 +184,9 @@ class PriceHistory:
                                    "the issue. Thank you for your patience.")
 
             data = data.json()
+        # Special case for rate limits
+        except YFRateLimitError:
+            raise
         except Exception:
             if raise_errors:
                 raise


### PR DESCRIPTION
### Changes
- New `YfRateLimitError` exception class, which is raised regardless of `raise_errors`
- Raises the above exception if the response from Yahoo! Finance returns `429` status code.

### Usage
Tricky. Can test it with any `yfinance` function. Would need to spam Yahoo! Finance until you get rate limited. But here is an example of how it looks:

![image](https://github.com/user-attachments/assets/83af8ae5-c12b-4adb-b732-fec595aa03b4)