### PR TITLE
Simplify phantom-dividend repair branch + drive-by typo/lint fixes

### DIFF
--- a/yfinance/domain/industry.py
+++ b/yfinance/domain/industry.py
@@ -92,17 +92,17 @@ class Industry(Domain):
         Returns:
             Optional[pd.DataFrame]: DataFrame containing parsed top performing companies data.
         """
-        compnaies_column = ['symbol','name','ytd return','last price','target price']
-        compnaies_values = [(c.get('symbol', None),
+        companies_column = ['symbol','name','ytd return','last price','target price']
+        companies_values = [(c.get('symbol', None),
                              c.get('name', None),
                              c.get('ytdReturn',{}).get('raw', None),
                              c.get('lastPrice',{}).get('raw', None),
                              c.get('targetPrice',{}).get('raw', None),) for c in top_performing_companies]
         
-        if not compnaies_values: 
+        if not companies_values: 
             return None
 
-        return _pd.DataFrame(compnaies_values, columns = compnaies_column).set_index('symbol')
+        return _pd.DataFrame(companies_values, columns = companies_column).set_index('symbol')
     
     def _parse_top_growth_companies(self, top_growth_companies: Dict) -> Optional[_pd.DataFrame]:
         """
@@ -114,16 +114,16 @@ class Industry(Domain):
         Returns:
             Optional[pd.DataFrame]: DataFrame containing parsed top growth companies data.
         """
-        compnaies_column = ['symbol','name','ytd return','growth estimate']
-        compnaies_values = [(c.get('symbol', None),
+        companies_column = ['symbol','name','ytd return','growth estimate']
+        companies_values = [(c.get('symbol', None),
                              c.get('name', None),
                              c.get('ytdReturn',{}).get('raw', None),
                              c.get('growthEstimate',{}).get('raw', None),) for c in top_growth_companies]
         
-        if not compnaies_values: 
+        if not companies_values: 
             return None
 
-        return _pd.DataFrame(compnaies_values, columns = compnaies_column).set_index('symbol')
+        return _pd.DataFrame(companies_values, columns = companies_column).set_index('symbol')
 
     def _fetch_and_parse(self) -> None:
         """

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -2252,8 +2252,7 @@ class PriceHistory:
                 if c == 'adj_exceeds_prices':
                     continue
 
-                if c == 'phantom' and self.ticker in ['KAP.IL', 'SAND']:
-                    # Manually approve, but these are probably safe to assume ok
+                if c == 'phantom':
                     continue
 
                 if c == 'div_date_wrong':
@@ -2731,7 +2730,8 @@ class PriceHistory:
             df_workings['VolStr'] = ''
             df_workings.loc[fna, 'VolStr'] = 'NaN'
             df_workings.loc[~fna, 'VolStr'] = (df_workings['Vol'][~fna]/1e6).astype('int').astype('str') + 'm'
-            df_workings['Vol'] = df_workings['VolStr'] ; df_workings.drop('VolStr', axis=1)
+            df_workings['Vol'] = df_workings['VolStr']
+            df_workings.drop('VolStr', axis=1)
         else:
             df_workings['Vol'] = (df_workings['Vol']/1e6).astype('int').astype('str') + 'm'
         debug_cols = ['Close']


### PR DESCRIPTION
## Summary

Originally proposed extracting a ticker-allowlist into a separate module. Per maintainer feedback on the review (#discussion_r3244327805), the allowlist was leakage from a custom debug build and should not be in `main` at all — phantom-dividend detections are safe to approve unconditionally in that branch. This PR now just applies that simplification plus two drive-by fixes that were already in the diff.

## Changes

- `yfinance/scrapers/history.py`
  - `_fix_bad_div_adjust`: replace `if c == 'phantom' and self.ticker in ['KAP.IL', 'SAND']:` with `if c == 'phantom':`. Removes a hardcoded ticker dependency from the repair kernel.
  - Drive-by: split a semicolon-joined statement (around line 2735) that was tripping ruff E702 in CI.
- `yfinance/domain/industry.py`
  - Drive-by typo: `compnaies_column` / `compnaies_values` → `companies_column` / `companies_values` (8 occurrences in `_parse_top_performing_companies` and `_parse_top_growth_companies`). Local-variable rename, no behavioural impact.

## Behaviour

`_fix_bad_div_adjust` now approves *all* phantom-dividend detections, not just those for `KAP.IL` / `SAND`. Per maintainer this is the intended behaviour.

## Test plan

- [x] `python -m unittest tests.test_price_repair` — 13 tests pass, 2 skipped
- [x] `ruff check yfinance/` — clean