### PR TITLE
Fix earnings_dates

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -44,6 +44,11 @@ from .scrapers.funds import FundsData
 
 from .const import _BASE_URL_, _ROOT_URL_, _QUERY1_URL_, _SENTINEL_
 
+from io import StringIO
+from bs4 import BeautifulSoup
+from dateutil import parser
+from zoneinfo import ZoneInfo
+
 
 _tz_info_fetch_ctr = 0
 
@@ -706,7 +711,97 @@ class TickerBase:
         return self._news
 
     @utils.log_indent_decorator
-    def get_earnings_dates(self, limit=12, proxy=_SENTINEL_) -> Optional[pd.DataFrame]:
+    def get_earnings_dates_using_scrape(self, limit = 12, offset = 0) -> Optional[pd.DataFrame]:
+        """
+        Uses YfData.cache_get() to scrape earnings data from YahooFinance.
+        (https://finance.yahoo.com/calendar/earnings?symbol=INTC)
+    
+        Args:
+            limit (int): Number of rows to extract (max=100)
+            offset (int): if 0, search from future EPS estimates. 
+                          if 1, search from the most recent EPS. 
+                          if x, search from x'th recent EPS. 
+    
+        Returns:
+            pd.DataFrame in the following format.
+    
+                       EPS Estimate Reported EPS Surprise(%)
+            Date
+            2025-10-30         2.97            -           -
+            2025-07-22         1.73         1.54      -10.88
+            2025-05-06         2.63          2.7        2.57
+            2025-02-06         2.09         2.42       16.06
+            2024-10-31         1.92         1.55      -19.36
+            ...                 ...          ...         ...
+            2014-07-31         0.61         0.65        7.38
+            2014-05-01         0.55         0.68       22.92
+            2014-02-13         0.55         0.58        6.36
+            2013-10-31         0.51         0.54        6.86
+            2013-08-01         0.46          0.5        7.86
+        """
+        #####################################################
+        # Define Constants
+        #####################################################
+        if limit > 0 and limit <= 25:
+            size = 25
+        elif limit > 25 and limit <= 50:
+            size = 50
+        elif limit > 50 and limit <= 100:
+            size = 100
+        else:
+            raise ValueError("Please use limit <= 100")
+    
+        # Define the URL
+        url = "https://finance.yahoo.com/calendar/earnings?symbol={}&offset={}&size={}".format(
+            self.ticker, offset, size
+        )
+        #####################################################
+        # Get data
+        #####################################################
+        response = self._data.cache_get(url)
+    
+        #####################################################
+        # Response -> pd.DataFrame
+        #####################################################
+        # Parse the HTML content using BeautifulSoup
+        soup = BeautifulSoup(response.text, "html.parser")
+        # This page should have only one <table>
+        table = soup.find("table")
+        # If the table is found
+        if table:
+            # Get the HTML string of the table
+            table_html = str(table)
+    
+            # Wrap the HTML string in a StringIO object
+            html_stringio = StringIO(table_html)
+    
+            # Pass the StringIO object to pd.read_html()
+            df = pd.read_html(html_stringio)[0]
+            df = df.dropna(subset=["Symbol", "Company", "Earnings Date"])
+    
+            # praser.parse doesn't understand "EDT", "EST"
+            tzinfos = {
+                "EDT": ZoneInfo("America/New_York"),
+                "EST": ZoneInfo("America/New_York"),
+            }
+            df.index = df["Earnings Date"].apply(
+                lambda date_str: parser.parse(date_str, tzinfos=tzinfos).strftime(
+                    "%Y-%m-%d"
+                )
+            )
+            df.index.name = "Date"
+            # Remove "+" sign from Surprise(%)
+            df["Surprise (%)"] = df["Surprise (%)"].apply(
+                lambda x: str(x[1:]) if x[0] == "+" else str(x)
+            )
+            df = df.drop(["Earnings Date", "Company", "Symbol"], axis=1)
+    
+        else:
+            raise ValueError("Table not found on the page.")
+        return df
+
+    @utils.log_indent_decorator
+    def get_earnings_dates_using_screener(self, limit=12, proxy=_SENTINEL_) -> Optional[pd.DataFrame]:
         """
         Get earning dates (future and historic)
         

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -2,6 +2,7 @@ import functools
 from functools import lru_cache
 
 from curl_cffi import requests
+from urllib.parse import urlsplit, urljoin
 from bs4 import BeautifulSoup
 import datetime
 
@@ -425,10 +426,101 @@ class YfData(metaclass=SingletonMeta):
     @lru_cache_freezeargs
     @lru_cache(maxsize=cache_maxsize)
     def cache_get(self, url, params=None, timeout=30):
-        return self.get(url, params, timeout)
+
+        response = self.get(url, params, timeout)
+
+        # Accept cookie-consent if redirected to consent page
+        if not self._is_this_consent_url(response.url):
+            # "Consent Page not detected"
+            pass
+        else:
+            # "Consent Page detected"
+            response = self._accept_consent_form(response, timeout)
+
+        return response
 
     def get_raw_json(self, url, params=None, timeout=30):
         utils.get_yf_logger().debug(f'get_raw_json(): {url}')
         response = self.get(url, params=params, timeout=timeout)
         response.raise_for_status()
         return response.json()
+
+    def _is_this_consent_url(self, response_url: str) -> bool:
+        """
+        Check if given response_url is consent page
+
+        Args:
+            response_url (str) : response.url
+    
+        Returns:
+            True : This is cookie-consent page
+            False : This is not cookie-consent page
+        """
+        try:
+            return urlsplit(response_url).hostname and urlsplit(
+                response_url
+            ).hostname.endswith("consent.yahoo.com")
+        except Exception:
+            return False
+
+    def _accept_consent_form(
+        self, consent_resp: requests.Response, timeout: int
+    ) -> requests.Response:
+        """
+        Click 'Accept all' to cookie-consent form and return response object.
+
+        Args:
+            consent_resp (requests.Response) : Response instance of cookie-consent page
+            timeout (int) : Raise TimeoutError if post doesn't respond
+    
+        Returns:
+            response (requests.Response) : Reponse instance received from the server after accepting cookie-consent post.
+        """
+        soup = BeautifulSoup(consent_resp.text, "html.parser")
+    
+        # Heuristic: pick the first form; Yahoo's CMP tends to have a single form for consent
+        form = soup.find("form")
+        if not form:
+            return consent_resp
+    
+        # action : URL to send "Accept Cookies"
+        action = form.get("action") or consent_resp.url
+        action = urljoin(consent_resp.url, action)
+    
+        # Collect inputs (hidden tokens, etc.)
+        """
+        <input name="csrfToken" type="hidden" value="..."/>
+        <input name="sessionId" type="hidden" value="..."/>
+        <input name="originalDoneUrl" type="hidden" value="..."/>
+        <input name="namespace" type="hidden" value="yahoo"/>
+        """
+        data = {}
+        for inp in form.find_all("input"):
+            name = inp.get("name")
+            if not name:
+                continue
+            typ = (inp.get("type") or "text").lower()
+            val = inp.get("value") or ""
+    
+            if typ in ("checkbox", "radio"):
+                # If it's clearly an "agree"/"accept" field or already checked, include it
+                if (
+                    "agree" in name.lower()
+                    or "accept" in name.lower()
+                    or inp.has_attr("checked")
+                ):
+                    data[name] = val if val != "" else "1"
+            else:
+                data[name] = val
+    
+        # If no explicit agree/accept in inputs, add a best-effort flag
+        lowered = {k.lower() for k in data.keys()}
+        if not any(("agree" in k or "accept" in k) for k in lowered):
+            data["agree"] = "1"
+    
+        # Submit the form with "Referer". Some servers check this header as a simple CSRF protection measure.
+        headers = {"Referer": consent_resp.url}
+        response = self._session.post(
+            action, data=data, headers=headers, timeout=timeout, allow_redirects=True
+        )
+        return response


### PR DESCRIPTION
TLDR;
pip uninstall yfinance
pip install git+https://github.com/hjlgood/yfinance.git
use function `Ticker.get_earnings_dates_using_scrape()`

---

Regarding https://github.com/ranaroussi/yfinance/issues/2566,

The current API does not fetch the most recent earnings data.
https://github.com/ranaroussi/yfinance/issues/2566#issuecomment-3111510412

This is a huge deal breaker that hasn't been fixed for quite a while.

As a work-around, I have implemented a function "get_earnings_dates_using_selenium" to scrap from the following link :
https://finance.yahoo.com/calendar/earnings?symbol=ERIE
(symbol is subject to change)

"get_earnings_dates_using_selenium" works pretty much the same as "get_earnings_dates"
but it requires "selenium" and "webdriver_manager" package in requirements.txt.

I understand that using selenium is not favorable because it's slow and it also brings more dependencies, 
but I think it is better than not fetching recent earnings data.

please take a look!