### PR TITLE
Fix: Broken "See also" links in documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -29,7 +29,8 @@ exclude_patterns = []
 autoclass_content = 'both'
 autosummary_generate = True
 autodoc_default_options = {
-    'exclude-members': '__init__'
+    'exclude-members': '__init__',
+    'members': True,
 }
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
The "See also" links in the documentation (e.g., [yfinance.screener](https://ranaroussi.github.io/yfinance/reference/yfinance.screener.html)) are broken.

![image](https://github.com/user-attachments/assets/b11feb97-1018-4404-bd35-35f3eb1114ed)