### PR TITLE
Feature: Ticker lookups

### DIFF
--- a/doc/source/reference/examples/lookup.py
+++ b/doc/source/reference/examples/lookup.py
@@ -1,0 +1,33 @@
+import yfinance as yf
+
+# Get All
+all = yf.Lookup("AAPL").all
+all = yf.Lookup("AAPL").get_all(count=100)
+
+# Get Stocks
+stock = yf.Lookup("AAPL").stock
+stock = yf.Lookup("AAPL").get_stock(count=100)
+
+# Get Mutual Funds
+mutualfund = yf.Lookup("AAPL").mutualfund
+mutualfund = yf.Lookup("AAPL").get_mutualfund(count=100)
+
+# Get ETFs
+etf = yf.Lookup("AAPL").etf
+etf = yf.Lookup("AAPL").get_etf(count=100)
+
+# Get Indices
+index = yf.Lookup("AAPL").index
+index = yf.Lookup("AAPL").get_index(count=100)
+
+# Get Futures
+future = yf.Lookup("AAPL").future
+future = yf.Lookup("AAPL").get_future(count=100)
+
+# Get Currencies
+currency = yf.Lookup("AAPL").currency
+currency = yf.Lookup("AAPL").get_currency(count=100)
+
+# Get Cryptocurrencies
+cryptocurrency = yf.Lookup("AAPL").cryptocurrency
+cryptocurrency = yf.Lookup("AAPL").get_cryptocurrency(count=100)

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -18,6 +18,7 @@ The following are the publicly available classes, and functions exposed by the `
 - :attr:`Market <yfinance.Market>`: Class for accessing market summary.
 - :attr:`download <yfinance.download>`: Function to download market data for multiple tickers.
 - :attr:`Search <yfinance.Search>`: Class for accessing search results.
+- :attr:`Lookup <yfinance.Lookup>`: Class for looking up tickers.
 - :attr:`Sector <yfinance.Sector>`: Domain class for accessing sector information.
 - :attr:`Industry <yfinance.Industry>`: Domain class for accessing industry information.
 - :attr:`Market <yfinance.Market>`: Class for accessing market status & summary.
@@ -39,6 +40,7 @@ The following are the publicly available classes, and functions exposed by the `
    yfinance.analysis
    yfinance.market
    yfinance.search
+   yfinance.lookup
    yfinance.sector_industry
    yfinance.screener
    yfinance.functions

--- a/doc/source/reference/yfinance.search.rst
+++ b/doc/source/reference/yfinance.search.rst
@@ -1,5 +1,5 @@
 =====================
-Search & News
+Search & Lookup
 =====================
 
 .. currentmodule:: yfinance
@@ -14,9 +14,21 @@ The `Search` module, allows you to access search data in a Pythonic way.
 
    Search
 
-Search Sample Code
+The `Lookup` module, allows you to look up tickers in a Pythonic way.
+
+.. autosummary::
+   :toctree: api/
+
+   Lookup
+
+Sample Code
 ------------------
 The `Search` module, allows you to access search data in a Pythonic way.
 
 .. literalinclude:: examples/search.py
+   :language: python
+
+The `Lookup` module, allows you to look up tickers in a Pythonic way.
+
+.. literalinclude:: examples/lookup.py
    :language: python

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,5 +1,7 @@
 import unittest
 
+import pandas as pd
+
 from tests.context import yfinance as yf, session_gbl
 
 
