### PR TITLE
Fix: Set frequency to 'B' for daily data in history method

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -271,6 +271,10 @@ class PriceHistory:
             msg = f'{self.ticker}: yfinance received OHLC data: {quotes.index[0]} -> {quotes.index[-1]}'
         logger.debug(msg)
 
+        # Fix frequency for daily data
+        if interval.lower() == "1d" and not quotes.empty:
+            quotes.index.freq = 'B'  # Set frequency to business days
+
         # 2) fix weird bug with Yahoo! - returning 60m for 30m bars
         if interval.lower() == "30m":
             logger.debug(f'{self.ticker}: resampling 30m OHLC from 15m')


### PR DESCRIPTION
- Added logic to set `quotes.index.freq` to `'B'` (business days) when the interval is "1d".
- Ensures consistency in frequency for daily data.
- Addresses issue [#1083](https://github.com/ranaroussi/yfinance/issues/1083) in the yfinance repository.