### PR TITLE
Preserve intraday closing-auction bar dropped by Yahoo schedule end

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -413,7 +413,7 @@ class TestPriceHistory(unittest.TestCase):
         end_d = special_day + _dt.timedelta(days=7)
         df = dat.history(start=start_d, end=end_d, interval="1h", prepost=False, keepna=True)
         tg_last_dt = df.loc[str(special_day)].index[-1]
-        self.assertTrue(tg_last_dt.time() < time_early_close)
+        self.assertTrue(tg_last_dt.time() <= time_early_close)
 
         # Test no other afternoons (or mornings) were pruned
         start_d = _dt.date(special_day.year, 1, 1)
@@ -440,6 +440,54 @@ class TestPriceHistory(unittest.TestCase):
         last_dts = _pd.Series(df.index).groupby(df.index.date).last()
         dfd = dat.history(start=start_d, end=end_d, interval='1d', prepost=False, keepna=True)
         self.assertTrue(_np.equal(dfd.index.date, _pd.to_datetime(last_dts.index).date).all())
+
+    def test_fix_prepost_keeps_closing_auction_bar(self):
+        # Synthetic test: for exchanges where Yahoo's tradingPeriods.end
+        # undershoots the actual close (SAU, SAO, KSC, BUD, NZE, SES, JNB, DFM),
+        # Yahoo still returns a bar at index == end with the closing-auction price.
+        # The filter must keep that bar but drop anything strictly past end and
+        # any pre-market bar entirely before start.
+        from yfinance import utils
+
+        day = _pd.Timestamp("2024-01-02", tz="UTC")
+        start = day + _pd.Timedelta(hours=10)
+        end = day + _pd.Timedelta(hours=15)
+        tps = _pd.DataFrame(
+            {"start": [start], "end": [end]},
+            index=_pd.Index([day.normalize()], name="Date"),
+        )
+        idx = _pd.DatetimeIndex([
+            start - _pd.Timedelta(hours=1),  # pre-market: drop
+            start,                            # first regular bar: keep
+            end - _pd.Timedelta(hours=1),     # mid-session: keep
+            end,                              # closing-auction bar: keep (regression)
+            end + _pd.Timedelta(hours=1),     # post-close: drop
+        ])
+        quotes = _pd.DataFrame({"Open": range(5), "Close": range(5)}, index=idx)
+
+        result = utils.fix_Yahoo_returning_prepost_unrequested(quotes, "1h", tps)
+
+        self.assertIn(end, result.index, "closing-auction bar at index==end was dropped")
+        self.assertIn(start, result.index)
+        self.assertNotIn(start - _pd.Timedelta(hours=1), result.index)
+        self.assertNotIn(end + _pd.Timedelta(hours=1), result.index)
+
+    def test_intraday_closing_auction_bar_saudi(self):
+        # Integration check on Tadawul: hourly bar at the Yahoo-reported
+        # session end (15:00 AST) must be present.
+        tkr = "2222.SR"
+        dat = yf.Ticker(tkr, session=self.session)
+        df = dat.history(period="5d", interval="1h", prepost=False, auto_adjust=False)
+        if df.empty or not isinstance(df.index, _pd.DatetimeIndex):
+            self.skipTest("No hourly data available for 2222.SR")
+        md = dat.get_history_metadata()
+        if md.get("exchangeName") != "SAU":
+            self.skipTest("Yahoo no longer reports 2222.SR on SAU")
+        schedule_end = md["tradingPeriods"]["end"].iloc[-1]
+        last_day_bars = df[df.index.date == schedule_end.date()]
+        self.assertGreater(len(last_day_bars), 0)
+        self.assertEqual(last_day_bars.index[-1], schedule_end,
+                         "last hourly bar should sit at the Yahoo schedule end (closing auction)")
 
     def test_weekly_2rows_fix(self):
         tkr = "AMZN"

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -599,8 +599,11 @@ def fix_Yahoo_returning_prepost_unrequested(quotes, interval, tradingPeriods):
     idx = quotes.index.copy()
     quotes = quotes.merge(tps_df, how="left")
     quotes.index = idx
