### PR TITLE
fix: expose financial_currency in earnings estimates when it differs from listing currency

### DIFF
--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -114,7 +114,9 @@ class TickerBase:
         # self._price_history = PriceHistory(self._data, self.ticker)
         self._price_history = None  # lazy-load
         self._analysis = Analysis(self._data, self.ticker)
-        self._holders = Holders(self._data, self.ticker)
+        self._quote = Quote(self._data, self.ticker)
+        financial_currency = (self._quote.info or {}).get('financialCurrency')
+        self._analysis = Analysis(self._data, self.ticker, financial_currency=financial_currency)
         self._quote = Quote(self._data, self.ticker)
         self._fundamentals = Fundamentals(self._data, self.ticker)
         self._funds_data = None

--- a/yfinance/scrapers/analysis.py
+++ b/yfinance/scrapers/analysis.py
@@ -10,10 +10,10 @@ from yfinance.scrapers.quote import _QUOTE_SUMMARY_URL_
 
 class Analysis:
 
-    def __init__(self, data: YfData, symbol: str):
+    def __init__(self, data: YfData, symbol: str, financial_currency: str = None):
         self._data = data
         self._symbol = symbol
-
+        self._financial_currency = financial_currency
         # In quoteSummary the 'earningsTrend' module contains most of the data below.
         # The format of data is not optimal so each function will process it's part of the data.
         # This variable works as a cache.
@@ -45,7 +45,10 @@ class Analysis:
         if len(data) == 0:
             return pd.DataFrame()
         df = pd.DataFrame(data).set_index('period')
-        if currency is not None:
+        if self._financial_currency is not None and currency != self._financial_currency:
+            df['currency'] = currency
+            df['financial_currency'] = self._financial_currency
+        elif currency is not None:
             df['currency'] = currency
         return df
 


### PR DESCRIPTION
Fixes #2699

## Problem
earnings_estimate returns currency based on Yahoo's earningsCurrency 
field, which reflects the listing currency (e.g. USD for Toyota/TM). 
For foreign-listed companies, this diverges from financialCurrency 
(e.g. JPY), causing confusion when interpreting earnings data.

## Fix
- Pass financialCurrency from ticker info into Analysis on init
- In _get_periodic_df, when listing currency differs from 
  financialCurrency, expose both as separate columns: 
  `currency` (listing) and `financial_currency` (company financials)

## Testing
import yfinance as yf
ticker = yf.Ticker("TM")
print(ticker.earnings_estimate)
# Now shows both currency=USD and financial_currency=JPY