### PR TITLE
Fix: Set period default to None in multi

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -252,7 +252,7 @@ def _realign_dfs():
 @_multitasking.task
 def _download_one_threaded(ticker, start=None, end=None,
                            auto_adjust=False, back_adjust=False, repair=False,
-                           actions=False, progress=True, period="max",
+                           actions=False, progress=True, period=None,
                            interval="1d", prepost=False,
                            keepna=False, rounding=False, timeout=10):
     _download_one(ticker, start, end, auto_adjust, back_adjust, repair,
@@ -264,7 +264,7 @@ def _download_one_threaded(ticker, start=None, end=None,
 
 def _download_one(ticker, start=None, end=None,
                   auto_adjust=False, back_adjust=False, repair=False,
-                  actions=False, period="max", interval="1d",
+                  actions=False, period=None, interval="1d",
                   prepost=False, rounding=False,
                   keepna=False, timeout=10):
     data = None

--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -46,7 +46,7 @@ class Tickers:
         #     "Tickers", ticker_objects.keys(), rename=True
         # )(*ticker_objects.values())
 
-    def history(self, period="1mo", interval="1d",
+    def history(self, period=None, interval="1d",
                 start=None, end=None, prepost=False,
                 actions=True, auto_adjust=True, repair=False,
                 threads=True, group_by='column', progress=True,
@@ -59,7 +59,7 @@ class Tickers:
             threads, group_by, progress,
             timeout, **kwargs)
 
-    def download(self, period="1mo", interval="1d",
+    def download(self, period=None, interval="1d",
                  start=None, end=None, prepost=False,
                  actions=True, auto_adjust=True, repair=False, 
                  threads=True, group_by='column', progress=True,


### PR DESCRIPTION
Set `period` default to `None` to avoid error when using `start` and `end` in `Tickers.history`: 
```
ValueError('Setting period, start and end is nonsense. Set maximum 2 of them.')
```
Fixes #2649