### PR TITLE
Improve exception handling

### DIFF
--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -32,6 +32,7 @@ from .domain.sector import Sector
 from .domain.industry import Industry
 from .domain.market import Market
 from .data import YfData
+from .config import YfConfig
 
 from .screener.query import EquityQuery, FundQuery
 from .screener.screener import screen, PREDEFINED_SCREENER_QUERIES
@@ -48,7 +49,9 @@ __all__ += ['EquityQuery', 'FundQuery', 'screen', 'PREDEFINED_SCREENER_QUERIES']
 
 # Config stuff:
 _NOTSET=object()
-def set_config(proxy=_NOTSET):
+def set_config(proxy=_NOTSET, hide_exceptions=_NOTSET):
     if proxy is not _NOTSET:
         YfData(proxy=proxy)
+    if hide_exceptions is not _NOTSET:
+        YfConfig(hide_exceptions=hide_exceptions)
 __all__ += ["set_config"]

--- a/yfinance/domain/industry.py
+++ b/yfinance/domain/industry.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 import warnings
 
 from .. import utils
+from ..config import YfConfig
 from ..const import _SENTINEL_
 from ..data import YfData
 
@@ -147,6 +148,8 @@ class Industry(Domain):
 
             return result
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             logger = utils.get_yf_logger()
             logger.error(f"Failed to get industry data for '{self._key}' reason: {e}")
             logger.debug("Got response: ")

--- a/yfinance/domain/market.py
+++ b/yfinance/domain/market.py
@@ -2,8 +2,10 @@ import datetime as dt
 import json as _json
 import warnings
 
+from ..config import YfConfig
 from ..const import _QUERY1_URL_, _SENTINEL_
 from ..data import utils, YfData
+from ..exceptions import YFDataException
 
 class Market:
     def __init__(self, market:'str', session=None, proxy=_SENTINEL_, timeout=30):
@@ -24,12 +26,12 @@ class Market:
     def _fetch_json(self, url, params):
         data = self._data.cache_get(url=url, params=params, timeout=self.timeout)
         if data is None or "Will be right back" in data.text:
-            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
-                               "Our engineers are working quickly to resolve "
-                               "the issue. Thank you for your patience.")
+            raise YFDataException("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***")
         try:
             return data.json()
         except _json.JSONDecodeError:
+            if not YfConfig().hide_exceptions:
+                raise
             self._logger.error(f"{self.market}: Failed to retrieve market data and recieved faulty data.")
             return {}
         
@@ -66,6 +68,8 @@ class Market:
             self._summary = self._summary['marketSummaryResponse']['result']
             self._summary = {x['exchange']:x for x in self._summary}
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             self._logger.error(f"{self.market}: Failed to parse market summary")
             self._logger.debug(f"{type(e)}: {e}")
 
@@ -75,17 +79,21 @@ class Market:
             self._status = self._status['finance']['marketTimes'][0]['marketTime'][0]
             self._status['timezone'] = self._status['timezone'][0]
             del self._status['time']  # redundant
-            try:
-                self._status.update({
-                    "open": dt.datetime.fromisoformat(self._status["open"]),
-                    "close": dt.datetime.fromisoformat(self._status["close"]),
-                    "tz": dt.timezone(dt.timedelta(hours=int(self._status["timezone"]["gmtoffset"]))/1000, self._status["timezone"]["short"])
-                })
-            except Exception as e:
-                self._logger.error(f"{self.market}: Failed to update market status")
-                self._logger.debug(f"{type(e)}: {e}")
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             self._logger.error(f"{self.market}: Failed to parse market status")
+            self._logger.debug(f"{type(e)}: {e}")
+        try:
+            self._status.update({
+                "open": dt.datetime.fromisoformat(self._status["open"]),
+                "close": dt.datetime.fromisoformat(self._status["close"]),
+                "tz": dt.timezone(dt.timedelta(hours=int(self._status["timezone"]["gmtoffset"]))/1000, self._status["timezone"]["short"])
+            })
+        except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
+            self._logger.error(f"{self.market}: Failed to update market status")
             self._logger.debug(f"{type(e)}: {e}")
 
 

