### PR TITLE
Docs: Add docstrings to Tickers.history() and Tickers.download()

### DIFF
--- a/yfinance/tickers.py
+++ b/yfinance/tickers.py
@@ -51,7 +51,41 @@ class Tickers:
                 actions=True, auto_adjust=True, repair=False,
                 threads=True, group_by='column', progress=True,
                 timeout=10, **kwargs):
+        """
+        Fetch historical market data for multiple tickers.
 
+        :Parameters:
+            period : str
+                Valid periods: 1d,5d,1mo,3mo,6mo,1y,2y,5y,10y,ytd,max
+                Default: '1mo'
+            interval : str
+                Valid intervals: 1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo
+            start : str
+                Download start date string (YYYY-MM-DD) or datetime, inclusive.
+            end : str
+                Download end date string (YYYY-MM-DD) or datetime, exclusive.
+            prepost : bool
+                Include Pre and Post market data in results? Default is False.
+            actions : bool
+                Download dividend + stock splits data. Default is True.
+            auto_adjust : bool
+                Adjust all OHLC automatically? Default is True.
+            repair : bool
+                Detect currency unit 100x mixups and attempt repair.
+                Default is False.
+            threads : bool / int
+                How many threads to use for mass downloading. Default is True.
+            group_by : str
+                Group by 'column' or 'ticker'. Default is 'column'.
+            progress : bool
+                Show progress bar? Default is True.
+            timeout : float
+                Timeout for requests in seconds. Default is 10.
+
+        :Returns:
+            pandas.DataFrame
+                Historical market data for all tickers
+        """
         return self.download(
             period, interval,
             start, end, prepost,
@@ -61,10 +95,44 @@ class Tickers:
 
     def download(self, period=None, interval="1d",
                  start=None, end=None, prepost=False,
-                 actions=True, auto_adjust=True, repair=False, 
+                 actions=True, auto_adjust=True, repair=False,
                  threads=True, group_by='column', progress=True,
                  timeout=10, **kwargs):
+        """
+        Download historical market data for multiple tickers.
 
+        :Parameters:
+            period : str
+                Valid periods: 1d,5d,1mo,3mo,6mo,1y,2y,5y,10y,ytd,max
+                Default: '1mo'
+            interval : str
+                Valid intervals: 1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo
+            start : str
+                Download start date string (YYYY-MM-DD) or datetime, inclusive.
+            end : str
+                Download end date string (YYYY-MM-DD) or datetime, exclusive.
+            prepost : bool
+                Include Pre and Post market data in results? Default is False.
+            actions : bool
+                Download dividend + stock splits data. Default is True.
+            auto_adjust : bool
+                Adjust all OHLC automatically? Default is True.
+            repair : bool
+                Detect currency unit 100x mixups and attempt repair.
+                Default is False.
+            threads : bool / int
+                How many threads to use for mass downloading. Default is True.
+            group_by : str
+                Group by 'column' or 'ticker'. Default is 'column'.
+            progress : bool
+                Show progress bar? Default is True.
+            timeout : float
+                Timeout for requests in seconds. Default is 10.
+
+        :Returns:
+            pandas.DataFrame
+                Historical market data for all tickers
+        """
         data = multi.download(self.symbols,
                               start=start, end=end,
                               actions=actions,


### PR DESCRIPTION
## Summary

Fixes #2707

Added comprehensive docstrings to `Tickers.history()` and `Tickers.download()` methods to document the correct default value for the `period` parameter.

## Problem

The auto-generated documentation stated that the default for `period` parameter was `None`, but the actual default behavior is `'1mo'` (enforced by `multi.download()`). This caused confusion when users tried to call these methods.

## Changes

- Added docstrings to both `history()` and `download()` methods in `tickers.py`
- Documented that the default `period` value is `'1mo'`
- Listed all valid period values
- Documented all other parameters following existing patterns in `multi.download()`

## Testing

- `python3 -m py_compile yfinance/tickers.py` passes
- Syntax validated

## Quality Checklist

- [x] Documentation fix (addresses an actual issue)
- [x] Clear commit message with issue reference
- [x] Follows existing documentation patterns in the codebase
- [x] Single focused change (documentation only)