### PR TITLE
fix: handle YFPricesMissingError in get_history_metadata when intraday data unavailable

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -546,15 +546,12 @@ class PriceHistory:
         return self._history_cache[cache_key]
 
     def get_history_metadata(self) -> dict:
-        if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
-            # Request intraday data, because then Yahoo returns exchange schedule (tradingPeriods).
+       if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
+        # Request intraday data, because then Yahoo returns exchange schedule (tradingPeriods).
+        try:
             self._get_history_cache(period="5d", interval="1h")['prices']
-
-        if self._history_metadata_formatted is False:
-            self._history_metadata = utils.format_history_metadata(self._history_metadata)
-            self._history_metadata_formatted = True
-
-        return self._history_metadata
+        except Exception:
+            pass  # tradingPeriods is optional enrichment; don't fail if intraday unavailable
 
     def get_dividends(self, period="max", repair=False) -> pd.Series:
         return self._get_history_cache(interval='1d', period=period, repair=repair)['dividends']

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -546,8 +546,8 @@ class PriceHistory:
         return self._history_cache[cache_key]
 
     def get_history_metadata(self) -> dict:
-       def get_history_metadata(self) -> dict:
         if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
+            # Request intraday data, because then Yahoo returns exchange schedule (tradingPeriods).
             try:
                 self._get_history_cache(period="5d", interval="1h")['prices']
             except Exception:
@@ -556,6 +556,8 @@ class PriceHistory:
         if self._history_metadata_formatted is False:
             self._history_metadata = utils.format_history_metadata(self._history_metadata)
             self._history_metadata_formatted = True
+
+        return self._history_metadata
 
         return self._history_metadata
     def get_dividends(self, period="max", repair=False) -> pd.Series:

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -546,13 +546,18 @@ class PriceHistory:
         return self._history_cache[cache_key]
 
     def get_history_metadata(self) -> dict:
-       if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
-        # Request intraday data, because then Yahoo returns exchange schedule (tradingPeriods).
-        try:
-            self._get_history_cache(period="5d", interval="1h")['prices']
-        except Exception:
-            pass  # tradingPeriods is optional enrichment; don't fail if intraday unavailable
+       def get_history_metadata(self) -> dict:
+        if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
+            try:
+                self._get_history_cache(period="5d", interval="1h")['prices']
+            except Exception:
+                pass  # tradingPeriods is optional enrichment; don't fail if intraday unavailable
 
+        if self._history_metadata_formatted is False:
+            self._history_metadata = utils.format_history_metadata(self._history_metadata)
+            self._history_metadata_formatted = True
+
+        return self._history_metadata
     def get_dividends(self, period="max", repair=False) -> pd.Series:
         return self._get_history_cache(interval='1d', period=period, repair=repair)['dividends']
 

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -553,13 +553,13 @@ class PriceHistory:
             except Exception:
                 pass  # tradingPeriods is optional enrichment; don't fail if intraday unavailable
 
+
         if self._history_metadata_formatted is False:
             self._history_metadata = utils.format_history_metadata(self._history_metadata)
             self._history_metadata_formatted = True
 
         return self._history_metadata
 
-        return self._history_metadata
     def get_dividends(self, period="max", repair=False) -> pd.Series:
         return self._get_history_cache(interval='1d', period=period, repair=repair)['dividends']
 


### PR DESCRIPTION
Fixes #2745

## Problem
`get_history_metadata()` raises `YFPricesMissingError` for valid, 
non-delisted tickers when intraday data is unavailable, even after 
`history()` succeeds. The `tradingPeriods` fetch was crashing the 
entire method instead of gracefully continuing.

## Fix
Wrapped the intraday cache call in a try/except block so that 
`YFPricesMissingError` is caught and ignored. The `tradingPeriods` 
field is optional enrichment — its absence should not prevent 
returning already-cached metadata.

## Testing
Tested with ROG.SW ticker as described in the issue report.