### PR TITLE
Fixes issues 2301 and 2383 AttributeError: module 'requests.cookies' has no attribute 'update'

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1016,6 +1016,22 @@ class TestTickerInfo(unittest.TestCase):
         data2 = self.tickers[2].info
         self.assertIsInstance(data2['trailingPegRatio'], float)
 
+    def test_isin_info(self):
+        isin_list = {"ES0137650018": True,
+                     "does_not_exist": True,  # Nonexistent but doesn't raise an error
+                     "INF209K01EN2": True,
+                     "INX846K01K35": False,    # Nonexistent and raises an error
+                     "INF846K01K35": True
+                     }
+        for isin in isin_list:
+            if not isin_list[isin]:
+                with self.assertRaises(ValueError) as context:
+                    ticker = yf.Ticker(isin)
+                self.assertIn(str(context.exception), [ f"Invalid ISIN number: {isin}", "Empty tickername" ])
+            else:
+                ticker = yf.Ticker(isin)
+            ticker.info
+            
     # def test_fast_info_matches_info(self):
     #     fast_info_keys = set()
     #     for ticker in self.tickers:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -61,9 +61,16 @@ class TickerBase:
         self._earnings = None
         self._financials = None
 
+        # raise an error if user tries to give empty ticker
+        if self.ticker == "":
+            raise ValueError("Empty ticker name")
+
         # accept isin as ticker
         if utils.is_isin(self.ticker):
+            isin = self.ticker
             self.ticker = utils.get_ticker_by_isin(self.ticker, None, session)
+            if self.ticker == "":
+                raise ValueError(f"Invalid ISIN number: {isin}")
 
         self._data: YfData = YfData(session=session)
 

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -193,7 +193,7 @@ def get_all_by_isin(isin, proxy=None, session=None):
     # Deferred this to prevent circular imports
     from .search import Search
 
-    session = session or _requests
+    session = session or _requests.Session()
     search = Search(query=isin, max_results=1, session=session, proxy=proxy)
 
     # Extract the first quote and news


### PR DESCRIPTION
- In utils.py line 196 if the session is None then _requests is mistakenly passed to as session to data.py which causes attribute error: module 'requests.cookies' has no attribute 'update'
- The above condition happens only when searching tickers with ISIN numbers
- Added tests with ISIN numbers
- Added tickerBase to raise an ValueError if an empty tickername is passed or isin search results in to empty ticker. This is to have consistent behaviour with utils.get_all_by_isin()

This PR requires that PR #2382 is first merged otherwise new tests introduced for ISIN will fail to same error as #2343 and #2363