### PR TITLE
Fix: _dts_in_same_interval("1mo") ignored year

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,17 @@ class TestDateIntervalCheck(unittest.TestCase):
         dt2 = pd.Timestamp("2025-01-15")
         self.assertFalse(_dts_in_same_interval(dt1, dt2, "1mo"))
 
+    def test_same_month_different_year(self):
+        # Same calendar month but different years must not be treated
+        # as the same monthly interval.
+        dt1 = pd.Timestamp("2024-12-15")
+        dt2 = pd.Timestamp("2025-12-15")
+        self.assertFalse(_dts_in_same_interval(dt1, dt2, "1mo"))
+
+        dt3 = pd.Timestamp("2020-06-01")
+        dt4 = pd.Timestamp("2025-06-01")
+        self.assertFalse(_dts_in_same_interval(dt3, dt4, "1mo"))
+
     def test_standard_quarters(self):
         q1_start = datetime(2023, 1, 1)
         self.assertTrue(_dts_in_same_interval(q1_start, datetime(2023, 1, 15), '3mo'))

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -624,7 +624,7 @@ def _dts_in_same_interval(dt1, dt2, interval):
     elif interval == "1wk":
         last_rows_same_interval = (dt2 - dt1).days < 7
     elif interval == "1mo":
-        last_rows_same_interval = dt1.month == dt2.month
+        last_rows_same_interval = dt1.month == dt2.month and dt1.year == dt2.year
     elif interval == "3mo":
         shift = (dt1.month % 3) - 1
         q1 = (dt1.month - shift - 1) // 3 + 1


### PR DESCRIPTION
## Summary

`_dts_in_same_interval(dt1, dt2, "1mo")` in `yfinance/utils.py` compared only `dt1.month == dt2.month`, so two timestamps that share the same calendar month but are in different years were treated as falling in the same monthly interval. For example, `(2024-12-15, 2025-12-15)` returned `True`.

The `"3mo"` branch already handles cross-year correctly (see the `year_diff` calculation just below). This PR brings the `"1mo"` branch in line by also requiring `dt1.year == dt2.year`.

```python
# before
elif interval == "1mo":
    last_rows_same_interval = dt1.month == dt2.month
# after
elif interval == "1mo":
    last_rows_same_interval = dt1.month == dt2.month and dt1.year == dt2.year
```

The function is called from `fix_Yahoo_returning_live_separate` (`yfinance/utils.py`), which merges the last two rows of a price series when they fall in the same interval, so the old behaviour could merge rows that are actually a full year apart in 1-month-interval data.

## Test plan

Added `test_same_month_different_year` in `tests/test_utils.py` covering `(Dec 2024, Dec 2025)` and `(Jun 2020, Jun 2025)`. It fails on the old logic and passes on the fix.

- [x] `python -m unittest tests.test_utils.TestDateIntervalCheck.test_same_month_different_year` — fails before the fix, passes after.
- [x] `python -m unittest tests.test_utils -v` — all 21 tests pass (20 pre-existing + 1 new), one pre-existing expected failure unchanged.
- [x] Diff limited to the two intended lines of logic + the new test.