### PR TITLE
Fix repair=True crash on read-only numpy arrays

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -2698,12 +2698,12 @@ class PriceHistory:
             # very volatile which reduces ability to detect genuine stock split errors
             _1d_change_x = np.full((n, 2), 1.0)
             price_data_cols = ['Open','Close']
-            price_data = df2[price_data_cols].to_numpy()
+            price_data = df2[price_data_cols].to_numpy(copy=True)
             f_zero = price_data == 0.0
         else:
             _1d_change_x = np.full((n, 4), 1.0)
             price_data_cols = OHLC
-            price_data = df2[price_data_cols].to_numpy()
+            price_data = df2[price_data_cols].to_numpy(copy=True)
             f_zero = price_data == 0.0
         if f_zero.any():
             price_data[f_zero] = 1.0


### PR DESCRIPTION
## Summary
- use `to_numpy(copy=True)` when extracting OHLC arrays in `_fix_prices_sudden_change`
- add a regression test that simulates read-only `DataFrame.to_numpy()` views and verifies repair does not crash

## Why
Issue #2688 reports `ValueError: output array is read-only` when `repair=True`.

## Validation
- `python3 -m compileall yfinance/scrapers/history.py tests/test_price_repair.py`

Closes #2688
