### PR TITLE
fix: handle non-numeric dividends/splits values in history scraper [pandas 3.x]

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1156,6 +1156,12 @@ class TestTickerInfo(unittest.TestCase):
     #                     else:
     #                         raise
 
+
+class TestEmptySeries(unittest.TestCase):
+    def test_empty_dividends(self):
+        self.assertTrue(yf.Ticker("AET").dividends.empty)
+
+
 class TestTickerFundsData(unittest.TestCase):
     session = None
 
@@ -1244,6 +1250,7 @@ def suite():
     suite.addTest(TestTickerMiscFinancials('Test misc financials'))
     suite.addTest(TestTickerInfo('Test info & fast_info'))
     suite.addTest(TestTickerFundsData('Test Funds Data'))
+    suite.addTest(TestEmptySeries('Test Empty Series'))
     return suite
 
 

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -402,20 +402,20 @@ class PriceHistory:
         if dividends.shape[0] > 0:
             df = utils.safe_merge_dfs(df, dividends, interval)
         if "Dividends" in df.columns:
-            df.loc[df["Dividends"].isna(), "Dividends"] = 0
+            df["Dividends"] = pd.to_numeric(df["Dividends"], errors="coerce").fillna(0)
         else:
             df["Dividends"] = 0.0
         if splits.shape[0] > 0:
             df = utils.safe_merge_dfs(df, splits, interval)
         if "Stock Splits" in df.columns:
-            df.loc[df["Stock Splits"].isna(), "Stock Splits"] = 0
+            df["Stock Splits"] = pd.to_numeric(df["Stock Splits"], errors="coerce").fillna(0)
         else:
             df["Stock Splits"] = 0.0
         if expect_capital_gains:
             if capital_gains.shape[0] > 0:
                 df = utils.safe_merge_dfs(df, capital_gains, interval)
             if "Capital Gains" in df.columns:
-                df.loc[df["Capital Gains"].isna(), "Capital Gains"] = 0
+                df["Capital Gains"] = pd.to_numeric(df["Capital Gains"], errors="coerce").fillna(0)
             else:
                 df["Capital Gains"] = 0.0
         if df.empty:


### PR DESCRIPTION
# Changes

Replace `.loc[df[col].isna()] = 0` with `pd.to_numeric(..., errors="coerce").fillna(0)` to safely coerce non-numeric values before filling NaN, preventing dtype issues when the API returns unexpected string data.

 Add TestEmptySeries test case to verify dividends are empty for a ticker with no dividend history (AET).

# Context

In pandas 3+, two behavioral changes make the old `.loc[mask, col] = 0` pattern problematic when a column contains only null values:

  1. Stricter dtype enforcement with nullable extension types                                                                                                                                                                           

  Pandas 3 changed how all-null columns are represented after a merge. Previously, they'd default to float64 (using np.nan). In pandas 3+, depending on the dtype backend, the column may be inferred as a nullable extension type      
  (Float64, object, or even null[pyarrow] with the Arrow backend). When you then do:                                                                                                                                                    

```
  df.loc[df["Dividends"].isna(), "Dividends"] = 0
```

  ...this only fills positions where .isna() is True. If the API ever returns non-numeric strings in that column (e.g. "N/A", "0.0"), those are not NaN so they're skipped - leaving a column with mixed types (strings and 0), which   
  causes TypeError downstream.

  2. Copy-on-Write semantics                                                                                                                                                                                                            

  Pandas 3 made Copy-on-Write (CoW) the default. While .loc setitem on the original DataFrame is CoW-safe in theory, doing it on an object-dtype column that came from a merge can trigger unexpected behavior - in some code paths     
  pandas creates an intermediate copy, and the assignment silently has no effect.

  The fix

```
  df["Dividends"] = pd.to_numeric(df["Dividends"], errors="coerce").fillna(0)                                                                                                                                                           
```
                                                                                                                                                                                                                                        
  This is safe because:                                                                                                                                                                                                                 
  - `pd.to_numeric(..., errors="coerce")` converts any non-numeric value (including strings) to NaN before filling                                                                                                                        
  - It replaces the entire column rather than doing an in-place masked assignment, so CoW has no effect                                                                                                                                 
  - The result is always a proper float64 Series regardless of what the API returned   

<img width="1129" height="1190" alt="image" src="https://github.com/user-attachments/assets/7a4501de-4f78-4912-8b83-e157a2a3e2ef" />

# Pandas compatibility (1.x → 2.x → 3.x)                                                                                                                                                                                                
                                                                                                                                                                                                                                        
  The old `.loc[df["Dividends"].isna(), "Dividends"] = 0` pattern worked reliably in pandas 1.x, where all-null columns from a merge consistently used float64 dtype with np.nan, making the `.isna()` mask straightforward. In pandas 2.x, 
  Copy-on-Write was introduced as an opt-in mode and nullable extension types (Float64, Int64) became more common - the assignment still worked in most cases but started producing FutureWarning about chained assignment in certain
  code paths, and behavior could differ depending on the dtype backend. In pandas 3.x, CoW is the default and nullable/Arrow-backed dtypes are used more aggressively, making the .loc masked assignment unreliable as described above. 

  The replacement - `pd.to_numeric(df["Dividends"], errors="coerce").fillna(0)` - is a full-column replacement with no in-place masked assignment, making it safe and consistent across all three major versions.