--- a/yfinance/domain/sector.py
+++ b/yfinance/domain/sector.py
@@ -4,6 +4,7 @@ import pandas as _pd
 from typing import Dict, Optional
 import warnings
 
+from ..config import YfConfig
 from ..const import SECTOR_INDUSTY_MAPPING, _SENTINEL_
 from ..data import YfData
 from ..utils import dynamic_docstring, generate_list_table_from_dict, get_yf_logger
@@ -148,7 +149,9 @@ class Sector(Domain):
             self._industries = self._parse_industries(data.get('industries', {}))
 
         except Exception as e:
-            logger = get_yf_logger()
+            if not YfConfig().hide_exceptions:
+                raise
+            logger = utils.get_yf_logger()
             logger.error(f"Failed to get sector data for '{self._key}' reason: {e}")
             logger.debug("Got response: ")
             logger.debug("-------------")

--- a/yfinance/live.py
+++ b/yfinance/live.py
@@ -7,6 +7,7 @@ from websockets.sync.client import connect as sync_connect
 from websockets.asyncio.client import connect as async_connect
 
 from yfinance import utils
+from yfinance.config import YfConfig
 from yfinance.pricing_pb2 import PricingData
 from google.protobuf.json_format import MessageToDict
 
@@ -27,6 +28,8 @@ class BaseWebSocket:
             pricing_data.ParseFromString(decoded_bytes)
             return MessageToDict(pricing_data, preserving_proto_field_name=True)
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             self.logger.error("Failed to decode message: %s", e, exc_info=True)
             if self.verbose:
                 print("Failed to decode message: %s", e)
@@ -61,6 +64,8 @@ class AsyncWebSocket(BaseWebSocket):
                 if self.verbose:
                     print("Connected to WebSocket.")
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             self.logger.error("Failed to connect to WebSocket: %s", e, exc_info=True)
             if self.verbose:
                 print(f"Failed to connect to WebSocket: {e}")
@@ -79,6 +84,8 @@ class AsyncWebSocket(BaseWebSocket):
                     if self.verbose:
                         print(f"Heartbeat subscription sent for symbols: {self._subscriptions}")
             except Exception as e:
+                if not YfConfig().hide_exceptions:
+                    raise
                 self.logger.error("Error in heartbeat subscription: %s", e, exc_info=True)
                 if self.verbose:
                     print(f"Error in heartbeat subscription: {e}")
@@ -162,6 +169,8 @@ class AsyncWebSocket(BaseWebSocket):
                             else:
                                 self._message_handler(decoded_message)
                         except Exception as handler_exception:
+                            if not YfConfig().hide_exceptions:
+                                raise
                             self.logger.error("Error in message handler: %s", handler_exception, exc_info=True)
                             if self.verbose:
                                 print("Error in message handler:", handler_exception)
@@ -176,6 +185,8 @@ class AsyncWebSocket(BaseWebSocket):
                 break
 
             except Exception as e:
+                if not YfConfig().hide_exceptions:
+                    raise
                 self.logger.error("Error while listening to messages: %s", e, exc_info=True)
                 if self.verbose:
                     print("Error while listening to messages: %s", e)
@@ -301,6 +312,8 @@ class WebSocket(BaseWebSocket):
                     try:
                         message_handler(decoded_message)
                     except Exception as handler_exception:
+                        if not YfConfig().hide_exceptions:
+                            raise
                         self.logger.error("Error in message handler: %s", handler_exception, exc_info=True)
                         if self.verbose:
                             print("Error in message handler:", handler_exception)
@@ -314,6 +327,8 @@ class WebSocket(BaseWebSocket):
                 break
 
             except Exception as e:
+                if not YfConfig().hide_exceptions:
+                    raise
                 self.logger.error("Error while listening to messages: %s", e, exc_info=True)
                 if self.verbose:
                     print("Error while listening to messages: %s", e)

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -3,6 +3,7 @@ import pandas as pd
 import warnings
 
 from yfinance import utils
