### PR TITLE
fix: copy price_data before mutation to prevent read-only ValueError in repair=True

### DIFF
--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -2746,6 +2746,7 @@ class PriceHistory:
         df_dtype = price_data.dtype
         if df_dtype == np.int64:
             price_data = price_data.astype('float')
+        price_data = price_data.copy()
         for j in range(price_data.shape[1]):
             price_data[:,j] *= adj
             if OHLC[j] in df_workings.columns:


### PR DESCRIPTION
Fixes #2688

## Problem
When `repair=True`, `_fix_prices_sudden_change()` raises:
`ValueError: output array is read-only`
because `price_data` is a read-only numpy array and cannot be 
mutated in-place with `*=`.

## Fix
Add `price_data = price_data.copy()` before the loop to ensure 
the array is writable before any in-place operations.

## Testing
Reproduces with:
```python
import yfinance as yf
df = yf.download("GME", period="max", interval="1d", 
                 auto_adjust=False, repair=True)
```
Fix prevents the ValueError.