### PR TITLE
fix: correct typo 'recieved' to 'received'

### DIFF
--- a/yfinance/domain/market.py
+++ b/yfinance/domain/market.py
@@ -28,7 +28,7 @@ class Market:
         except _json.JSONDecodeError:
             if not YfConfig.debug.hide_exceptions:
                 raise
-            self._logger.error(f"{self.market}: Failed to retrieve market data and recieved faulty data.")
+            self._logger.error(f"{self.market}: Failed to retrieve market data and received faulty data.")
             return {}
         
     def _parse_data(self):


### PR DESCRIPTION
Fixes typo in error message in `market.py`.