+from yfinance.config import YfConfig
 from yfinance.const import quote_summary_valid_modules, _SENTINEL_
 from yfinance.data import YfData
 from yfinance.exceptions import YFException
@@ -84,6 +85,8 @@ class Analysis:
             data = self._fetch(['financialData'])
             data = data['quoteSummary']['result'][0]['financialData']
         except (TypeError, KeyError):
+            if not YfConfig().hide_exceptions:
+                raise
             self._analyst_price_targets = {}
             return self._analyst_price_targets
 
@@ -107,6 +110,8 @@ class Analysis:
             data = self._fetch(['earningsHistory'])
             data = data['quoteSummary']['result'][0]['earningsHistory']['history']
         except (TypeError, KeyError):
+            if not YfConfig().hide_exceptions:
+                raise
             self._earnings_history = pd.DataFrame()
             return self._earnings_history
 
@@ -143,6 +148,8 @@ class Analysis:
             trends = self._fetch(['industryTrend', 'sectorTrend', 'indexTrend'])
             trends = trends['quoteSummary']['result'][0]
         except (TypeError, KeyError):
+            if not YfConfig().hide_exceptions:
+                raise
             self._growth_estimates = pd.DataFrame()
             return self._growth_estimates
 
@@ -180,6 +187,8 @@ class Analysis:
         try:
             result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_ + f"/{self._symbol}", params=params_dict)
         except curl_cffi.requests.exceptions.HTTPError as e:
+            if not YfConfig().hide_exceptions:
+                raise
             utils.get_yf_logger().error(str(e))
             return None
         return result
@@ -189,4 +198,6 @@ class Analysis:
             data = self._fetch(['earningsTrend'])
             self._earnings_trend = data['quoteSummary']['result'][0]['earningsTrend']['trend']
         except (TypeError, KeyError):
+            if not YfConfig().hide_exceptions:
+                raise
             self._earnings_trend = []

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -5,6 +5,7 @@ import warnings
 import pandas as pd
 
 from yfinance import utils, const
+from yfinance.config import YfConfig
 from yfinance.data import YfData
 from yfinance.exceptions import YFException, YFNotImplementedError
 
@@ -104,6 +105,8 @@ class Financials:
             if statement is not None:
                 return statement
         except YFException as e:
+            if not YfConfig().hide_exceptions:
+                raise
             utils.get_yf_logger().error(f"{self._symbol}: Failed to create {name} financials table for reason: {e}")
         return pd.DataFrame()
 
@@ -117,6 +120,8 @@ class Financials:
         try:
             return self._get_financials_time_series(timescale, keys)
         except Exception:
+            if not YfConfig().hide_exceptions:
+                raise
             pass
 
     def _get_financials_time_series(self, timescale, keys: list) -> pd.DataFrame:

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional
 import warnings
 
 from yfinance import utils
+from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_, _SENTINEL_
 from yfinance.data import YfData
 from yfinance.exceptions import YFDataException
@@ -193,8 +194,12 @@ class FundsData:
             self._parse_top_holdings(data["topHoldings"])
             self._parse_fund_profile(data["fundProfile"])
         except KeyError:
-            raise YFDataException("No Fund data found.")
+            if not YfConfig().hide_exceptions:
+                raise
+            raise YFDataException(f"{self._symbol}: No Fund data found.")
         except Exception as e:
+            if not YfConfig().hide_exceptions:
+                raise
             logger = utils.get_yf_logger()
             logger.error(f"Failed to get fund data for '{self._symbol}' reason: {e}")
             logger.debug("Got response: ")

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -10,8 +10,9 @@ import time as _time
 import warnings
 
 from yfinance import shared, utils
