### PR TITLE
Fix: Interval check and error message formatting in `multi.py`

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -111,7 +111,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
 
     if ignore_tz is None:
         # Set default value depending on interval
-        if interval[1:] in ['m', 'h']:
+        if interval[-1] in ['m', 'h']:
             # Intraday
             ignore_tz = False
         else:
@@ -185,7 +185,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
         errors = {}
         for ticker in shared._ERRORS:
             err = shared._ERRORS[ticker]
-            err = err.replace(f'{ticker}', '%ticker%')
+            err = err.replace(f'${ticker}: ', '')
             if err not in errors:
                 errors[err] = [ticker]
             else:
@@ -197,7 +197,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
         tbs = {}
         for ticker in shared._TRACEBACKS:
             tb = shared._TRACEBACKS[ticker]
-            tb = tb.replace(f'{ticker}', '%ticker%')
+            tb = tb.replace(f'${ticker}: ', '')
             if tb not in tbs:
                 tbs[tb] = [ticker]
             else:


### PR DESCRIPTION
### Changes
- Fixed interval checking logic, intervals like `60m` and `90m` were previously not recognized.
- Updated error message formatting #2251 
```python
[*********************100%***********************]  27 of 27 completed

2 Failed downloads:
['AISUDFYHAOISDUFHA', 'ASDFSF']: YFTzMissingError('possibly delisted; no timezone found')
```