### PR TITLE
Restore requests support

### DIFF
--- a/tests/context.py
+++ b/tests/context.py
@@ -5,8 +5,6 @@ import datetime as _dt
 import sys
 import os
 import yfinance
-# from requests_ratelimiter import LimiterSession
-# from pyrate_limiter import Duration, RequestRate, Limiter
 
 _parent_dp = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 _src_dp = _parent_dp
@@ -25,24 +23,22 @@ if os.path.isdir(testing_cache_dirpath):
         import shutil
         shutil.rmtree(testing_cache_dirpath)
 
-# Since switching to curl_cffi, the requests_ratelimiter|cache won't work.
-session_gbl = None
-
-# # Setup a session to only rate-limit
-# history_rate = RequestRate(1, Duration.SECOND)
-# limiter = Limiter(history_rate)
-# session_gbl = LimiterSession(limiter=limiter)
-
-# # Use this instead if you also want caching:
-# from requests_cache import CacheMixin, SQLiteCache
-# from requests_ratelimiter import LimiterMixin
-# from requests import Session
-# from pyrate_limiter import MemoryQueueBucket
-# class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
-#     pass
-# cache_fp = os.path.join(testing_cache_dirpath, "unittests-cache")
-# session_gbl = CachedLimiterSession(
-#     limiter=limiter,
-#     bucket_class=MemoryQueueBucket,
-#     backend=SQLiteCache(cache_fp, expire_after=_dt.timedelta(hours=1)),
-# )
+# Setup a session to only rate-limit
+from pyrate_limiter import Duration, RequestRate, Limiter
+from requests_ratelimiter import LimiterSession
+history_rate = RequestRate(1, Duration.SECOND)
+limiter = Limiter(history_rate)
+session_gbl = LimiterSession(limiter=limiter)
+# Use this instead if you also want caching:
+from requests_cache import CacheMixin, SQLiteCache
+from requests_ratelimiter import LimiterMixin
+from requests import Session
+from pyrate_limiter import MemoryQueueBucket
+class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
+    pass
+cache_fp = os.path.join(testing_cache_dirpath, "unittests-cache")
+session_gbl = CachedLimiterSession(
+    limiter=limiter,
+    bucket_class=MemoryQueueBucket,
+    backend=SQLiteCache(cache_fp, expire_after=_dt.timedelta(hours=1)),
+)

--- a/tests/context.py
+++ b/tests/context.py
@@ -6,6 +6,13 @@ import sys
 import os
 import yfinance
 
+from pyrate_limiter import Duration, RequestRate, Limiter
+from requests_ratelimiter import LimiterSession
+from requests_cache import CacheMixin, SQLiteCache
+from requests_ratelimiter import LimiterMixin
+from requests import Session
+from pyrate_limiter import MemoryQueueBucket
+
 _parent_dp = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 _src_dp = _parent_dp
 sys.path.insert(0, _src_dp)
@@ -24,16 +31,10 @@ if os.path.isdir(testing_cache_dirpath):
         shutil.rmtree(testing_cache_dirpath)
 
 # Setup a session to only rate-limit
-from pyrate_limiter import Duration, RequestRate, Limiter
-from requests_ratelimiter import LimiterSession
 history_rate = RequestRate(1, Duration.SECOND)
 limiter = Limiter(history_rate)
 session_gbl = LimiterSession(limiter=limiter)
 # Use this instead if you also want caching:
-from requests_cache import CacheMixin, SQLiteCache
-from requests_ratelimiter import LimiterMixin
-from requests import Session
-from pyrate_limiter import MemoryQueueBucket
 class CachedLimiterSession(CacheMixin, LimiterMixin, Session):
     pass
 cache_fp = os.path.join(testing_cache_dirpath, "unittests-cache")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,150 @@
