### PR TITLE
Direct TTM Financial Data Retrieval Feature

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -318,7 +318,7 @@ class TickerBase:
                 Return table as Python dict
                 Default is False
             freq: str
-                "yearly" or "quarterly"
+                "yearly" or "quarterly" or "trailing"
                 Default is "yearly"
             proxy: str
                 Optional. Proxy server URL scheme
@@ -345,7 +345,7 @@ class TickerBase:
                 Format row names nicely for readability
                 Default is False
             freq: str
-                "yearly" or "quarterly"
+                "yearly" or "quarterly" or "trailing"
                 Default is "yearly"
             proxy: str
                 Optional. Proxy server URL scheme

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -73,12 +73,15 @@ class Financials:
         # despite 'QuoteSummaryStore' containing valid data.
 
         allowed_names = ["income", "balance-sheet", "cash-flow"]
-        allowed_timescales = ["yearly", "quarterly"]
+        allowed_timescales = ["yearly", "quarterly", "trailing"]
 
         if name not in allowed_names:
             raise ValueError(f"Illegal argument: name must be one of: {allowed_names}")
         if timescale not in allowed_timescales:
             raise ValueError(f"Illegal argument: timescale must be one of: {allowed_timescales}")
+        if timescale == "trailing" and name not in ('income', 'cash-flow'):
+            raise ValueError("Illegal argument: frequency 'trailing'" +
+                             " only available for cash-flow or income data.")
 
         try:
             statement = self._create_financials_table(name, timescale, proxy)
@@ -102,7 +105,7 @@ class Financials:
             pass
 
     def get_financials_time_series(self, timescale, keys: list, proxy=None) -> pd.DataFrame:
-        timescale_translation = {"yearly": "annual", "quarterly": "quarterly"}
+        timescale_translation = {"yearly": "annual", "quarterly": "quarterly", "trailing": "trailing"}
         timescale = timescale_translation[timescale]
 
         # Step 2: construct url:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -202,6 +202,10 @@ class Ticker(TickerBase):
         return self.get_income_stmt(pretty=True, freq='quarterly')
 
     @property
+    def ttm_income_stmt(self) -> _pd.DataFrame:
+        return self.get_income_stmt(pretty=True, freq='trailing')
+
+    @property
     def incomestmt(self) -> _pd.DataFrame:
         return self.income_stmt
 
@@ -210,12 +214,20 @@ class Ticker(TickerBase):
         return self.quarterly_income_stmt
 
     @property
+    def ttm_incomestmt(self) -> _pd.DataFrame:
+        return self.ttm_income_stmt
+
+    @property
     def financials(self) -> _pd.DataFrame:
         return self.income_stmt
 
     @property
     def quarterly_financials(self) -> _pd.DataFrame:
         return self.quarterly_income_stmt
+
+    @property
+    def ttm_financials(self) -> _pd.DataFrame:
+        return self.ttm_income_stmt
 
     @property
     def balance_sheet(self) -> _pd.DataFrame:
@@ -242,12 +254,20 @@ class Ticker(TickerBase):
         return self.get_cash_flow(pretty=True, freq='quarterly')
 
     @property
+    def ttm_cash_flow(self) -> _pd.DataFrame:
+        return self.get_cash_flow(pretty=True, freq='trailing')
+
+    @property
     def cashflow(self) -> _pd.DataFrame:
         return self.cash_flow
 
     @property
     def quarterly_cashflow(self) -> _pd.DataFrame:
         return self.quarterly_cash_flow
+
+    @property
+    def ttm_cashflow(self) -> _pd.DataFrame:
+        return self.ttm_cash_flow
 
     @property
     def analyst_price_targets(self) -> dict:


### PR DESCRIPTION
This PR completes the earlier #1643 and moves the PR in to the dev branch.

- Fetches the TTM values for cash flow and income statement from Yahoo.
- Added tests test_ttm_income_statement and test_ttm_cash_flow.

Changes to version.py removed from this commit.

This feature was also requested in #2287 