-    # "end" = end of regular trading hours (including any auction)
-    f_drop = quotes.index >= quotes["end"]
+    # "end" = end of regular trading hours per Yahoo metadata. For some exchanges
+    # (SAU, SAO, KSC, BUD, NZE, SES, JNB, DFM, ...) Yahoo's `end` undershoots the
+    # real close by omitting the closing auction, but still returns a bar at that
+    # timestamp containing the auction's Close. Use strict > so that bar survives.
+    f_drop = quotes.index > quotes["end"]
     td = _interval_to_timedelta(interval)
     f_drop = f_drop | (quotes.index + td <= quotes["start"])
     if f_drop.any():


### PR DESCRIPTION
## Summary

Closes #1585.

Yahoo's `tradingPeriods.end` undershoots the real session close on several exchanges by omitting the closing auction. Yahoo still returns a bar at `index == end` holding the auction price, but `fix_Yahoo_returning_prepost_unrequested` was discarding it via `index >= end`, leaving users without the official close.

The reporter's case was Saudi (2222.SR), but a sweep of the major venues found the same pattern on at least 8 exchanges plus US half-days:

| Exchange | Yahoo end | Notes |
|---|---|---|
| SAU (Tadawul) | 15:00 AST | actual close incl. auction is 15:20 |
| KSC (KOSPI) | 15:00 KST | closing auction 15:20–15:30 |
| SAO (B3) | 17:00 BRT | closing call to ~17:55 |
| BUD (BSE) | 17:00 CET | |
| NZE (NZX) | 17:00 NZST | |
| SES (SGX) | 17:00 SGT | closing routine 17:00–17:06 |
| JNB (JSE) | 17:00 SAST | |
| DFM (Dubai) | 15:00 GST | |
| US half-days | 13:00 EST | Thanksgiving etc. |

In every case Yahoo returns a bar at exactly `end` with a valid `Close` and `Volume == 0`, i.e. the closing-auction print. The `Volume == 0` part is acknowledged as a Yahoo data limitation in the original issue thread (auction volume not exposed intraday) and is out of scope for this PR.

## Changes

- `yfinance/utils.py`: switch the drop boundary in `fix_Yahoo_returning_prepost_unrequested` from `quotes.index >= quotes['end']` to `quotes.index > quotes['end']`. Single-character semantic change. Pre-market bars are still pruned by the other half of the filter; bars strictly past `end` (post-close) still get dropped.
- `tests/test_prices.py`:
  - `test_fix_prepost_keeps_closing_auction_bar` — synthetic, no-network regression test exercising both sides of the boundary (pre-market and post-close still drop, bar at == end survives).
  - `test_intraday_closing_auction_bar_saudi` — live integration check on 2222.SR.
  - `test_prune_post_intraday_us` assertion relaxed from `<` to `<=`: the half-day closing-auction bar at the early-close timestamp is now preserved, which is the intended behavior.

## Behavior before

```python
>>> yf.Ticker('2222.SR').history(period='5d', interval='1h').tail(2)
                              Close     Volume
2026-05-07 13:00:00+03:00     27.18    1489165
2026-05-07 14:00:00+03:00     27.12    2800336    # 15:00 closing-auction bar dropped
```

## Behavior after

```python
>>> yf.Ticker('2222.SR').history(period='5d', interval='1h').tail(2)
                              Close     Volume
2026-05-07 14:00:00+03:00     27.12    2800336
2026-05-07 15:00:00+03:00     27.20          0    # closing-auction print preserved
```

## Test plan

- [x] `python -m unittest tests.test_prices.TestPriceHistory.test_fix_prepost_keeps_closing_auction_bar tests.test_prices.TestPriceHistory.test_intraday_closing_auction_bar_saudi tests.test_prices.TestPriceHistory.test_prune_post_intraday_us tests.test_prices.TestPriceHistory.test_prune_post_intraday_asx -v` — all pass
- [x] TDD red→green: both new tests fail on `dev` (verified by reverting just the `>=`/`>` change), pass with the fix
- [x] Spot-checked the 8 affected exchanges plus AAPL (US, unaffected) — closing-auction bars now appear, no spurious post-market bars

