### PR TITLE
chore: fix typos (prividing -> providing, Reponse -> Response)

### DIFF
--- a/yfinance/calendars.py
+++ b/yfinance/calendars.py
@@ -340,7 +340,7 @@ class Calendars:
         _end = self._parse_date_param(end)
         if (start and not end) or (end and not start):
             warnings.warn(
-                "When prividing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
+                "When providing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -385,7 +385,7 @@ class Calendars:
         _end = self._parse_date_param(end)
         if (start and not end) or (end and not start):
             warnings.warn(
-                "When prividing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
+                "When providing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -446,7 +446,7 @@ class Calendars:
         _end = self._parse_date_param(end)
         if (start and not end) or (end and not start):
             warnings.warn(
-                "When prividing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
+                "When providing custom `start` and `end` parameters, you may want to specify both, to avoid unexpected behaviour.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -492,7 +492,7 @@ class YfData(metaclass=SingletonMeta):
             timeout (int) : Raise TimeoutError if post doesn't respond
     
         Returns:
-            response (requests.Response) : Reponse instance received from the server after accepting cookie-consent post.
+            response (requests.Response) : Response instance received from the server after accepting cookie-consent post.
         """
         soup = BeautifulSoup(consent_resp.text, "html.parser")
     


### PR DESCRIPTION
## Summary

Small typo-only cleanup:

- `yfinance/calendars.py`: `prividing` -> `providing` in three identical user-facing `UserWarning` messages (raised from `_get_startdatetime_operands`, `get_earnings_calendar`, and `get_ipo_info_calendar`).
- `yfinance/data.py`: `Reponse` -> `Response` in a docstring describing the return value of the cookie-consent helper.

Both were surfaced by `codespell`. No logic, signatures, or tests are changed.

## Test plan

- [x] `codespell yfinance/calendars.py yfinance/data.py` is clean.
- [x] `python -m ast` parses both files.
- [x] `git grep` confirms no remaining occurrences of `prividing` or `Reponse` in the repo.
- [x] Diff is limited to the four intended lines.