### PR TITLE
pass proxy and sesseion to default PriceHistory object

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -78,7 +78,7 @@ class TickerBase:
 
     @utils.log_indent_decorator
     def history(self, *args, **kwargs) -> pd.DataFrame:
-        return self._lazy_load_price_history().history(*args, **kwargs)
+        return self._lazy_load_price_history().history(*args, **kwargs, session=self.session, proxy=self.proxy)
 
     # ------------------------
 


### PR DESCRIPTION
fix this case:
`
import yfinance as yf

n225 = yf.Ticker("^N225", proxy="socks5://127.0.0.1:1080")

df = n225.history()

print(df)
`