### PR TITLE
Update index.rst - duplicate market reference

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -23,7 +23,6 @@ The following are the publicly available classes, and functions exposed by the `
 - :class:`AsyncWebSocket <yfinance.AsyncWebSocket>`: Class for asynchronously streaming live market data.
 - :attr:`Sector <yfinance.Sector>`: Domain class for accessing sector information.
 - :attr:`Industry <yfinance.Industry>`: Domain class for accessing industry information.
-- :attr:`Market <yfinance.Market>`: Class for accessing market status & summary.
 - :attr:`EquityQuery <yfinance.EquityQuery>`: Class to build equity query filters.
 - :attr:`FundQuery <yfinance.FundQuery>`: Class to build fund query filters.
 - :attr:`screen <yfinance.screen>`: Run equity/fund queries.


### PR DESCRIPTION
The market reference in the documentation (https://ranaroussi.github.io/yfinance/reference/api/yfinance.Market.html#) is duplicated.