### PR TITLE
Add Auth class for Logging In

### DIFF
--- a/doc/source/reference/examples/auth.py
+++ b/doc/source/reference/examples/auth.py
@@ -1,0 +1,18 @@
+import yfinance as yf
+import os
+
+auth = yf.Auth()
+
+# Set log in cookies from browser
+auth.set_login_cookies(os.getenv("COOKIE_T"), os.getenv("COOKIE_Y"))
+
+# Check if the cookies worked
+if auth.check_login():
+    print("Logged in")
+else:
+    print("Invalid cookie")
+
+# Every subsequent request sent to Yahoo Finance will now be under the logged-in user.
+
+# Access user information
+auth.user

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -28,6 +28,7 @@ The following are the publicly available classes, and functions exposed by the `
 - :attr:`FundQuery <yfinance.FundQuery>`: Class to build fund query filters.
 - :attr:`ETFQuery <yfinance.ETFQuery>`: Class to build ETF query filters.
 - :attr:`screen <yfinance.screen>`: Run equity/fund queries.
+- :attr:`Auth <yfinance.Auth>`: Class for handling Yahoo Finance authentication.
 - :attr:`config.debug.logging <yfinance.config>`: Enable verbose debug logging (``yf.config.debug.logging = True``).
 - :attr:`set_tz_cache_location <yfinance.set_tz_cache_location>`: Function to set the timezone cache location.
 
@@ -47,6 +48,7 @@ The following are the publicly available classes, and functions exposed by the `
    yfinance.websocket
    yfinance.sector_industry
    yfinance.screener
+   yfinance.auth
    yfinance.functions
 
    yfinance.funds_data

--- a/doc/source/reference/yfinance.auth.rst
+++ b/doc/source/reference/yfinance.auth.rst
@@ -1,0 +1,44 @@
+=====================
+Authentication
+=====================
+
+.. currentmodule:: yfinance
+
+.. note::
+   The `Auth` module **cannot automate login** using a username and password
+   because Yahoo Finance requires solving a **reCAPTCHA**, which blocks automation.
+   You must manually obtain and set the authentication cookies.
+
+Class
+------------
+The `Auth` module, allows you to login to Yahoo! Finance.
+
+.. autosummary::
+   :toctree: api/
+
+   Auth
+
+Auth Sample Code
+------------------
+The `Auth` module, allows you to login to Yahoo! Finance.
+
+.. literalinclude:: examples/auth.py
+   :language: python
+
+Obtaining Yahoo Finance Cookies
+--------------------------------
+
+To authenticate with Yahoo Finance, you need to obtain specific cookies. Follow these steps:
+
+.. rubric:: Steps to Obtain the Cookies
+
+1. Open your browser (e.g., Chrome, Firefox).
+2. Log in to `Yahoo Finance <https://finance.yahoo.com>`_.
+3. Open the browser's Developer Tools:
+
+   - Press `F12` or `Ctrl + Shift + I` (Windows/Linux)
+   - Press `Cmd + Option + I` (Mac)
+4. Navigate to the **Application** tab (Chrome) or **Storage** tab (Firefox).
+5. In the **Cookies** section, select `https://finance.yahoo.com`.
+6. Locate the cookies named **T** and **Y**.
+7. Copy the values of these cookies and pass them to the authentication function.

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -33,6 +33,7 @@ from .domain.sector import Sector
 from .domain.industry import Industry
 from .domain.market import Market
 from .config import YfConfig as config
+from .data import Auth
 
 from .screener.query import EquityQuery, FundQuery, ETFQuery
 from .screener.screener import screen, PREDEFINED_SCREENER_QUERIES
@@ -43,7 +44,8 @@ __author__ = "Ran Aroussi"
 import warnings
 warnings.filterwarnings('default', category=DeprecationWarning, module='^yfinance')
 
