### PR TITLE
Fixes issue 2344 empty result for get splits

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -453,6 +453,59 @@ class TestPriceHistory(unittest.TestCase):
 
         dat.history(start=start, end=end, interval=interval)
 
+    def test_get_history_metadata(self):
+        tkrs = ["AAPL", "INTC", "FORTUM.HE"]
+        periods = ["pre_start", "pre_end", "start", "end", "post_start", "post_end"]
+
+        for tkr in tkrs:
+            metadata = yf.Ticker(tkr).get_history_metadata()
+            # Check that tradingPeriods were returned
+            self.assertTrue('tradingPeriods' in metadata)
+            self.assertTrue(len(metadata['tradingPeriods']) > 0)
+            for prd in periods:
+                self.assertIsInstance(metadata['tradingPeriods'][prd].iloc[0], _pd.Timestamp, f"Trading period {prd} is not a Timestap.")
+
+    def test_get_dividends(self):
+        tkrs = ["AAPL", "INTC"]
+
+        for tkr in tkrs:
+            df = yf.Ticker(tkr).get_dividends()
+            # Check that dividends were returned
+            self.assertEqual('Dividends', df.name, "Name doesn't match with Dividends")
+            self.assertEqual('float64', df.dtype, "Value is not float64")
+            self.assertTrue(len(df) > 0)
+
+    def test_get_capital_gains(self):
+        tkrs = ["FXAIX"]
+
+        for tkr in tkrs:
+            df = yf.Ticker(tkr).get_capital_gains()
+            # Check that capital gains were returned
+            self.assertEqual('Capital Gains', df.name, "Name doesn't match with Capital Gains")
+            self.assertEqual('float64', df.dtype, "Value is not float64")
+            self.assertTrue(len(df) > 0)
+
+    def test_get_splits(self):
+        tkrs = ["AAPL", "INTC"]
+
+        for tkr in tkrs:
+            df = yf.Ticker(tkr).get_splits()
+            # Check that splits were returned
+            self.assertEqual('Stock Splits', df.name, "Name doesn't match with Stock Splits")
+            self.assertEqual('float64', df.dtype, "Value is not float64")
+            self.assertTrue(len(df) > 0)
+
+    def test_get_actions(self):
+        tkrs = [["FXAIX", ['Dividends', 'Stock Splits', 'Capital Gains']], 
+                ["AAPL", ['Dividends', 'Stock Splits']]]
+
+        for tkr in tkrs:
+            df = yf.Ticker(tkr[0]).get_actions()
+            # Check that Dividends, Stock Splits and Capital Gains were returned
+            for column in tkr[1]:
+                self.assertTrue(column, df)
+            self.assertEqual('float64', df.iloc[0].dtype, "Value is not float64")
+            self.assertTrue(len(df) > 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -466,7 +466,7 @@ class PriceHistory:
         return df
 
     def get_history_metadata(self, proxy=None) -> dict:
-        if self._history_metadata is None:
+        if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
             # Request intraday data, because then Yahoo returns exchange schedule.
             self.history(period="5d", interval="1h", prepost=True, proxy=proxy)
 
@@ -477,7 +477,7 @@ class PriceHistory:
         return self._history_metadata
 
     def get_dividends(self, proxy=None) -> pd.Series:
-        if self._history is None:
+        if self._history is None or self._history_metadata['range'] != '':
             self.history(period="max", proxy=proxy)
         if self._history is not None and "Dividends" in self._history:
             dividends = self._history["Dividends"]
@@ -485,7 +485,7 @@ class PriceHistory:
         return pd.Series()
 
     def get_capital_gains(self, proxy=None) -> pd.Series:
-        if self._history is None:
+        if self._history is None or self._history_metadata['range'] != '':
             self.history(period="max", proxy=proxy)
         if self._history is not None and "Capital Gains" in self._history:
             capital_gains = self._history["Capital Gains"]
@@ -493,7 +493,7 @@ class PriceHistory:
         return pd.Series()
 
     def get_splits(self, proxy=None) -> pd.Series:
-        if self._history is None:
+        if self._history is None or self._history_metadata['range'] != '':
             self.history(period="max", proxy=proxy)
         if self._history is not None and "Stock Splits" in self._history:
             splits = self._history["Stock Splits"]
@@ -501,7 +501,7 @@ class PriceHistory:
         return pd.Series()
 
     def get_actions(self, proxy=None) -> pd.Series:
-        if self._history is None:
+        if self._history is None or self._history_metadata['range'] != '':
             self.history(period="max", proxy=proxy)
         if self._history is not None and "Dividends" in self._history and "Stock Splits" in self._history:
             action_columns = ["Dividends", "Stock Splits"]


### PR DESCRIPTION
Simple fix for #2344. Checks the current history that it contains the timescale we expect for these functions if not refetch the history.
- Added check in get_history_metadata that if cached metadata doesn't contain trading periods then fetch intra day history.
- Added check that if cached history is not max period then refetch the history for get_dividends, get_capital_gains, get_splits and get_actions.

This pull request can be discarded if the larger rework #2345 is completed.