### PR TITLE
adjusting for processing time in max period (reduced)

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -133,13 +133,14 @@ class PriceHistory:
                 end = utils._parse_user_dt(end, tz)
             if start is None:
                 if interval == "1m":
-                    start = end - 604800   # 7 days
-                elif interval in ("5m", "15m", "30m", "90m"):
+                    start = end - 691200  # 8 days
+                elif interval in ("2m", "5m", "15m", "30m", "90m"):
                     start = end - 5184000  # 60 days
-                elif interval in ("1h", '60m'):
+                elif interval in ("1h", "60m"):
                     start = end - 63072000  # 730 days
                 else:
                     start = end - 3122064000  # 99 years
+                start += 5 # allow for processing time
             else:
                 start = utils._parse_user_dt(start, tz)
             params = {"period1": start, "period2": end}


### PR DESCRIPTION
This PR is to address the primary problem in issue #2451 - around yf.download with period="max".

There was a bug that interval="2m" was not accounted for.
Intraday intervals often fail due to processing time - which leads to requesting a period of data that exceeds the maximum period. In reducing a buffer from the calculated end and start dates, the error is avoided.
Also, the 1m interval chunk was increased to 8 days as this is the actual max requestable period/chunk.


**--This time without automated formatting changes--** 

Cheers,
Cole