### PR TITLE
Fix: Result of None Type doesn't have update() attribute

### DIFF
--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -607,10 +607,10 @@ class Quote:
         self._already_fetched = True
         modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
         result = self._fetch(proxy, modules=modules)
-        result.update(self._fetch_additional_info(proxy))
         if result is None:
             self._info = {}
             return
+        result.update(self._fetch_additional_info(proxy))
 
         query1_info = {}
         for quote in ["quoteSummary", "quoteResponse"]:


### PR DESCRIPTION
## Issue: 
Sometime _fetch() method returns None and before checking the NoneType an attribute of the _fetch() result is called. This breaks the code when get_info() method is called of Tickers which contains multiple stocks.

## Fix:
- Moved the result NoneType check before accessing its update() attribute in /scrapers/quote.py file