### PR TITLE
Fix test_ticker unit test failure due to NEPT delisting

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -983,7 +983,7 @@ class TestTickerInfo(unittest.TestCase):
         self.symbols.append("QCSTIX")  # good for testing, doesn't trade
         self.symbols += ["BTC-USD", "IWO", "VFINX", "^GSPC"]
         self.symbols += ["SOKE.IS", "ADS.DE"]  # detected bugs
-        self.symbols += ["EXTO", "NEPT" ] # Issues 2343 and 2363
+        self.symbols += ["EXTO" ] # Issues 2343
         self.tickers = [yf.Ticker(s, session=self.session) for s in self.symbols]
 
     def tearDown(self):
@@ -1034,15 +1034,6 @@ class TestTickerInfo(unittest.TestCase):
         data = self.tickers[10].info
         self.assertCountEqual(['quoteType', 'symbol', 'underlyingSymbol', 'uuid', 'maxAge', 'trailingPegRatio'], data.keys())
         self.assertIn("trailingPegRatio", data.keys(), "Did not find expected key 'trailingPegRatio' in info dict")
-
-        # Test issue 2363 (Empty QuoteResponse)
-        data = self.tickers[11].info
-        expected_keys = ['maxAge', 'priceHint', 'previousClose', 'open', 'dayLow', 'dayHigh', 'regularMarketPreviousClose',
-                         'regularMarketOpen', 'regularMarketDayLow', 'regularMarketDayHigh', 'volume', 'regularMarketVolume',
-                         'bid', 'ask', 'bidSize', 'askSize', 'fiftyTwoWeekLow', 'fiftyTwoWeekHigh', 'currency', 'tradeable',
-                         'exchange', 'quoteType', 'symbol', 'underlyingSymbol', 'shortName', 'timeZoneFullName', 'timeZoneShortName',
-                         'uuid', 'gmtOffSetMilliseconds', 'trailingPegRatio']
-        self.assertCountEqual(expected_keys, data.keys())
 
     # def test_fast_info_matches_info(self):
     #     fast_info_keys = set()


### PR DESCRIPTION
This PR fixes the bug in: https://github.com/ranaroussi/yfinance/issues/2576

The unit test now pass:

```
python3 -m unittest tests.test_ticker
```

```
Ran 64 tests in 25.539s

OK
```