### PR TITLE
chore: minor doc fixes

### DIFF
--- a/doc/source/development/code.rst
+++ b/doc/source/development/code.rst
@@ -52,7 +52,7 @@ Creating your branch
 Running a branch
 ----------------
 
-Please see `this page </development/running>`_.
+Please see `this page </development/running.html>`_.
 
 Git stuff
 ---------

--- a/doc/source/development/documentation.rst
+++ b/doc/source/development/documentation.rst
@@ -27,8 +27,7 @@ To build the documentation locally, follow these steps:
 
 2. **Build with Sphinx**:
     
-   * After dependencies are installed, use the sphinx-build command to generate HTML documentation. 
-   * Go to ``doc/`` directory Run:
+   * After dependencies are installed, use the sphinx-build command to generate HTML documentation.
 
    .. code-block:: bash
 


### PR DESCRIPTION
This change fixes some stray documentation issues. The first fix addresses a broken link within the  file, while the second removes a line saying to go into the  directory before running the sphinx command to build the documentation.

Broken link shown:
<img width="1646" height="748" alt="Screenshot 2026-03-11 at 9 27 47 PM" src="https://github.com/user-attachments/assets/3df0a183-3f83-4b25-a28e-21bdecad3ab5" />

No second bullet:
<img width="1508" height="342" alt="Screenshot 2026-03-11 at 9 27 09 PM" src="https://github.com/user-attachments/assets/7a385da5-60e6-458a-ae56-cb8afb64a3df" />