### PR TITLE
Incorporate curl_cffi to avoid rate limiting and cookie errors

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - frozendict >=2.3.4
     - beautifulsoup4 >=4.11.1
     - html5lib >=1.1
+    - curl_cffi >=0.7
     - peewee >=3.16.2
     - pip
     - python
@@ -41,6 +42,7 @@ requirements:
     - frozendict >=2.3.4
     - beautifulsoup4 >=4.11.1
     - html5lib >=1.1
+    - curl_cffi >=0.7
     - peewee >=3.16.2
     - python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ peewee>=3.16.2
 requests_cache>=1.0
 requests_ratelimiter>=0.3.1
 scipy>=1.6.3
-curl_cffi>=0.10.0
+curl_cffi>=0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ peewee>=3.16.2
 requests_cache>=1.0
 requests_ratelimiter>=0.3.1
 scipy>=1.6.3
+curl_cffi>=0.10.0

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
                       'requests>=2.31', 'multitasking>=0.0.7',
                       'platformdirs>=2.0.0', 'pytz>=2022.5',
                       'frozendict>=2.3.4', 'peewee>=3.16.2',
-                      'beautifulsoup4>=4.11.1'],
+                      'beautifulsoup4>=4.11.1', 'curl_cffi>=0.7'],
     extras_require={
         'nospam': ['requests_cache>=1.0', 'requests_ratelimiter>=0.3.1'],
         'repair': ['scipy>=1.6.3'],

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -28,7 +28,8 @@ from urllib.parse import quote as urlencode
 
 import numpy as np
 import pandas as pd
-import requests
+from curl_cffi import requests
+
 
 from . import utils, cache
 from .data import YfData
@@ -48,7 +49,7 @@ _tz_info_fetch_ctr = 0
 class TickerBase:
     def __init__(self, ticker, session=None, proxy=_SENTINEL_):
         self.ticker = ticker.upper()
-        self.session = session
+        self.session = session or requests.Session(impersonate="chrome")
         self._tz = None
 
         self._isin = None

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -28,6 +28,7 @@ from typing import Union
 
 import multitasking as _multitasking
 import pandas as _pd
+from curl_cffi import requests
 
 from . import Ticker, utils
 from .data import YfData
@@ -90,6 +91,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             Optional. Always return a MultiIndex DataFrame? Default is True
     """
     logger = utils.get_yf_logger()
+    session = session or requests.Session(impersonate="chrome")
 
     if auto_adjust is None:
         # Warn users that default has changed to True

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -6,6 +6,7 @@ import pandas as pd
 from math import isclose
 import time as _time
 import bisect
+from curl_cffi import requests
 
 from yfinance import shared, utils
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, _SENTINEL_
@@ -19,7 +20,7 @@ class PriceHistory:
         if proxy is not _SENTINEL_:
             utils.print_once("YF deprecation warning: set proxy via new config function: yf.set_config(proxy=proxy)")
             self._data._set_proxy(proxy)
-        self.session = session
+        self.session = session or requests.Session(impersonate="chrome")
 
         self._history_cache = {}
         self._history_metadata = None

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -35,7 +35,6 @@ from typing import List, Optional
 import numpy as _np
 import pandas as _pd
 import pytz as _tz
-import requests as _requests
 from dateutil.relativedelta import relativedelta
 from pytz import UnknownTimeZoneError
 
@@ -196,7 +195,6 @@ def get_all_by_isin(isin, proxy=const._SENTINEL_, session=None):
     # Deferred this to prevent circular imports
     from .search import Search
 
-    session = session or _requests.Session()
     search = Search(query=isin, max_results=1, session=session, proxy=proxy)
 
     # Extract the first quote and news


### PR DESCRIPTION
~**Don't merge this!**~

~This is just a temporary workaround to allow yfinance to work if using an impersonated session from curl_cffi. Probably is better to actually incorporate curl_cffi into yfinance itself rather than require the session to be passed in to all requests, but this works for now.~

Made the change myself to use curl_cffi by default. Tested by downloading some data and appears to work locally.