@@ -11,55 +13,55 @@ class TestLookup(unittest.TestCase):
     def test_get_all(self):
         result = self.lookup.get_all(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
-    def test_get_equity(self):
-        result = self.lookup.get_equity(count=5)
+    def test_get_stock(self):
+        result = self.lookup.get_stock(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_mutualfund(self):
         result = self.lookup.get_mutualfund(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_etf(self):
         result = self.lookup.get_etf(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_index(self):
         result = self.lookup.get_index(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_future(self):
         result = self.lookup.get_future(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_currency(self):
         result = self.lookup.get_currency(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_get_cryptocurrency(self):
         result = self.lookup.get_cryptocurrency(count=5)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 5)
 
     def test_large_all(self):
         result = self.lookup.get_all(count=1000)
 
-        self.assertIsInstance(result, list)
+        self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 1000)
 
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -1,0 +1,67 @@
+import unittest
+
+from tests.context import yfinance as yf, session_gbl
+
+
+class TestLookup(unittest.TestCase):
+    def setUp(self):
+        self.query = "A"  # Generic query to make sure all lookup types are returned
+        self.lookup = yf.Lookup(query=self.query, session=session_gbl)
+
+    def test_get_all(self):
+        result = self.lookup.get_all(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_equity(self):
+        result = self.lookup.get_equity(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_mutualfund(self):
+        result = self.lookup.get_mutualfund(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_etf(self):
+        result = self.lookup.get_etf(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_index(self):
+        result = self.lookup.get_index(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_future(self):
+        result = self.lookup.get_future(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_currency(self):
+        result = self.lookup.get_currency(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_get_cryptocurrency(self):
+        result = self.lookup.get_cryptocurrency(count=5)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 5)
+
+    def test_large_all(self):
+        result = self.lookup.get_all(count=1000)
+
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1000)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -21,6 +21,7 @@
 
 from . import version
 from .search import Search
+from .lookup import Lookup
 from .ticker import Ticker
 from .tickers import Tickers
 from .multi import download
@@ -39,6 +40,6 @@ __author__ = "Ran Aroussi"
 import warnings
 warnings.filterwarnings('default', category=DeprecationWarning, module='^yfinance')
 
-__all__ = ['download', 'Market', 'Search', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location', 'Sector', 'Industry']
+__all__ = ['download', 'Market', 'Search', 'Lookup', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location', 'Sector', 'Industry']
 # screener stuff:
 __all__ += ['EquityQuery', 'FundQuery', 'screen', 'PREDEFINED_SCREENER_QUERIES']

--- a/yfinance/lookup.py
+++ b/yfinance/lookup.py
@@ -21,6 +21,8 @@
 
 import json as _json
 
+import pandas as pd
+
 from . import utils
 from .const import _QUERY1_URL_
 from .data import YfData
@@ -92,16 +94,20 @@ class Lookup:
         return data
 
     @staticmethod
-    def _parse_response(response: dict) -> list:
+    def _parse_response(response: dict) -> pd.DataFrame:
         finance = response.get("finance", {})
         result = finance.get("result", [])
         result = result[0] if len(result) > 0 else {}
-        return result.get("documents", [])
+        documents = result.get("documents", [])
+        df = pd.DataFrame(documents)
+        if "symbol" not in df.columns:
+            return pd.DataFrame()
+        return df.set_index("symbol")
 
-    def _get_data(self, lookup_type: str, count: int = 25) -> list:
+    def _get_data(self, lookup_type: str, count: int = 25) -> pd.DataFrame:
         return self._parse_response(self._fetch_lookup(lookup_type, count))
 
-    def get_all(self, count=25) -> list:
+    def get_all(self, count=25) -> pd.DataFrame:
         """
         Returns all available financial instruments.
 
@@ -110,7 +116,7 @@ class Lookup:
         """
         return self._get_data("all", count)
 
-    def get_stock(self, count=25) -> list:
+    def get_stock(self, count=25) -> pd.DataFrame:
         """
         Returns stock related financial instruments.
 
@@ -119,7 +125,7 @@ class Lookup:
         """
         return self._get_data("equity", count)
 
-    def get_mutualfund(self, count=25) -> list:
+    def get_mutualfund(self, count=25) -> pd.DataFrame:
         """
         Returns mutual funds related financial instruments.
 
@@ -128,7 +134,7 @@ class Lookup:
         """
         return self._get_data("mutualfund", count)
 
-    def get_etf(self, count=25) -> list:
+    def get_etf(self, count=25) -> pd.DataFrame:
         """
         Returns ETFs related financial instruments.
 
@@ -137,7 +143,7 @@ class Lookup:
         """
         return self._get_data("etf", count)
 
-    def get_index(self, count=25) -> list:
+    def get_index(self, count=25) -> pd.DataFrame:
         """
         Returns Indices related financial instruments.
 
@@ -146,7 +152,7 @@ class Lookup:
         """
         return self._get_data("index", count)
 
-    def get_future(self, count=25) -> list:
+    def get_future(self, count=25) -> pd.DataFrame:
         """
         Returns Futures related financial instruments.
 
@@ -155,7 +161,7 @@ class Lookup:
         """
         return self._get_data("future", count)
 
-    def get_currency(self, count=25) -> list:
+    def get_currency(self, count=25) -> pd.DataFrame:
         """
         Returns Currencies related financial instruments.
 
@@ -164,7 +170,7 @@ class Lookup:
         """
         return self._get_data("currency", count)
 
-    def get_cryptocurrency(self, count=25) -> list:
+    def get_cryptocurrency(self, count=25) -> pd.DataFrame:
         """
         Returns Cryptocurrencies related financial instruments.
 
@@ -174,41 +180,41 @@ class Lookup:
         return self._get_data("cryptocurrency", count)
 
     @property
-    def all(self) -> list:
+    def all(self) -> pd.DataFrame:
         """Returns all available financial instruments."""
         return self._get_data("all")
 
     @property
-    def stock(self) -> list:
+    def stock(self) -> pd.DataFrame:
         """Returns stock related financial instruments."""
         return self._get_data("equity")
 
     @property
-    def mutualfund(self) -> list:
+    def mutualfund(self) -> pd.DataFrame:
         """Returns mutual funds related financial instruments."""
         return self._get_data("mutualfund")
 
     @property
-    def etf(self) -> list:
+    def etf(self) -> pd.DataFrame:
         """Returns ETFs related financial instruments."""
         return self._get_data("etf")
 
     @property
-    def index(self) -> list:
+    def index(self) -> pd.DataFrame:
         """Returns Indices related financial instruments."""
         return self._get_data("index")
 
     @property
-    def future(self) -> list:
+    def future(self) -> pd.DataFrame:
         """Returns Futures related financial instruments."""
         return self._get_data("future")
 
     @property
-    def currency(self) -> list:
+    def currency(self) -> pd.DataFrame:
         """Returns Currencies related financial instruments."""
         return self._get_data("currency")
 
     @property
-    def cryptocurrency(self) -> list:
+    def cryptocurrency(self) -> pd.DataFrame:
         """Returns Cryptocurrencies related financial instruments."""
         return self._get_data("cryptocurrency")

--- a/yfinance/lookup.py
+++ b/yfinance/lookup.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# yfinance - market data downloader
+# https://github.com/ranaroussi/yfinance
+#
+# Copyright 2017-2019 Ran Aroussi
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json as _json
+
+from . import utils
+from .const import _QUERY1_URL_
+from .data import YfData
+from .exceptions import YFException
+
+LOOKUP_TYPES = ["all", "equity", "mutualfund", "etf", "index", "future", "currency", "cryptocurrency"]
+
+
+class Lookup:
+    """
+    Fetches quote (ticker) lookups from Yahoo Finance.
+
+    :param query: The search query for financial data lookup.
+    :type query: str
+    :param session: Custom HTTP session for requests (default None).
+    :param proxy: Proxy settings for requests (default None).
+    :param timeout: Request timeout in seconds (default 30).
+    :param raise_errors: Raise exceptions on error (default True).
+    """
+
+    def __init__(self, query: str, session=None, proxy=None, timeout=30, raise_errors=True):
+        self.query = query
+
+        self.session = session
+        self.proxy = proxy
+        self.timeout = timeout
+        self.raise_errors = raise_errors
+
+        self._logger = utils.get_yf_logger()
+        self._data = YfData(session=self.session)
+
+        self._cache = {}
+
+    def _fetch_lookup(self, lookup_type="all", count=25) -> dict:
+        cache_key = (lookup_type, count)
+        if cache_key in self._cache:
+            return self._cache[cache_key]
+
+        url = f"{_QUERY1_URL_}/v1/finance/lookup"
+        params = {
+            "query": self.query,
+            "type": lookup_type,
+            "start": 0,
+            "count": count,
+            "formatted": False,
+            "fetchPricingData": True,
+            "lang": "en-US",
+            "region": "US"
+        }
+
+        self._logger.debug(f'GET Lookup for ticker ({self.query}) with parameters: {str(dict(params))}')
+
+        data = self._data.get(url=url, params=params, proxy=self.proxy, timeout=self.timeout)
+        if data is None or "Will be right back" in data.text:
+            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
+                               "Our engineers are working quickly to resolve "
+                               "the issue. Thank you for your patience.")
+        try:
+            data = data.json()
+        except _json.JSONDecodeError:
+            self._logger.error(f"{self.query}: Failed to retrieve lookup results and received faulty response instead.")
+            data = {}
+
+        # Error returned
+        if data.get("finance", {}).get("error", {}):
+            raise YFException(data.get("finance", {}).get("error", {}))
+
+        self._cache[cache_key] = data
+        return data
+
+    @staticmethod
+    def _parse_response(response: dict) -> list:
+        finance = response.get("finance", {})
+        result = finance.get("result", [])
+        result = result[0] if len(result) > 0 else {}
+        return result.get("documents", [])
+
+    def _get_data(self, lookup_type: str, count: int = 25) -> list:
+        return self._parse_response(self._fetch_lookup(lookup_type, count))
+
+    def get_all(self, count=25) -> list:
+        """
+        Returns all available financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("all", count)
+
+    def get_stock(self, count=25) -> list:
+        """
+        Returns stock related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("equity", count)
+
+    def get_mutualfund(self, count=25) -> list:
+        """
+        Returns mutual funds related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("mutualfund", count)
+
+    def get_etf(self, count=25) -> list:
+        """
+        Returns ETFs related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("etf", count)
+
+    def get_index(self, count=25) -> list:
+        """
+        Returns Indices related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("index", count)
+
+    def get_future(self, count=25) -> list:
+        """
+        Returns Futures related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("future", count)
+
+    def get_currency(self, count=25) -> list:
+        """
+        Returns Currencies related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("currency", count)
+
+    def get_cryptocurrency(self, count=25) -> list:
+        """
+        Returns Cryptocurrencies related financial instruments.
+
+        :param count: The number of results to retrieve.
+        :type count: int
+        """
+        return self._get_data("cryptocurrency", count)
+
+    @property
+    def all(self) -> list:
+        """Returns all available financial instruments."""
+        return self._get_data("all")
+
+    @property
+    def stock(self) -> list:
+        """Returns stock related financial instruments."""
+        return self._get_data("equity")
+
+    @property
+    def mutualfund(self) -> list:
+        """Returns mutual funds related financial instruments."""
+        return self._get_data("mutualfund")
+
+    @property
+    def etf(self) -> list:
+        """Returns ETFs related financial instruments."""
+        return self._get_data("etf")
+
+    @property
+    def index(self) -> list:
+        """Returns Indices related financial instruments."""
+        return self._get_data("index")
+
+    @property
+    def future(self) -> list:
+        """Returns Futures related financial instruments."""
+        return self._get_data("future")
+
+    @property
+    def currency(self) -> list:
+        """Returns Currencies related financial instruments."""
+        return self._get_data("currency")
+
+    @property
+    def cryptocurrency(self) -> list:
+        """Returns Cryptocurrencies related financial instruments."""
+        return self._get_data("cryptocurrency")


### PR DESCRIPTION
The `Search` module seems like it has been heavily nerfed for searching just tickers. It seems more useful now for fetching news.

### Changes:
I have therefore added a new class `Lookup` that provides the functionality as provided on this page
https://finance.yahoo.com/lookup/?s=apple

### Example:
To perform the same as the link above:
```python
import yfinance as yf

all = yf.Lookup("apple").all
print(all)
```

Closes #2359