### PR TITLE
Docs: point Market reference link to detailed module page

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -15,7 +15,7 @@ The following are the publicly available classes, and functions exposed by the `
 
 - :attr:`Ticker <yfinance.Ticker>`: Class for accessing single ticker data.
 - :attr:`Tickers <yfinance.Tickers>`: Class for handling multiple tickers.
-- :attr:`Market <yfinance.Market>`: Class for accessing market summary.
+- :doc:`Market <yfinance.market>`: Class for accessing market summary.
 - :attr:`Calendars <yfinance.Calendars>`: Class for accessing calendar events data.
 - :attr:`download <yfinance.download>`: Function to download market data for multiple tickers.
 - :attr:`Search <yfinance.Search>`: Class for accessing search results.


### PR DESCRIPTION
## Summary
- update the API reference overview to link **Market** to the module docs page (`yfinance.market`) instead of the autogenerated class stub
- keeps the description text unchanged

## Why
Issue #2358 notes that the current Market link lands on an unhelpful stub page, while the module page contains the useful class documentation.

Closes #2358