-__all__ = ['download', 'Market', 'Search', 'Lookup', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location', 'Sector', 'Industry', 'WebSocket', 'AsyncWebSocket', 'Calendars']
+__all__ = ['download', 'Market', 'Search', 'Lookup', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location',
+           'Sector', 'Industry', 'WebSocket', 'AsyncWebSocket', 'Calendars', 'Auth']
 # screener stuff:
 __all__ += ['EquityQuery', 'FundQuery', 'ETFQuery', 'screen', 'PREDEFINED_SCREENER_QUERIES']
 

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -2,6 +2,7 @@ import functools
 from functools import lru_cache
 import socket
 import time as _time
+import json as _json
 
 from curl_cffi import requests
 from urllib.parse import urlsplit, urljoin
@@ -91,6 +92,14 @@ class YfData(metaclass=SingletonMeta):
 
         self._session = None
         self._set_session(session or requests.Session(impersonate="chrome"))
+
+    def set_login_cookies(self, cookie_t, cookie_y):
+        with self._cookie_lock:
+            self._session.cookies.update({
+                "T": cookie_t,
+                "Y": cookie_y
+            })
+            self._cookie = True
 
     def _set_session(self, session):
         if session is None:
@@ -542,3 +551,70 @@ class YfData(metaclass=SingletonMeta):
             action, data=data, headers=headers, timeout=timeout, allow_redirects=True
         )
         return response
+
+class Auth:
+    def __init__(self, session=None):
+        self._session = session
+        self._data = YfData(session)
+
+        self._user: dict | None = None
+
+    def set_login_cookies(self, cookie_t: str, cookie_y: str) -> None:
+        """
+        Set the login cookies to indicate that the user is logged in.
+
+        How to Obtain the Cookies:
+            1. Open your browser (e.g., Chrome, Firefox).
+            2. Log in to Yahoo Finance (https://finance.yahoo.com).
+            3. Open the browser's Developer Tools:
+               Press `F12` or `Ctrl + Shift + I` (Windows/Linux) or `Cmd + Option + I` (Mac).
+            4. Go to the "Application" tab (Chrome) or "Storage" tab (Firefox).
+            5. In the "Cookies" section, select `https://finance.yahoo.com`.
+            6. Look for the cookies named `T` and `Y`.
+            7. Copy the values of these cookies and pass them to this function.
+
+        Args:
+            cookie_t (str): The value for the 'T' cookie.
+            cookie_y (str): The value for the 'Y' cookie.
+        """
+        self._data.set_login_cookies(cookie_t, cookie_y)
+
+    def check_login(self) -> bool:
+        """Check whether the user is logged in to Yahoo Finance."""
+        if self._user:
+            return True
+
+        try:
+            response = self._data.get("https://finance.yahoo.com/")
+            soup = BeautifulSoup(response.text, 'html.parser')
+
+            script_tag = soup.find('script', id='nimbus-benji-config')
+            if not script_tag:
+                return False
+
+            config_json = script_tag.string
+            config_data = _json.loads(config_json).get('i13n')
+
+            if "user" in config_data and "guid" in config_data["user"]:
+                self._user = config_data["user"]
+                return True
+            else:
+                return False
+        except Exception as e:
+            if not YfConfig.debug.hide_exceptions:
+                raise
+            utils.get_yf_logger().error(f"Error confirming login: {e}")
+            return False
+
+    @property
+    def user(self) -> dict | None:
+        """
+        Get the logged-in user's details.
+
+        Returns:
+            dict | None: A dictionary containing the user's details if logged in, or None if not logged in.
+        """
+        if self._user is not None or self.check_login():
+            return self._user
+
+        return None


### PR DESCRIPTION
Revival of #2254. Adds an `Auth` class that allows user to login using manually retrieved cookies.

Implements #2370.

```py
import yfinance as yf
import os

auth = yf.Auth()
auth.set_login_cookies(os.getenv("COOKIE_T"), os.getenv("COOKIE_Y"))
if auth.check_login():
    print("Logged in")
    print(auth.user)
else:
    print("Invalid cookie")
```

I considered adding a `check_login` call at the end of `set_login_cookies` but decided against it. `check_login` is expensive (~1 second), and we don't want to give a false positive if the cookies the user provided expired after being cached. Curious if you have any thoughts on this.

Also just noting that the T/Y cookies expire after 1 year.