+"""
+Tests for YfData sessions
+"""
+
+from tests.context import yfinance as yf
+from yfinance.exceptions import YFDataException
+
+import curl_cffi
+import requests
+from curl_adapter import CurlCffiAdapter
+
+import unittest
+
+class TestData(unittest.TestCase):
+    session = None
+
+    @classmethod
+    def setUpClass(cls):
+        # yf.enable_debug_mode()
+        # cls.session = session_gbl
+        cls.ticker = 'AMD'
+
+    # @classmethod
+    # def tearDownClass(cls):
+    #     if cls.session is not None:
+    #         cls.session.close()
+
+    def test_curlCffi(self):
+        session = curl_cffi.requests.Session(impersonate="chrome")
+
+        dat = yf.Ticker(self.ticker, session=session)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+    def test_requestsWithCurl(self):
+        session = requests.Session()
+        session.mount("http://", CurlCffiAdapter())
+        session.mount("https://", CurlCffiAdapter())
+
+        dat = yf.Ticker(self.ticker, session=session)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+    def test_cookie_strat_switch(self):
+        session = curl_cffi.requests.Session(impersonate="chrome")
+        dat = yf.Ticker(self.ticker, session=session)
+        dat._data._set_cookie_strategy('csrf')
+        dat._data._set_cookie_strategy('basic')
+        dat._data._set_cookie_strategy('csrf')
+        dat._data._set_cookie_strategy('basic')
+        
+        session = requests.Session()
+        session.mount("http://", CurlCffiAdapter())
+        session.mount("https://", CurlCffiAdapter())
+        dat = yf.Ticker(self.ticker, session=session)
+        dat._data._n_strategy_flips = 0
+        dat._data._set_cookie_strategy('csrf')
+        dat._data._set_cookie_strategy('basic')
+        dat._data._set_cookie_strategy('csrf')
+        dat._data._set_cookie_strategy('basic')
+
+    def test_cookie_csrf_strategy(self):
+        session = curl_cffi.requests.Session(impersonate="chrome")
+        dat = yf.Ticker(self.ticker, session=session)
+        dat._data._set_cookie_strategy('csrf')
+        df = dat.history(period='1mo')
+        
+        session = requests.Session()
+        session.mount("http://", CurlCffiAdapter())
+        session.mount("https://", CurlCffiAdapter())
+        dat = yf.Ticker(self.ticker, session=session)
+        dat._data._n_strategy_flips = 0
+        dat._data._set_cookie_strategy('csrf')
+        df = dat.history(period='1mo')
+
+    def test_requestsWithoutCurlRaise(self):
+        session = requests.Session()
+
+        # One of these functions below should raise this exception:
+        with self.assertRaises(YFDataException) as context:
+            dat = yf.Ticker(self.ticker, session=session)
+            df = dat.history(period='1mo')
+
+        self.assertIn("curl", str(context.exception).lower())  # Optional: check message content
+
+    def test_requestsWithCurlAndRateLimiter(self):
+        ReqSession = requests.Session
+        from requests_ratelimiter import LimiterMixin
+        from pyrate_limiter import Duration, RequestRate, Limiter
+        class LimiterSession(LimiterMixin, ReqSession):
+            """Session class with cURL adapter and rate-limiting."""
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.mount("http://", CurlCffiAdapter())
+                self.mount("https://", CurlCffiAdapter())
+        limiter = Limiter(RequestRate(1, 5 * Duration.SECOND))
+        session = LimiterSession(limiter=limiter)
+
+        dat = yf.Ticker(self.ticker, session=session)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+        df = dat.history(period='1mo')
+        self.assertIsNotNone(df)
+        self.assertGreater(len(df), 1)
+
+from unittest.mock import patch
+from requests.exceptions import HTTPError
+class TestDataWithBlock(unittest.TestCase):
+    def setUp(self):
+        self.blocked_url = "https://fc.yahoo.com"
+
+    def send_with_block_check(self, original_send, request, **kwargs):
+        if self.blocked_url_fragment in request.url:
+            raise HTTPError(f"Blocked URL: {request.url}")
+        return original_send(request, **kwargs)
+
+    def test_requestsWithCurl_blocked_url(self):
+        # Create real session with adapters
+        session = requests.Session()
+        session.mount("http://", CurlCffiAdapter())
+        session.mount("https://", CurlCffiAdapter())
+
+        # Save unpatched version of send
+        real_send = requests.sessions.Session.send
+
+        def send_with_block_check(self_obj, request, **kwargs):
+            if self.blocked_url_fragment in request.url:
+                raise HTTPError(f"Blocked URL: {request.url}")
+            return real_send(self_obj, request, **kwargs)
+
+        yf.enable_debug_mode()
+        with patch('requests.sessions.Session.send', new=send_with_block_check):
+            dat = yf.Ticker('AAPL', session=session)
+            df = dat.history(period='1mo')
+            print(df.shape)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -10,6 +10,8 @@ import requests
 from curl_adapter import CurlCffiAdapter
 
 import unittest
+from unittest.mock import patch
+from requests.exceptions import HTTPError
 
 class TestData(unittest.TestCase):
     session = None
@@ -75,7 +77,7 @@ class TestData(unittest.TestCase):
         session = curl_cffi.requests.Session(impersonate="chrome")
         dat = yf.Ticker(self.ticker, session=session)
         dat._data._set_cookie_strategy('csrf')
-        df = dat.history(period='1mo')
+        dat.history(period='1mo')
         
         session = requests.Session()
         session.mount("http://", CurlCffiAdapter())
@@ -83,7 +85,7 @@ class TestData(unittest.TestCase):
         dat = yf.Ticker(self.ticker, session=session)
         dat._data._n_strategy_flips = 0
         dat._data._set_cookie_strategy('csrf')
-        df = dat.history(period='1mo')
+        dat.history(period='1mo')
 
     def test_requestsWithoutCurlRaise(self):
         session = requests.Session()
@@ -91,7 +93,7 @@ class TestData(unittest.TestCase):
         # One of these functions below should raise this exception:
         with self.assertRaises(YFDataException) as context:
             dat = yf.Ticker(self.ticker, session=session)