+from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, _SENTINEL_
-from yfinance.exceptions import YFInvalidPeriodError, YFPricesMissingError, YFTzMissingError, YFRateLimitError
+from yfinance.exceptions import YFDataException, YFInvalidPeriodError, YFPricesMissingError, YFRateLimitError, YFTzMissingError
 
 class PriceHistory:
     def __init__(self, data, ticker, tz, session=None, proxy=_SENTINEL_):
@@ -81,13 +82,16 @@ class PriceHistory:
             warnings.warn("Set proxy via new config function: yf.set_config(proxy=proxy)", DeprecationWarning, stacklevel=5)
             self._data._set_proxy(proxy)
 
+        if raise_errors:
+            warnings.warn("'raise_errors' deprecated, use yf.set_config(hide_exceptions=False)", DeprecationWarning, stacklevel=5)
+
         interval_user = interval
         period_user = period
         if repair and interval in ["5d", "1wk", "1mo", "3mo"]:
             # Yahoo's way of adjusting mutiday intervals is fundamentally broken.
             # Have to fetch 1d, adjust, then resample.
             if interval == '5d':
-                raise Exception("Yahoo's interval '5d' is nonsense, not supported with repair")
+                raise ValueError("Yahoo's interval '5d' is nonsense, not supported with repair")
             if start is None and end is None and period is not None:
                 tz = self.tz
                 if tz is None:
@@ -96,7 +100,7 @@ class PriceHistory:
                     err_msg = str(_exception)
                     shared._DFS[self.ticker] = utils.empty_df()
                     shared._ERRORS[self.ticker] = err_msg.split(': ', 1)[1]
-                    if raise_errors:
+                    if raise_errors or (not YfConfig().hide_exceptions):
                         raise _exception
                     else:
                         logger.error(err_msg)
@@ -122,7 +126,7 @@ class PriceHistory:
                 err_msg = str(_exception)
                 shared._DFS[self.ticker] = utils.empty_df()
                 shared._ERRORS[self.ticker] = err_msg.split(': ', 1)[1]
-                if raise_errors:
+                if raise_errors or (not YfConfig().hide_exceptions):
                     raise _exception
                 else:
                     logger.error(err_msg)
@@ -183,22 +187,22 @@ class PriceHistory:
                 timeout=timeout
             )
             if "Will be right back" in data.text or data is None:
-                raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
-                                   "Our engineers are working quickly to resolve "
-                                   "the issue. Thank you for your patience.")
+                raise YFDataException("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***")
 
             data = data.json()
         # Special case for rate limits
         except YFRateLimitError:
             raise
         except Exception:
-            if raise_errors:
+            if raise_errors or (not YfConfig().hide_exceptions):
                 raise
 
         # Store the meta data that gets retrieved simultaneously
         try:
             self._history_metadata = data["chart"]["result"][0]["meta"]
         except Exception:
+            if not YfConfig().hide_exceptions:
+                raise
             self._history_metadata = {}
 
         intraday = params["interval"][-1] in ("m", 'h')
@@ -245,7 +249,7 @@ class PriceHistory:
             err_msg = str(_exception)
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg.split(': ', 1)[1]
-            if raise_errors:
+            if raise_errors or (not YfConfig().hide_exceptions):
                 raise _exception
             else:
                 logger.error(err_msg)
@@ -297,6 +301,8 @@ class PriceHistory:
                 quotes['Dividends'] = quotes2['Dividends'].max()
                 quotes['Stock Splits'] = quotes2['Stock Splits'].max()
             except Exception:
+                if raise_errors or (not YfConfig().hide_exceptions):
+                    raise
                 pass
 
         # Note: ordering is important. If you change order, run the tests!
@@ -427,16 +433,15 @@ class PriceHistory:
             elif back_adjust:
                 df = utils.back_adjust(df)
         except Exception as e:
+            if raise_errors or (not YfConfig().hide_exceptions):
+                raise
             if auto_adjust:
                 err_msg = "auto_adjust failed with %s" % e
             else:
                 err_msg = "back_adjust failed with %s" % e
             shared._DFS[self.ticker] = utils.empty_df()
             shared._ERRORS[self.ticker] = err_msg
