### PR TITLE
Tickers: validate conflicting date args before download

### DIFF
--- a/tests/test_tickers.py
+++ b/tests/test_tickers.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import patch
+
+from tests.context import yfinance as yf
+
+
+class TestTickers(unittest.TestCase):
+    def test_download_rejects_period_start_end_together(self):
+        tickers = yf.Tickers("AAPL MSFT")
+
+        with self.assertRaises(ValueError) as exc:
+            tickers.download(period="1mo", start="2025-01-01", end="2025-02-01", progress=False)
+
+        self.assertIn("at most 2", str(exc.exception))
+
+    @patch("yfinance.tickers.multi.download")
+    def test_history_forwards_when_date_args_valid(self, mock_download):
+        mock_download.return_value = {"AAPL": None}
+        tickers = yf.Tickers("AAPL")
+
+        tickers.history(period=None, start="2025-01-01", end="2025-02-01", progress=False, group_by="ticker")
+
+        self.assertTrue(mock_download.called)

--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -28,6 +28,13 @@ from .data import YfData
 
 class Tickers:
 
+    @staticmethod
+    def _validate_period_start_end(period, start, end):
+        if period is not None and start is not None and end is not None:
+            raise ValueError(
+                "Too many date parameters: provide at most 2 of 'period', 'start', and 'end'."
+            )
+
     def __repr__(self):
         return f"yfinance.Tickers object <{','.join(self.symbols)}>"
 
@@ -52,6 +59,8 @@ class Tickers:
                 threads=True, group_by='column', progress=True,
                 timeout=10, **kwargs):
 
+        self._validate_period_start_end(period, start, end)
+
         return self.download(
             period, interval,
             start, end, prepost,
@@ -64,6 +73,8 @@ class Tickers:
                  actions=True, auto_adjust=True, repair=False, 
                  threads=True, group_by='column', progress=True,
                  timeout=10, **kwargs):
+
+        self._validate_period_start_end(period, start, end)
 
         data = multi.download(self.symbols,
                               start=start, end=end,


### PR DESCRIPTION
## Summary\n- add explicit validation in  /  for conflicting date arguments\n- raise a clearer  when , , and  are all provided\n- add unit tests for both the validation path and a valid forwarding path\n\n## Why\nIssue #2707 reports confusing behavior around date argument handling on the  entry points. This keeps the existing constraint but surfaces it earlier with clearer wording.\n\nCloses #2707