### PR TITLE
Fix Market API docs reference link

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -15,7 +15,7 @@ The following are the publicly available classes, and functions exposed by the `
 
 - :attr:`Ticker <yfinance.Ticker>`: Class for accessing single ticker data.
 - :attr:`Tickers <yfinance.Tickers>`: Class for handling multiple tickers.
-- :attr:`Market <yfinance.Market>`: Class for accessing market summary.
+- :doc:`Market <yfinance.market>`: Class for accessing market summary.
 - :attr:`Calendars <yfinance.Calendars>`: Class for accessing calendar events data.
 - :attr:`download <yfinance.download>`: Function to download market data for multiple tickers.
 - :attr:`Search <yfinance.Search>`: Class for accessing search results.


### PR DESCRIPTION
This PR fixes the Market API reference link so it points users to the useful Market documentation page instead of the autogenerated stub.

Closes #2358.
