### PR TITLE
Add Valuation Measures Table from Statistics Page

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -19,6 +19,7 @@ from yfinance.config import YfConfig
 
 import unittest
 # import requests_cache
+from unittest.mock import patch, MagicMock
 from typing import Union, Any, get_args, _GenericAlias
 # from urllib.parse import urlparse, parse_qs, urlencode, urlunparse
 
@@ -1235,6 +1236,54 @@ class TestTickerFundsData(unittest.TestCase):
             sector_weightings = ticker.funds_data.sector_weightings
             self.assertIsInstance(sector_weightings, dict)
 
+class TestTickerValuationMeasures(unittest.TestCase):
+
+    _MOCK_HTML = """<html><body>
+    <table>
+        <tr><td></td><td>Current</td><td>12/31/2025</td><td>9/30/2025</td></tr>
+        <tr><td>Market Cap</td><td>3.76T</td><td>4.00T</td><td>3.76T</td></tr>
+        <tr><td>Enterprise Value</td><td>3.78T</td><td>4.04T</td><td>3.81T</td></tr>
+        <tr><td>Trailing P/E</td><td>32.39</td><td>36.44</td><td>38.64</td></tr>
+        <tr><td>Forward P/E</td><td>29.76</td><td>32.79</td><td>31.65</td></tr>
+        <tr><td>PEG Ratio (5yr expected)</td><td>2.27</td><td>2.75</td><td>2.44</td></tr>
+        <tr><td>Price/Sales</td><td>8.77</td><td>9.80</td><td>9.41</td></tr>
+        <tr><td>Price/Book</td><td>42.60</td><td>54.21</td><td>57.14</td></tr>
+        <tr><td>Enterprise Value/Revenue</td><td>8.68</td><td>9.71</td><td>9.32</td></tr>
+        <tr><td>Enterprise Value/EBITDA</td><td>24.73</td><td>27.92</td><td>26.87</td></tr>
+    </table>
+    </body></html>"""
+
+    def _make_ticker_with_mock(self, html):
+        mock_response = MagicMock()
+        mock_response.text = html
+        with patch("yfinance.data.YfData.cache_get", return_value=mock_response):
+            dat = yf.Ticker("AAPL")
+            data = dat.valuation_measures
+        return data
+
+    def test_valuation_measures(self):
+        data = self._make_ticker_with_mock(self._MOCK_HTML)
+        self.assertEqual(data.shape, (9, 3), "unexpected shape")
+        self.assertListEqual(list(data.columns), ["Current", "12/31/2025", "9/30/2025"])
+        self.assertIn("Market Cap", data.index)
+        self.assertIn("Trailing P/E", data.index)
+        self.assertIn("Enterprise Value/EBITDA", data.index)
+        self.assertIsNone(data.index.name)
+        self.assertEqual(data.loc["Market Cap", "Current"], "3.76T")
+        self.assertEqual(data.loc["Forward P/E", "12/31/2025"], "32.79")
+
+    def test_valuation_measures_no_table(self):
+        data = self._make_ticker_with_mock("<html><body><p>No tables here</p></body></html>")
+        self.assertIsInstance(data, pd.DataFrame)
+        self.assertTrue(data.empty)
+
+    def test_valuation_measures_fetch_error(self):
+        with patch("yfinance.data.YfData.cache_get", side_effect=Exception("network error")):
+            dat = yf.Ticker("AAPL")
+            data = dat.valuation_measures
+        self.assertIsInstance(data, pd.DataFrame)
+        self.assertTrue(data.empty)
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(TestTicker('Test ticker'))
@@ -1244,6 +1293,7 @@ def suite():
     suite.addTest(TestTickerMiscFinancials('Test misc financials'))
     suite.addTest(TestTickerInfo('Test info & fast_info'))
     suite.addTest(TestTickerFundsData('Test Funds Data'))
+    suite.addTest(TestTickerValuationMeasures('Test valuation measures'))
     return suite
 
 

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -287,6 +287,10 @@ class TickerBase:
             self._fast_info = FastInfo(self)
         return self._fast_info
 
+    def get_valuation_measures(self):
+        data = self._quote.valuation_measures
+        return data
+
     def get_sustainability(self, as_dict=False):
         data = self._quote.sustainability
         if as_dict:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import numpy as _np
 import pandas as pd
