### PR TITLE
Fix broken contributing link in PyPI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Install `yfinance` from PYPI using `pip`:
 $ pip install yfinance
 ```
 
-### [yfinance relies on the community to investigate bugs and contribute code. Here's how you can help.](CONTRIBUTING.md)
+### [yfinance relies on the community to investigate bugs and contribute code. Here's how you can help.](https://github.com/ranaroussi/yfinance/blob/main/CONTRIBUTING.md)
 
 ---
 


### PR DESCRIPTION
### Description
This PR fixes the broken "Contributing" link on the PyPI project page, as reported in issue #2659.

### Problem
Relative links (like `[link](file.md)`) in README do not render correctly on PyPI, resulting in a 404 error when users try to read the contribution guide.

### Solution
Updated the link to use the absolute GitHub URL, ensuring it works on both GitHub and PyPI.

Fixes #2659