### PR TITLE
Fix Python 3.9 compatibility regression in calendars.py

### DIFF
--- a/yfinance/calendars.py
+++ b/yfinance/calendars.py
@@ -1,5 +1,6 @@
+from __future__ import annotations # Just in case
 import json
-from typing import Any, Optional
+from typing import Any, Optional, List, Union, Dict
 import warnings
 import numpy as np
 from requests import Session, Response, exceptions
@@ -30,7 +31,7 @@ class CalendarQuery:
     ```
     """
 
-    def __init__(self, operator: str, operand: list[Any] | list["CalendarQuery"]):
+    def __init__(self, operator: str, operand: Union[List[Any], List["CalendarQuery"]]):
         """
         :param operator: Operator string, e.g., 'eq', 'gte', 'and', 'or'.
         :param operand: List of operands: can be values (str, int), or other Operands instances (nested).
@@ -179,8 +180,8 @@ class Calendars:
 
     def __init__(
         self,
-        start: Optional[str | datetime | date] = None,
-        end: Optional[str | datetime | date] = None,
+        start: Optional[Union[str, datetime, date]] = None,
+        end: Optional[Union[str, datetime, date]] = None,
         session: Optional[Session] = None,
     ):
         """
@@ -208,9 +209,9 @@ class Calendars:
         self._most_active_qy: CalendarQuery = CalendarQuery("or", [])
 
         self._cache_request_body = {}
-        self.calendars: dict[str, pd.DataFrame] = {}
+        self.calendars: Dict[str, pd.DataFrame] = {}
 
-    def _parse_date_param(self, _date: Optional[str | datetime | date | int]) -> str:
+    def _parse_date_param(self, _date: Optional[Union[str, datetime, date, int]]) -> str:
         if not _date:
             return ""
         else:


### PR DESCRIPTION
### **User description**
Fixes #2672 Python 3.9 Compatability



___

### **PR Type**
Bug fix


___

### **Description**
- Added `__future__ import annotations` for forward references

- Updated type hints with `Union`, `List`, `Dict`

- Modified method signatures for Python 3.9 compatibility Replace PEP 604 unions + builtin generics with `typing.Union` + `typing.List` / `typing.Dict` in `yfinance/calendars.py`.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[Add __future__ import] --> B[Update type hints]
  B --> C[Modify method signatures]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calendars.py`</strong><dd><code>Update type hints and imports for Python 3.9 compatibility</code></dd></summary>
<hr>

`yfinance/calendars.py`

<ul><li>Added <code>__future__ import annotations</code><br> <li> Updated type hints using <code>Union</code>, <code>List</code>, <code>Dict</code><br> <li> Modified method signatures for compatibility</ul>


</details>


  </td>
  <td><a href=""></a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

## PR Reviewer Guide 🔍

Here are some key observations to aid the review process:

<table>
<tr><td>⏱️&nbsp;<strong>Estimated effort to review</strong>: 2 🔵🔵⚪⚪⚪</td></tr>
<tr><td>🧪&nbsp;<strong>No relevant tests</strong></td></tr>
<tr><td>🔒&nbsp;<strong>No security concerns identified</strong></td></tr>
<tr><td>⚡&nbsp;<strong>Recommended focus areas for review</strong><br><br>

<details><summary><a href='https://github.com/orionnelson/yfinance/pull/1/files#diff-d7097337c717ba06dbd9cdcd11baff678eb89603580c9e93cc32cba3531bde36R183-R184'><strong>Missing datetime import</strong></a>

The method signatures use datetime and date types without importing them, which will raise NameError.
</summary>

```python
start: Optional[Union[str, datetime, date]] = None,
end: Optional[Union[str, datetime, date]] = None,
```

</details>

</td></tr>
</table>


## PR Code Suggestions ✨
<!-- a3a63f0 -->

Latest suggestions up to a3a63f0
<table><thead><tr><td><strong>Category</strong></td><td align=left><strong>Suggestion&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></td><td align=center><strong>Impact</strong></td></tr><tbody><tr><td rowspan=1>Possible issue</td>
<td>



<details><summary>Handle integer date inputs safely</summary>

___


**Check that <code>_date</code> is not an integer before calling <code>_parse_user_dt</code>, as the helper <br>expects a date-like object and may raise errors with raw timestamps. If integer <br>timestamps are intended, convert them to a datetime first.**

[yfinance/calendars.py [214]](https://github.com/orionnelson/yfinance/pull/1/files#diff-d7097337c717ba06dbd9cdcd11baff678eb89603580c9e93cc32cba3531bde36R214-R214)

```diff
-def _parse_date_param(self, _date: Optional[Union[str, datetime, date, int]]) -> str:
+def _parse_date_param(self, _date: Optional[Union[str, datetime, date]] ) -> str:
```
<details><summary>Suggestion importance[1-10]: 6</summary>

__

Why: The change tightens the type hint for `_date` but does not add the suggested runtime check for integers, limiting its safety impact.


</details></details></td><td align=center>Low

</td></tr></tr></tbody></table>

___

#### Previous suggestions
<details><summary>Suggestions up to commit 994a97d</summary>
<br><table><thead><tr><td><strong>Category</strong></td><td align=left><strong>Suggestion&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </strong></td><td align=center><strong>Impact</strong></td></tr><tbody><tr><td rowspan=1>Possible issue</td>
<td>



<details><summary>Fix syntax assignment spacing</summary>

___


**The assignment line is missing a space between the type annotation and the equals <br>sign, which causes a syntax error. Adding the space resolves the parsing issue and <br>makes the code valid Python.**

[yfinance/calendars.py [212]](https://github.com/orionnelson/yfinance/pull/1/files#diff-d7097337c717ba06dbd9cdcd11baff678eb89603580c9e93cc32cba3531bde36R212-R212)

```diff
-self.calendars: Dict[str, pd.DataFrame]= {}
+self.calendars: Dict[str, pd.DataFrame] = {}
```
<details><summary>Suggestion importance[1-10]: 7</summary>

__

Why: The line `self.calendars: Dict[str, pd.DataFrame]= {}` lacks a space before `=`, causing a syntax error; adding the space makes it valid Python.


</details></details></td><td align=center>Medium

</td></tr></tr></tbody></table>

</details>