-            if raise_errors:
-                raise Exception('%s: %s' % (self.ticker, err_msg))
-            else:
-                logger.error('%s: %s' % (self.ticker, err_msg))
+            logger.error('%s: %s' % (self.ticker, err_msg))
 
         if rounding:
             df = np.round(df, data["chart"]["result"][0]["meta"]["priceHint"])
@@ -567,7 +572,7 @@ class PriceHistory:
                 align_month = _datetime.datetime.now().strftime('%b').upper()
             resample_period = f"QS-{align_month}"
         else:
-            raise Exception(f"Not implemented resampling to interval '{target_interval}'")
+            raise ValueError(f"Not implemented resampling to interval '{target_interval}'")
         resample_map = {
             'Open': 'first', 'Low': 'min', 'High': 'max', 'Close': 'last',
             'Volume': 'sum', 'Dividends': 'sum', 'Stock Splits': 'prod'
@@ -590,7 +595,7 @@ class PriceHistory:
         log_extras = {'yf_cat': 'price-reconstruct', 'yf_interval': interval, 'yf_symbol': self.ticker}
 
         if not isinstance(df, pd.DataFrame):
-            raise Exception("'df' must be a Pandas DataFrame not", type(df))
+            raise ValueError("'df' must be a Pandas DataFrame not", type(df))
         if interval == "1m":
             # Can't go smaller than 1m so can't reconstruct
             return df
@@ -995,6 +1000,8 @@ class PriceHistory:
                     prices_in_subunits = False
             except Exception:
                 # Should never happen but just-in-case
+                if not YfConfig().hide_exceptions:
+                    raise
                 pass
         if prices_in_subunits:
             for c in _PRICE_COLNAMES_:
@@ -1646,7 +1653,7 @@ class PriceHistory:
                     # elif k == 'div_true_date':
                     #     div_status_df[k] = pd.Series(dtype='datetime64[ns, UTC]')
                     else:
-                        raise Exception(k,v,type(v))
+                        raise ValueError(k,v,type(v))
                 div_status_df.loc[dt, k] = v
         checks += ['adj_missing', 'adj_exceeds_div', 'div_exceeds_adj']
 
@@ -1886,7 +1893,7 @@ class PriceHistory:
                     elif k == 'div_true_date':
                         div_status_df[k] = pd.Series(dtype='datetime64[ns, UTC]')
                     else:
-                        raise Exception(k,v,type(v))
+                        raise ValueError(k,v,type(v))
                 div_status_df.loc[dt, k] = v
             if 'div_too_big' in div_status_df.columns and 'div_date_wrong' in div_status_df.columns:
                 # Where div_date_wrong = True, discard div_too_big. Helps with false-positive handling later.
@@ -2340,9 +2347,6 @@ class PriceHistory:
         for k in div_repairs:
             msg = f"Repaired {k}: {[str(dt.date()) for dt in sorted(div_repairs[k])]}"
             logger.info(msg, extra=log_extras)
-
-        if 'Adj' in df2.columns:
-            raise Exception('"Adj" has snuck in df2')
 
         if not df2_nan.empty:
             df2 = pd.concat([df2, df2_nan]).sort_index()

--- a/yfinance/scrapers/holders.py
+++ b/yfinance/scrapers/holders.py
@@ -3,6 +3,7 @@ import pandas as pd
 import warnings
 
 from yfinance import utils
+from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_, _SENTINEL_
 from yfinance.data import YfData
 from yfinance.exceptions import YFDataException
@@ -75,6 +76,8 @@ class Holders:
         try:
             result = self._fetch()
         except curl_cffi.requests.exceptions.HTTPError as e:
+            if not YfConfig().hide_exceptions:
+                raise
             utils.get_yf_logger().error(str(e))
 
             self._major = pd.DataFrame()
@@ -98,6 +101,8 @@ class Holders:
             self._parse_insider_holders(data.get("insiderHolders", {}))
             self._parse_net_share_purchase_activity(data.get("netSharePurchaseActivity", {}))
         except (KeyError, IndexError):
+            if not YfConfig().hide_exceptions:
+                raise
             raise YFDataException("Failed to parse holders json data.")
 
     @staticmethod

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -6,6 +6,7 @@ import pandas as pd
 import warnings
 
 from yfinance import utils
+from yfinance.config import YfConfig
 from yfinance.const import quote_summary_valid_modules, _BASE_URL_, _QUERY1_URL_, _SENTINEL_
 from yfinance.data import YfData
 from yfinance.exceptions import YFDataException, YFException
@@ -106,7 +107,7 @@ class FastInfo:
 
     def __getitem__(self, k):
         if not isinstance(k, str):
-            raise KeyError("key must be a string")
+            raise KeyError(f"key must be a string not '{type(k)}'")
         if k not in self._keys:
             raise KeyError(f"'{k}' not valid key. Examine 'FastInfo.keys()'")
         if k in self._cc_to_sc_key:
@@ -467,8 +468,6 @@ class FastInfo:
         except Exception as e:
             if "Cannot retrieve share count" in str(e):
                 shares = None
-            elif "failed to decrypt Yahoo" in str(e):
-                shares = None
             else:
                 raise
 
@@ -523,6 +522,8 @@ class Quote:
                 try:
                     data = result["quoteSummary"]["result"][0]
                 except (KeyError, IndexError):
+                    if not YfConfig().hide_exceptions:
+                        raise
                     raise YFDataException(f"Failed to parse json response from Yahoo Finance: {result}")
                 self._sustainability = pd.DataFrame(data)
         return self._sustainability
@@ -537,6 +538,8 @@ class Quote:
                 try:
                     data = result["quoteSummary"]["result"][0]["recommendationTrend"]["trend"]
                 except (KeyError, IndexError):
+                    if not YfConfig().hide_exceptions:
+                        raise
                     raise YFDataException(f"Failed to parse json response from Yahoo Finance: {result}")
                 self._recommendations = pd.DataFrame(data)
         return self._recommendations
@@ -558,6 +561,8 @@ class Quote:
                     df.index = pd.to_datetime(df.index, unit='s')
                     self._upgrades_downgrades = df
                 except (KeyError, IndexError):
+                    if not YfConfig().hide_exceptions:
+                        raise
                     raise YFDataException(f"Failed to parse json response from Yahoo Finance: {result}")
         return self._upgrades_downgrades
 
@@ -589,6 +594,8 @@ class Quote:
         try:
             result = self._data.get_raw_json(_QUOTE_SUMMARY_URL_ + f"/{self._symbol}", params=params_dict)
         except curl_cffi.requests.exceptions.HTTPError as e:
+            if not YfConfig().hide_exceptions:
+                raise
             utils.get_yf_logger().error(str(e))
             return None
         return result
@@ -598,6 +605,8 @@ class Quote:
         try:
             result = self._data.get_raw_json(f"{_QUERY1_URL_}/v7/finance/quote?", params=params_dict)
         except curl_cffi.requests.exceptions.HTTPError as e:
+            if not YfConfig().hide_exceptions:
+                raise
             utils.get_yf_logger().error(str(e))
             return None
         return result
@@ -740,6 +749,8 @@ class Quote:
                 self._calendar['Revenue Low'] = earnings.get('revenueLow', None)
                 self._calendar['Revenue Average'] = earnings.get('revenueAverage', None)
         except (KeyError, IndexError):
+            if not YfConfig().hide_exceptions:
+                raise
             raise YFDataException(f"Failed to parse json response from Yahoo Finance: {result}")
 
 

--- a/yfinance/search.py
+++ b/yfinance/search.py
@@ -23,8 +23,10 @@ import json as _json
 import warnings
 
 from . import utils
+from .config import YfConfig
 from .const import _BASE_URL_, _SENTINEL_
 from .data import YfData
+from .exceptions import YFDataException
 
 
 class Search:
@@ -104,13 +106,13 @@ class Search:
 
         data = self._data.cache_get(url=url, params=params, timeout=self.timeout)
         if data is None or "Will be right back" in data.text:
-            raise RuntimeError("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***\n"
-                               "Our engineers are working quickly to resolve "
-                               "the issue. Thank you for your patience.")
+            raise YFDataException("*** YAHOO! FINANCE IS CURRENTLY DOWN! ***")
         try:
             data = data.json()
         except _json.JSONDecodeError:
-            self._logger.error(f"{self.query}: Failed to retrieve search results and received faulty response instead.")
+            if not YfConfig().hide_exceptions:
+                raise
+            self._logger.error(f"{self.query}: 'search' fetch received faulty data")
             data = {}
 
         self._response = data

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -39,6 +39,7 @@ from dateutil.relativedelta import relativedelta
 from pytz import UnknownTimeZoneError
 
 from yfinance import const
+from yfinance.exceptions import YFException
 
 # From https://stackoverflow.com/a/59128615
 def attributes(obj):
@@ -48,6 +49,13 @@ def attributes(obj):
     return {
         name: getattr(obj, name) for name in dir(obj)
         if name[0] != '_' and name not in disallowed_names and hasattr(obj, name)}
+
+
+@lru_cache(maxsize=20)
+def print_once(msg):
+    # 'warnings' module suppression of repeat messages does not work.
+    # This function replicates correct behaviour
+    print(msg)
 
 
 # Logging
@@ -696,14 +704,10 @@ def fix_Yahoo_returning_live_separate(quotes, interval, tz_exchange, prepost, re
 
 
 def safe_merge_dfs(df_main, df_sub, interval):
-    if df_sub.empty:
-        raise Exception("No data to merge")
     if df_main.empty:
         return df_main
 
     data_cols = [c for c in df_sub.columns if c not in df_main]
-    if len(data_cols) > 1:
-        raise Exception("Expected 1 data col")
     data_col = data_cols[0]
 
     df_main = df_main.sort_index()
@@ -780,7 +784,7 @@ def safe_merge_dfs(df_main, df_sub, interval):
     f_outOfRange = indices == -1
     if f_outOfRange.any():
         if intraday or interval in ['1d', '1wk']:
-            raise Exception(f"The following '{data_col}' events are out-of-range, did not expect with interval {interval}: {df_sub.index[f_outOfRange]}")
+            raise YFException(f"The following '{data_col}' events are out-of-range, did not expect with interval {interval}: {df_sub.index[f_outOfRange]}")
         get_yf_logger().debug(f'Discarding these {data_col} events:' + '\n' + str(df_sub[f_outOfRange]))
         df_sub = df_sub[~f_outOfRange].copy()
         indices = indices[~f_outOfRange]
@@ -802,7 +806,7 @@ def safe_merge_dfs(df_main, df_sub, interval):
             df = df.groupby("_NewIndex").prod()
             df.index.name = None
         else:
-            raise Exception(f"New index contains duplicates but unsure how to aggregate for '{data_col_name}'")
+            raise YFException(f"New index contains duplicates but unsure how to aggregate for '{data_col_name}'")
         if "_NewIndex" in df.columns:
             df = df.drop("_NewIndex", axis=1)
         return df
@@ -814,7 +818,7 @@ def safe_merge_dfs(df_main, df_sub, interval):
     f_na = df[data_col].isna()
     data_lost = sum(~f_na) < df_sub.shape[0]
     if data_lost:
-        raise Exception('Data was lost in merge, investigate')
+        raise YFException('Data was lost in merge, investigate')
 
     return df
 


### PR DESCRIPTION
Stop hiding exceptions if `yf.set_config(hide_exceptions=False)`. Because hiding exceptions makes bugs difficult to manage.

But also improve handling exceptions by replacing with more meaningful. E.g. replace 404 with YFTickerMissingError ... possible delisted

Fix https://github.com/ranaroussi/yfinance/issues/2213