### PR TITLE
Fix: Extra key in Search quotes

### DIFF
--- a/doc/source/reference/examples/search.py
+++ b/doc/source/reference/examples/search.py
@@ -5,3 +5,6 @@ quotes = yf.Search("AAPL", max_results=10).quotes
 
 # get list of news
 news = yf.Search("Google", news_count=10).news
+
+# get list of related research
+research = yf.Search("apple", include_research=True).research

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -4,18 +4,14 @@ from tests.context import yfinance as yf
 
 
 class TestSearch(unittest.TestCase):
-    def test_valid_query(self):
-        search = yf.Search(query="AAPL", max_results=5, news_count=3)
-
-        self.assertEqual(len(search.quotes), 5)
-        self.assertEqual(len(search.news), 3)
-        self.assertIn("AAPL", search.quotes[0]['symbol'])
-
     def test_invalid_query(self):
         search = yf.Search(query="XYZXYZ")
 
         self.assertEqual(len(search.quotes), 0)
         self.assertEqual(len(search.news), 0)
+        self.assertEqual(len(search.lists), 0)
+        self.assertEqual(len(search.nav), 0)
+        self.assertEqual(len(search.research), 0)
 
     def test_empty_query(self):
         search = yf.Search(query="")
@@ -29,3 +25,18 @@ class TestSearch(unittest.TestCase):
         # Check if the fuzzy search retrieves relevant results despite the typo
         self.assertGreater(len(search.quotes), 0)
         self.assertIn("AAPL", search.quotes[0]['symbol'])
+
+    def test_quotes(self):
+        search = yf.Search(query="AAPL", max_results=5)
+
+        self.assertEqual(len(search.quotes), 5)
+        self.assertIn("AAPL", search.quotes[0]['symbol'])
+
+    def test_news(self):
+        search = yf.Search(query="AAPL", news_count=3)
+
+        self.assertEqual(len(search.news), 3)
+
+    def test_research_reports(self):
+        search = yf.Search(query="AAPL", include_research=True)
+        self.assertEqual(len(search.research), 3)

--- a/yfinance/search.py
+++ b/yfinance/search.py
@@ -105,11 +105,12 @@ class Search:
         try:
             data = data.json()
         except _json.JSONDecodeError:
-            self._logger.error(f"{self.query}: Failed to retrieve the news and received faulty response instead.")
+            self._logger.error(f"{self.query}: Failed to retrieve search results and received faulty response instead.")
             data = {}
 
         self._response = data
-        self._quotes = data.get("quotes", [])
+        # Filter quotes to only include symbols
+        self._quotes = [quote for quote in data.get("quotes", []) if "symbol" in quote]
         self._news = data.get("news", [])
         self._lists = data.get("lists", [])
         self._research = data.get("researchReports", [])

--- a/yfinance/search.py
+++ b/yfinance/search.py
@@ -27,7 +27,8 @@ from .data import YfData
 
 
 class Search:
-    def __init__(self, query, max_results=8, news_count=8, lists_count=8, include_cb=True, include_nav_links=False,  include_research=False, include_cultural_assets=False, enable_fuzzy_query=False, recommended=8,
+    def __init__(self, query, max_results=8, news_count=8, lists_count=8, include_cb=True, include_nav_links=False,
+                 include_research=False, include_cultural_assets=False, enable_fuzzy_query=False, recommended=8,
                  session=None, proxy=None, timeout=30, raise_errors=True):
         """
         Fetches and organizes search results from Yahoo Finance, including stock quotes and news articles.
@@ -116,10 +117,10 @@ class Search:
         self._research = data.get("researchReports", [])
         self._nav = data.get("nav", [])
 
-        self._all = {"quotes": self._quotes, "news": self._news, "lists": self._lists, "research": self._research, "nav": self._nav}
+        self._all = {"quotes": self._quotes, "news": self._news, "lists": self._lists, "research": self._research,
+                     "nav": self._nav}
 
         return self
-
 
     @property
     def quotes(self) -> 'list':
@@ -130,27 +131,27 @@ class Search:
     def news(self) -> 'list':
         """Get the news from the search results."""
         return self._news
-    
+
     @property
     def lists(self) -> 'list':
         """Get the lists from the search results."""
         return self._lists
-    
+
     @property
     def research(self) -> 'list':
         """Get the research reports from the search results."""
         return self._research
-    
+
     @property
     def nav(self) -> 'list':
         """Get the navigation links from the search results."""
         return self._nav
-    
+
     @property
     def all(self) -> 'dict[str,list]':
         """Get all the results from the search results: filtered down version of response."""
         return self._all
-    
+
     @property
     def response(self) -> 'dict':
         """Get the raw response from the search results."""


### PR DESCRIPTION
Retrieving quotes using `Search` was returning an extra row.

```python
{
  'index': '78ddc07626ff4bbcae663e88514c23a0',
  'name': 'AAPlasma',
  'permalink': 'aaplasma',
  'isYahooFinance': False
}
```