### PR TITLE
Fix: Earnings Date

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -339,6 +339,12 @@ class TestTickerEarnings(unittest.TestCase):
     #     data_cached = self.ticker.earnings_trend
     #     self.assertIs(data, data_cached, "data not cached")
 
+    def test_parse_earnings_dates(self):
+        dates = pd.Series(['October 26, 2025 at 8 PM EDT', 'July 27, 2025 at 8 PM EST'])
+        expected = pd.Series(pd.to_datetime(['2025-10-27 00:00:00', '2025-07-28 00:00:00'], utc=True))
+
+        result = yf.Ticker.parse_earnings_dates(dates)
+        pd.testing.assert_series_equal(result, expected)
 
 class TestTickerHolders(unittest.TestCase):
     session = None

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -30,6 +30,7 @@ from urllib.parse import quote as urlencode
 
 import pandas as pd
 import requests
+from bs4 import BeautifulSoup
 
 from . import utils, cache
 from .data import YfData
@@ -606,6 +607,12 @@ class TickerBase:
                 raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
                                    "Our engineers are working quickly to resolve "
                                    "the issue. Thank you for your patience.")
+
+            # Remove extra <tfoot> tag from HTML
+            soup = BeautifulSoup(data, "html.parser")
+            if soup.tfoot:
+                soup.tfoot.decompose()
+            data = str(soup)
 
             try:
                 data = pd.read_html(StringIO(data))[0]


### PR DESCRIPTION
Fixes the date and column parsing logic when retrieving Earnings Date.

### Changes
- New method `parse_earnings_dates` in base.py
- Updated url and columns
- Rename `Surprise(%)` into `Surprise (%)` to maintain backwards compatibility

### Usage
```python
import yfinance as yf
earnings =  yf.Ticker('MSFT').earnings_dates
print(earnings)
```

The above should match the results from [MSFT Earnings](https://finance.yahoo.com/calendar/earnings?from=2024-12-15&to=2024-12-21&day=2024-12-20&symbol=MSFT)

Would appreciate feedback from someone from non EU.

Thanks for the work from #1932 and #2169