### PR TITLE
Fix "Nonetype is not iterable" crash in _fetch_info()

### DIFF
--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -617,7 +617,7 @@ class Quote:
             result = additional_info
 
         query1_info = {}
-        if result is not None
+        if result is not None:
             for quote in ["quoteSummary", "quoteResponse"]:
                 if quote in result and len(result[quote]["result"]) > 0:
                     result[quote]["result"][0]["symbol"] = self._symbol

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -617,16 +617,17 @@ class Quote:
             result = additional_info
 
         query1_info = {}
-        for quote in ["quoteSummary", "quoteResponse"]:
-            if quote in result and len(result[quote]["result"]) > 0:
-                result[quote]["result"][0]["symbol"] = self._symbol
-                query_info = next(
-                    (info for info in result.get(quote, {}).get("result", [])
-                    if info["symbol"] == self._symbol),
-                    None,
-                )
-                if query_info:
-                    query1_info.update(query_info)
+        if result is not None:
+            for quote in ["quoteSummary", "quoteResponse"]:
+                if quote in result and len(result[quote]["result"]) > 0:
+                    result[quote]["result"][0]["symbol"] = self._symbol
+                    query_info = next(
+                        (info for info in result.get(quote, {}).get("result", [])
+                        if info["symbol"] == self._symbol),
+                        None,
+                    )
+                    if query_info:
+                        query1_info.update(query_info)
 
         # Normalize and flatten nested dictionaries while converting maxAge from days (1) to seconds (86400).
         # This handles Yahoo Finance API inconsistency where maxAge is sometimes expressed in days instead of seconds.

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -617,16 +617,17 @@ class Quote:
             result = additional_info
 
         query1_info = {}
-        for quote in ["quoteSummary", "quoteResponse"]:
-            if quote in result and len(result[quote]["result"]) > 0:
-                result[quote]["result"][0]["symbol"] = self._symbol
-                query_info = next(
-                    (info for info in result.get(quote, {}).get("result", [])
-                    if info["symbol"] == self._symbol),
-                    None,
-                )
-                if query_info:
-                    query1_info.update(query_info)
+        if result is not None
+            for quote in ["quoteSummary", "quoteResponse"]:
+                if quote in result and len(result[quote]["result"]) > 0:
+                    result[quote]["result"][0]["symbol"] = self._symbol
+                    query_info = next(
+                        (info for info in result.get(quote, {}).get("result", [])
+                        if info["symbol"] == self._symbol),
+                        None,
+                    )
+                    if query_info:
+                        query1_info.update(query_info)
 
         # Normalize and flatten nested dictionaries while converting maxAge from days (1) to seconds (86400).
         # This handles Yahoo Finance API inconsistency where maxAge is sometimes expressed in days instead of seconds.


### PR DESCRIPTION
Currently, if both `result` and `additional_info` are `None`, the line `if quote in result and len(result[quote]["result"]) > 0:` crashes.

This PR adds a simple check whether `result` is `None`.

Note this error is quite rare and unpredictable. It does not consistently occur for the same tickers.

I'll attach my log of when I encountered the crash:
```
Company - A1ZXY7.SG
HTTP Error 404: {"quoteSummary":{"result":null,"error":{"code":"Not Found","description":"Quote not found for symbol: A1ZXY7.SG"}}}
Failed to perform, curl: (16) . See https://curl.se/libcurl/c/libcurl-errors.html first for more details.
ERROR: Company - Builder: Error while parsing StaticCompanyData t=A1ZXY7.SG: argument of type 'NoneType' is not iterable
ERROR: CompanyList - Builder: Error while building CompanyList: argument of type 'NoneType' is not iterable
FATAL ERROR - The program will now exit
Traceback (most recent call last):
  File "/home/user/VSProjects/StockPicker9000/./stockpicker9000.py", line 166, in <module>
    companies = sd.CompanyList(ticker_dataframe)
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 49, in __init__
    Log.e(self._TAG, f"Builder: Error while building CompanyList", exception=e, fatal=True)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/VSProjects/StockPicker9000/utils.py", line 210, in e
    raise exception
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 43, in __init__
    self._company_list_init(i)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 58, in _company_list_init
    self.company_list[ticker] = Company(ticker)
                                ~~~~~~~^^^^^^^^
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 390, in __init__
    self.set_static_company_data()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 437, in set_static_company_data
    Log.e(self._TAG, f"Builder: Error while parsing StaticCompanyData t={self.ticker}", exception=e)
    ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/VSProjects/StockPicker9000/utils.py", line 210, in e
    raise exception
  File "/home/user/VSProjects/StockPicker9000/stockdata.py", line 410, in set_static_company_data
    company_info = self.company.get_info() # TODO: DEBUG - Crash in yfinance raised here - investigate and submit patch?
  File "/home/user/VSProjects/StockPicker9000/env/lib/python3.13/site-packages/yfinance/base.py", line 282, in get_info
    data = self._quote.info
           ^^^^^^^^^^^^^^^^
  File "/home/user/VSProjects/StockPicker9000/env/lib/python3.13/site-packages/yfinance/scrapers/quote.py", line 503, in info
    self._fetch_info()
    ~~~~~~~~~~~~~~~~^^
  File "/home/user/VSProjects/StockPicker9000/env/lib/python3.13/site-packages/yfinance/scrapers/quote.py", line 621, in _fetch_info
    if quote in result and len(result[quote]["result"]) > 0:
       ^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```