### PR TITLE
add option to keep the timestamps provided by Yahoo

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -31,7 +31,7 @@ class PriceHistory:
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
                 proxy=None, rounding=False, timeout=10,
-                raise_errors=False) -> pd.DataFrame:
+                raise_errors=False, keep_timestamps=False) -> pd.DataFrame:
         """
         :Parameters:
             period : str
@@ -72,6 +72,8 @@ class PriceHistory:
                 Default is 10 seconds.
             raise_errors: bool
                 If True, then raise errors as Exceptions instead of logging.
+            keep_timestamps: bool
+                If True, then keep original timestamps from Yahoo. Default is False.
         """
         logger = utils.get_yf_logger()
         proxy = proxy or self.proxy
@@ -257,7 +259,7 @@ class PriceHistory:
             start -= _datetime.timedelta(days=4)
 
         # parse quotes
-        quotes = utils.parse_quotes(data["chart"]["result"][0])
+        quotes = utils.parse_quotes(data["chart"]["result"][0], keep_timestamps)
         # Yahoo bug fix - it often appends latest price even if after end date
         if end and not quotes.empty:
             endDt = pd.to_datetime(end, unit='s')


### PR DESCRIPTION
I added parameter keep_timestamps to method `PriceHistory.history` and to function  `parse_quotes` in file utils.py.

If keep_timestamp is True, the original timestamps are added as an extra column to the DataFrame returned by `parse_quotes`. keep_timestamps defaults to False, so the default behaviour is not changed.

I also added type specifiers in `parse_quotes` and eliminated a violation of rule python:S6734.