### PR TITLE
Fix: Correct 30m interval alignment and filtering for NSE/early-open markets

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -320,8 +320,8 @@ class PriceHistory:
             })
 
         # Note: ordering is important. If you change order, run the tests!
-        quotes = utils.set_df_tz(quotes, params["interval"], tz_exchange)
-        quotes = utils.fix_Yahoo_dst_issue(quotes, params["interval"])
+        quotes = utils.set_df_tz(quotes, interval, tz_exchange)
+        quotes = utils.fix_Yahoo_dst_issue(quotes, interval)
         intraday = params["interval"][-1] in ("m", 'h')
         if not prepost and intraday and "tradingPeriods" in self._history_metadata:
             tps = self._history_metadata["tradingPeriods"]
@@ -329,7 +329,7 @@ class PriceHistory:
                 self._history_metadata = utils.format_history_metadata(self._history_metadata, tradingPeriodsOnly=True)
                 self._history_metadata_formatted = True
                 tps = self._history_metadata["tradingPeriods"]
-            quotes = utils.fix_Yahoo_returning_prepost_unrequested(quotes, params["interval"], tps)
+            quotes = utils.fix_Yahoo_returning_prepost_unrequested(quotes, interval, tps)
         if quotes.empty:
             msg = f'{self.ticker}: OHLC after cleaning: EMPTY'
         elif len(quotes) == 1:

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -601,7 +601,8 @@ def fix_Yahoo_returning_prepost_unrequested(quotes, interval, tradingPeriods):
     quotes.index = idx
     # "end" = end of regular trading hours (including any auction)
     f_drop = quotes.index >= quotes["end"]
-    f_drop = f_drop | (quotes.index < quotes["start"])
+    td = _interval_to_timedelta(interval)
+    f_drop = f_drop | (quotes.index + td <= quotes["start"])
     if f_drop.any():
         # When printing report, ignore rows that were already NaNs:
         # f_na = quotes[["Open","Close"]].isna().all(axis=1)


### PR DESCRIPTION
Fixes #1436 

### Problem
When requesting `interval="30m"` for tickers like `^NSEI`, the first 15 minutes (09:15-09:30 IST) were dropped because they fell into a 09:00 bucket which the filter deemed "pre-market".

### Fix
1.  **`scrapers/history.py`**: Passed correct `interval` to cleaner functions.
2.  **`utils.py`**: Relaxed filtering to keep candles that *overlap* the market open (end > open), protecting the 09:00-09:30 candle.

### Verification
- Verified `^NSEI` 30m data now includes the 09:15 open.
- Passed `tests/test_prices.py` (22/22).