+from bs4 import BeautifulSoup
 
 from yfinance import utils
 from yfinance.config import YfConfig
@@ -492,6 +493,7 @@ class Quote:
         self._upgrades_downgrades = None
         self._calendar = None
         self._sec_filings = None
+        self._valuation_measures = None
 
         self._already_scraped = False
         self._already_fetched = False
@@ -571,6 +573,12 @@ class Quote:
             f = self._fetch_sec_filings()
             self._sec_filings = {} if f is None else f
         return self._sec_filings
+
+    @property
+    def valuation_measures(self) -> pd.DataFrame:
+        if self._valuation_measures is None:
+            self._fetch_valuation_measures()
+        return self._valuation_measures
 
     @staticmethod
     def valid_modules():
@@ -660,6 +668,40 @@ class Quote:
             return v2
 
         self._info = {k: _format(k, v) for k, v in query1_info.items()}
+
+    def _fetch_valuation_measures(self):
+        url = f"https://finance.yahoo.com/quote/{self._symbol}/key-statistics"
+        try:
+            response = self._data.cache_get(url=url)
+        except Exception as e:
+            if not YfConfig.debug.hide_exceptions:
+                raise
+            utils.get_yf_logger().error(f"Failed to fetch key-statistics page: {e}")
+            self._valuation_measures = pd.DataFrame()
+            return
+
+        try:
+            soup = BeautifulSoup(response.text, "html.parser")
+            table = soup.find("table")
+            if table is None:
+                self._valuation_measures = pd.DataFrame()
+                return
+
+            headers = [th.get_text(strip=True) for th in table.find("tr").find_all(["th", "td"])]
+            rows = []
+            for tr in table.find_all("tr")[1:]:
+                cells = [td.get_text(strip=True) for td in tr.find_all(["th", "td"])]
+                rows.append(cells)
+
+            df = pd.DataFrame(rows, columns=headers)
+            df = df.set_index(df.columns[0])
+            df.index.name = None
+            self._valuation_measures = df
+        except Exception as e:
+            if not YfConfig.debug.hide_exceptions:
+                raise
+            utils.get_yf_logger().error(f"Failed to parse key-statistics page: {e}")
+            self._valuation_measures = pd.DataFrame()
 
     def _fetch_complementary(self):
         if self._already_fetched_complementary:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -163,6 +163,10 @@ class Ticker(TickerBase):
         return self.get_fast_info()
 
     @property
+    def valuation(self) -> _pd.DataFrame:
+        return self.get_valuation_measures()
+
+    @property
     def calendar(self) -> dict:
         """
         Returns a dictionary of events, earnings, and dividends for the ticker


### PR DESCRIPTION
Add `ticker.valuation_measures`, which fetches the Valuation Measures table that is at the top of the key-statistics page, closing #2426 and #2570. See image below.

<img width="1252" height="970" alt="image" src="https://github.com/user-attachments/assets/ac289f71-1c18-4685-800b-bb654e0a1991" />

Sample Usage:
```
import yfinance as yf; 
t = yf.Ticker('AAPL'); 
print(t.valuation_measures)
```
Output:
```
                         Current 12/31/2025 9/30/2025 6/30/2025 3/31/2025 12/31/2024
Market Cap                 3.76T      4.00T     3.76T     3.05T     3.32T      3.77T
Enterprise Value           3.78T      4.04T     3.81T     3.10T     3.36T      3.81T
Trailing P/E               32.39      36.44     38.64     31.96     35.26      41.19
Forward P/E                29.76      32.79     31.65     25.71     30.30      33.67
PEG Ratio (5yr expected)    2.27       2.75      2.44      1.87      2.06       2.29
Price/Sales                 8.77       9.80      9.41      7.79      8.59       9.87
Price/Book                 42.60      54.21     57.14     45.63     49.71      66.14
Enterprise Value/Revenue    8.68       9.71      9.32      7.74      8.49       9.74
Enterprise Value/EBITDA    24.73      27.92     26.87     22.31     24.47      28.28
```

I also added tests for this - since it looks like tests aren't actively being run in CI because they hit live endpoints, I mocked a response for testing.