### PR TITLE
Stabilize period2 when end is omitted to allow requests_cache hits

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -450,6 +450,27 @@ class TestPriceHistory(unittest.TestCase):
         df = dat.history(start=start, interval="1wk")
         self.assertTrue((df.index.weekday == 0).all())
 
+    def test_history_start_no_end_stable_url(self):
+        # period2 must be stable across calls in the same calendar day
+        # (requests_cache hit).
+        from unittest.mock import patch
+        captured = []
+        dat = yf.Ticker('MSFT')
+        real_get = dat._data.get
+        def spy(*args, **kw):
+            url = kw.get('url') or (args[0] if args else '')
+            params = kw.get('params') or (args[1] if len(args) > 1 else None)
+            if '/chart/' in url and params and 'period2' in params:
+                captured.append(params['period2'])
+            return real_get(*args, **kw)
+        with patch.object(dat._data, 'get', side_effect=spy):
+            dat.history(start='2024-01-01', interval='1d')
+            dat._history = None
+            dat.history(start='2024-01-01', interval='1d')
+        self.assertGreaterEqual(len(captured), 2)
+        self.assertEqual(captured[0], captured[1],
+                         f"period2 changed between calls: {captured[0]} vs {captured[1]}")
+
     def test_aggregate_capital_gains(self):
         # Setup
         tkr = "FXAIX"

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -153,7 +153,9 @@ class PriceHistory:
                 start_dt = end_dt - utils._interval_to_timedelta('1mo')
                 start = int(start_dt.timestamp())
             elif not end:
-                end_dt = pd.Timestamp.now('UTC').tz_convert(tz)
+                # Snap to next-day midnight in exchange tz so identical calls
+                # within the same calendar day produce a stable URL (cache hits).
+                end_dt = pd.Timestamp.now('UTC').tz_convert(tz).normalize() + pd.Timedelta(days=1)
                 end = int(end_dt.timestamp())
         else:
             if period.lower() == "max":


### PR DESCRIPTION
## Summary

Closes #2156.

When `start` is supplied without `end`, `PriceHistory.history()` filled `period2` with `pd.Timestamp.now()` — different on every invocation. The Yahoo chart URL changed every second, so `requests_cache.CachedSession` users got a fresh network fetch and a fresh cache row on every call:

```text
url=https://query2.finance.yahoo.com/v8/finance/chart/ABB.NS
params={'period1': 1546281000, 'period2': 1732735151, ...}   # call 1
params={'period1': 1546281000, 'period2': 1732735152, ...}   # call 2 (1s later)
```

## Fix

Snap `end_dt` to the next-day midnight in the exchange timezone. Identical calls within the same calendar day now produce an identical URL, and Yahoo truncates `period2` to "now" server-side so the returned data is unchanged.

## Changes

- `yfinance/scrapers/history.py` (~3 lines): `pd.Timestamp.now(...)` → `pd.Timestamp.now(...).normalize() + pd.Timedelta(days=1)` in the `start without end` branch.
- `tests/test_prices.py`: `test_history_start_no_end_stable_url` — patches `YfData.get` to capture `period2` from two back-to-back calls and asserts equality.

## Test plan

- [x] TDD red→green: test fails on `dev` (`period2` differs by 1s) and passes with the fix.
- [x] `python -m unittest tests.test_prices.TestPriceHistory.test_history_start_no_end_stable_url` — passes.
- [x] Live spot-check: same start, no end → identical URL → `requests_cache` returns from cache on the second call.
