### PR TITLE
download-raise-errors: Add raise_errors and raises to download()

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -290,9 +290,8 @@ def _download_one(ticker, start=None, end=None,
         # glob try/except needed as current thead implementation breaks if exception is raised.
         shared._DFS[ticker.upper()] = utils.empty_df()
         if raises:
-            for r in raises:
-                if type(e) == r:
-                    raise e
+            if any(isinstance(e, exc_type) for exc_type in raises):
+                raise e
         elif raise_errors:
             raise e
         else:


### PR DESCRIPTION
download() has no raise_errors flag which seems like an oversight 

https://github.com/ranaroussi/yfinance/discussions/1832

I have added 'raise_errors' and 'raises' if you need granular exception raises e.g. only the rate limiting exception 