### PR TITLE
Financials: ensure dtype float

### DIFF
--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -159,6 +159,10 @@ class Financials:
 
         df.index = df.index.str.replace("^" + timescale, "", regex=True)
 
+        # Ensure float type, not object
+        for d in df.columns:
+            df[d] = df[d].astype('float')
+
         # Reorder table to match order on Yahoo website
         df = df.reindex([k for k in keys if k in df.index])
         df = df[sorted(df.columns, reverse=True)]


### PR DESCRIPTION
Not sure how long the financials tables have been `object` dtype not `float`. Suddenly my codes began breaking but I don't see any recent relevant changes.

before:
```
>>> dat.income_stmt.dtypes
2024-12-31    object
2023-12-31    object
2022-12-31    object
2021-12-31    object
2020-12-31    object
dtype: object
```

after:
```
>>> dat.income_stmt.dtypes
2024-12-31    float64
2023-12-31    float64
2022-12-31    float64
2021-12-31    float64
2020-12-31    float64
```