-            df = dat.history(period='1mo')
+            dat.history(period='1mo')
 
         self.assertIn("curl", str(context.exception).lower())  # Optional: check message content
 
@@ -118,8 +120,6 @@ class TestData(unittest.TestCase):
         self.assertIsNotNone(df)
         self.assertGreater(len(df), 1)
 
-from unittest.mock import patch
-from requests.exceptions import HTTPError
 class TestDataWithBlock(unittest.TestCase):
     def setUp(self):
         self.blocked_url = "https://fc.yahoo.com"

--- a/yfinance/cache.py
+++ b/yfinance/cache.py
@@ -372,9 +372,9 @@ class _CookieCache:
             return None
 
         try:
-            schema = _CookieSchema.get(_CookieSchema.strategy == strategy)
-            data = _pkl.loads(schema.cookie_bytes)
-            return {'data':data, 'age':_datetime.datetime.now()-schema.fetch_date}
+            row = _CookieSchema.get(_CookieSchema.strategy == strategy)
+            cookie = _pkl.loads(row.cookie_bytes)
+            return {'data':cookie, 'age':_datetime.datetime.now()-row.fetch_date}
         except _CookieSchema.DoesNotExist:
             return None
 

--- a/yfinance/cache.py
+++ b/yfinance/cache.py
@@ -372,9 +372,9 @@ class _CookieCache:
             return None
 
         try:
-            data =  _CookieSchema.get(_CookieSchema.strategy == strategy)
-            cookie = _pkl.loads(data.cookie_bytes)
-            return {'cookie':cookie, 'age':_datetime.datetime.now()-data.fetch_date}
+            schema = _CookieSchema.get(_CookieSchema.strategy == strategy)
+            data = _pkl.loads(schema.cookie_bytes)
+            return {'data':data, 'age':_datetime.datetime.now()-schema.fetch_date}
         except _CookieSchema.DoesNotExist:
             return None
 

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 # from curl_cffi import requests
 from curl_cffi import requests as req_cc
 from curl_adapter import CurlCffiAdapter
-import requests as req
+# import requests as req
 
 from bs4 import BeautifulSoup
 import datetime
@@ -20,8 +20,6 @@ from .const import USER_AGENTS
 from .exceptions import YFRateLimitError, YFDataException
 
 cache_maxsize = 64
-
-from pprint import pprint
 
 
 def lru_cache_freezeargs(func):
@@ -209,15 +207,15 @@ class YfData(metaclass=SingletonMeta):
     def _load_cookies_curlCffi(self):
         if self._session is None:
             # Need a session to load cookie into
-            utils.get_yf_logger().debug(f'self._session is None')
+            utils.get_yf_logger().debug('self._session is None')
             return False
         cookies = cache.get_cookie_cache().lookup('cookies-curlCffi')
         if cookies is None:
-            utils.get_yf_logger().debug(f'Cache returned None')
+            utils.get_yf_logger().debug('Cache returned None')
             return False
         cookies = cookies['data']
         if len(cookies) == 0:
-            utils.get_yf_logger().debug(f'Cached cookie jar empty')
+            utils.get_yf_logger().debug('Cached cookie jar empty')
             return False
 
         utils.get_yf_logger().debug(f'Loading cached curlCffi cookies: {cookies}')

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -137,7 +137,10 @@ class YfData(metaclass=SingletonMeta):
             for scheme in ['http://', 'https://']:
                 adapter = session.adapters.get(scheme)
                 if not isinstance(adapter, CurlCffiAdapter):
-                    raise YFDataException(f"Yahoo API requires requests have TLS fingerprints. Options: leave session=None, attach CurlCffiAdapter to your request, or use curl_cffi session.")
+                    # raise YFDataException(f"Yahoo API requires requests have TLS fingerprints. Options: leave session=None, attach CurlCffiAdapter to your request, or use curl_cffi session.")
+                    # Add adapters
+                    session.mount(scheme, CurlCffiAdapter())
+                    utils.get_yf_logger().debug(f"Adding CurlCffiAdapter() to session['{scheme}']")
             self._session_is_requests = True
             # except Exception:
             #     raise YFDataException(f"Yahoo API requires requests have TLS fingerprints. Options: leave session=None, attach CurlCffiAdapter to your request, or use curl_cffi session.")

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -309,7 +309,6 @@ class YfData(metaclass=SingletonMeta):
                 url='https://fc.yahoo.com',
                 timeout=timeout,
                 allow_redirects=True)
-            raise req.exceptions.HTTPError
         except req_cc.exceptions.DNSError:
             # Possible because url on some privacy/ad blocklists
             return False


### PR DESCRIPTION
Thanks to @deeleeramone https://github.com/ranaroussi/yfinance/issues/2486#issuecomment-2870628204, learnt that requests can work if it has a curl_adapter.

Confirmed working with rate limiter. Also works with requests_cache, but probably always misses cache because of crumb changing.