### PR TITLE
Fix history() fetch when dividends have currency

### DIFF
--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -532,6 +532,7 @@ def parse_actions(data):
             dividends.set_index("date", inplace=True)
             dividends.index = _pd.to_datetime(dividends.index, unit="s")
             dividends.sort_index(inplace=True)
+            dividends = dividends[["amount"]]
             dividends.columns = ["Dividends"]
 
         if "capitalGains" in data["events"]:


### PR DESCRIPTION
When calling history() for Vietnamese stocks, if it contains dividend records, the dividend records will have a currency field, causing an exception. Delete the extra fields from the dividend records to return the history price normally.

fix #2270