### PR TITLE
Add 'repair' to get_history_metadata()

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -289,6 +289,14 @@ class TestTickerHistory(unittest.TestCase):
         self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 
+    def test_history_metadata(self):
+        # Mainly testing that if user requested price repair, 
+        # that any metadata refetch also uses repaired data.
+        self.ticker.history("1mo", repair=True)
+        # - metadata will be fetched because prefers intraday fetch
+        md = self.ticker.history_metadata
+        self.assertTrue(md['YF repair?'])
+
     def test_download(self):
         tomorrow = pd.Timestamp.now().date() + pd.Timedelta(days=1)  # helps with caching
         for t in [False, True]:

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -31,7 +31,7 @@ from curl_cffi import requests
 
 
 from . import utils, cache
-from .const import _MIC_TO_YAHOO_SUFFIX
+from .const import _MIC_TO_YAHOO_SUFFIX, _SENTINEL_
 from .data import YfData
 from .config import YfConfig
 from .exceptions import YFDataException, YFEarningsDateMissing, YFRateLimitError
@@ -789,8 +789,13 @@ class TickerBase:
         self._earnings_dates[limit] = df
         return df
 
-    def get_history_metadata(self) -> dict:
-        return self._lazy_load_price_history().get_history_metadata()
+    def get_history_metadata(self, repair=_SENTINEL_) -> dict:
+        """
+        repair default value depends on whether user requested price repair
+        with previous history() call. If user did not set repair here, then
+        it is set to match previous history() call.
+        """
+        return self._lazy_load_price_history().get_history_metadata(repair=repair)
 
     def get_funds_data(self) -> Optional[FundsData]:
         if not self._funds_data:

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -11,7 +11,7 @@ import warnings
 
 from yfinance import shared, utils
 from yfinance.config import YfConfig
-from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, period_default
+from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, period_default, _SENTINEL_
 from yfinance.exceptions import YFDataException, YFInvalidPeriodError, YFPricesMissingError, YFRateLimitError, YFTzMissingError
 
 class PriceHistory:
@@ -238,6 +238,7 @@ class PriceHistory:
             meta = {}
 
         self._history_metadata = meta
+        self._history_metadata['YF repair?'] = repair
 
         intraday = params["interval"][-1] in ("m", 'h')
         _price_data_debug = ''
@@ -545,10 +546,23 @@ class PriceHistory:
                                                 'capital gains': self._capital_gains}
         return self._history_cache[cache_key]
 
-    def get_history_metadata(self) -> dict:
+    def get_history_metadata(self, repair=_SENTINEL_) -> dict:
+        """
+        repair default value depends on whether user requested price repair
+        with previous history() call. If user did not set repair here, then
+        it is set to match previous history() call.
+        """
+        
+        # - repair affects currency, particularly GBp -> GBP
         if self._history_metadata is None or 'tradingPeriods' not in self._history_metadata:
             # Request intraday data, because then Yahoo returns exchange schedule (tradingPeriods).
-            self._get_history_cache(period="5d", interval="1h")['prices']
+            if repair == _SENTINEL_:
+                if self._history_metadata is not None:
+                    repair = self._history_metadata['YF repair?']
+                else:
+                    # default
+                    repair = False
+            self._get_history_cache(period="5d", interval="1h", repair=repair)['prices']
 
         if self._history_metadata_formatted is False:
             self._history_metadata = utils.format_history_metadata(self._history_metadata)


### PR DESCRIPTION
This fixes currency in `history_metadata()` diverging from `history(repair=True, ...)`. E.g. repair fixes GBp -> GBP