### PR TITLE
Docs: clarify debug logging config and deprecate enable_debug_mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -62,8 +62,14 @@ body:
   - type: textarea
     id: debug-log
     attributes:
-      label: "Debug log from yf.enable_debug_mode()"
-      description: "Run code with debug logging enabled - `yf.enable_debug_mode()` - and post the full output. Context: https://github.com/ranaroussi/yfinance/tree/main#logging"
+      label: "Debug log with debug logging enabled"
+      description: |
+        Enable debug logging, reproduce the issue, then paste the full output:
+
+            import yfinance as yf
+            yf.config.debug.logging = True
+
+        Context: https://ranaroussi.github.io/yfinance/advanced/logging.html
     validations:
       required: true
 

--- a/doc/source/advanced/logging.rst
+++ b/doc/source/advanced/logging.rst
@@ -8,4 +8,4 @@ If debugging, you can switch to debug mode with custom formatting using:
 .. code-block:: python
 
    import yfinance as yf
-   yf.enable_debug_mode()
+   yf.config.debug.logging = True

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -27,7 +27,7 @@ The following are the publicly available classes, and functions exposed by the `
 - :attr:`EquityQuery <yfinance.EquityQuery>`: Class to build equity query filters.
 - :attr:`FundQuery <yfinance.FundQuery>`: Class to build fund query filters.
 - :attr:`screen <yfinance.screen>`: Run equity/fund queries.
-- :attr:`enable_debug_mode <yfinance.enable_debug_mode>`: Function to enable debug mode for logging.
+- :attr:`config.debug.logging <yfinance.config>`: Enable verbose debug logging (``yf.config.debug.logging = True``).
 - :attr:`set_tz_cache_location <yfinance.set_tz_cache_location>`: Function to set the timezone cache location.
 
 .. toctree::


### PR DESCRIPTION
Align logging documentation with the config-based API (`yf.config.debug.logging`) and clarify
where debug logs are emitted.

Marks `enable_debug_mode()` as deprecated in docs while keeping it documented for backward
compatibility.

Addresses logging confusion reported in #2686.
