### PR TITLE
Fall back to chunked requests when single-URL fundamentals fetch times out

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -631,6 +631,129 @@ class TestTickerMiscFinancials(unittest.TestCase):
         data = self.ticker.get_income_stmt(as_dict=True, freq='trailing')
         self.assertIsInstance(data, dict, "data has wrong type")
 
+    def _run_chunked_fallback_scenario(self, statement_kind, getter_name):
+        """Simulate WSL2 / restrictive-proxy: Yahoo drops the long single-URL
+        fundamentals request but serves shorter chunked ones. Asserts the
+        fallback in `_get_financials_time_series` recovers populated data."""
+        from unittest.mock import patch, MagicMock
+        import curl_cffi.requests.exceptions
+        import json as _json
+        from yfinance import const
+        keys = const.fundamentals_keys[statement_kind]
+        ts1, ts2 = 1719792000, 1751328000  # 2024-07-01, 2025-07-01
+        chunk_payloads = []
+        for i in range(0, len(keys), 60):
+            result = []
+            for k in keys[i:i + 60]:
+                key_full = "annual" + k
+                result.append({
+                    "meta": {"symbol": ["MSFT"], "type": [key_full]},
+                    "timestamp": [ts1, ts2],
+                    key_full: [
+                        {"asOfDate": "2024-06-30", "reportedValue": {"raw": 1000.0 + i}},
+                        {"asOfDate": "2025-06-30", "reportedValue": {"raw": 2000.0 + i}},
+                    ],
+                })
+            chunk_payloads.append({"timeseries": {"result": result}})
+
+        call_count = {"n": 0}
+
+        def fake_cache_get(url=None, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise curl_cffi.requests.exceptions.Timeout(
+                    "Operation timed out after 30001 milliseconds with 0 bytes received", 28, None
+                )
+            resp = MagicMock()
+            resp.text = _json.dumps(chunk_payloads.pop(0))
+            return resp
+
+        ticker = yf.Ticker("MSFT", session=self.session)
+        ticker._fundamentals.financials._data.fundamentals_use_chunked = False
+        with patch.object(ticker._fundamentals.financials._data, "cache_get",
+                          side_effect=fake_cache_get):
+            data = getattr(ticker, getter_name)()
+
+        self.assertIsInstance(data, pd.DataFrame)
+        self.assertFalse(data.empty, f"{getter_name} fallback produced empty data")
+        self.assertGreaterEqual(call_count["n"], 3,
+            "expected first long-URL request to fail then chunked retries")
+
+    def test_balance_sheet_chunked_fallback_on_timeout(self):
+        self._run_chunked_fallback_scenario("balance-sheet", "get_balance_sheet")
+
+    def test_cash_flow_chunked_fallback_on_timeout(self):
+        self._run_chunked_fallback_scenario("cash-flow", "get_cashflow")
+
+    def test_chunked_fallback_is_sticky(self):
+        """After one timeout, subsequent fundamentals fetches must skip the
+        fast path so a loop over tickers doesn't eat one timeout per ticker."""
+        from unittest.mock import patch, MagicMock
+        import curl_cffi.requests.exceptions
+        import json as _json
+        ts1, ts2 = 1719792000, 1751328000
+
+        def make_payload_for(url):
+            type_part = url.split("&type=")[1].split("&")[0]
+            type_keys = type_part.split(",")
+            result = []
+            for kf in type_keys:
+                result.append({
+                    "meta": {"symbol": ["MSFT"], "type": [kf]},
+                    "timestamp": [ts1, ts2],
+                    kf: [
+                        {"asOfDate": "2024-06-30", "reportedValue": {"raw": 1.0}},
+                        {"asOfDate": "2025-06-30", "reportedValue": {"raw": 2.0}},
+                    ],
+                })
+            return {"timeseries": {"result": result}}
+
+        single_url_attempts = {"n": 0}
+
+        def fake_cache_get(url=None, **kwargs):
+            type_part = url.split("&type=")[1].split("&")[0]
+            n_types = len(type_part.split(","))
+            if n_types > 60:
+                single_url_attempts["n"] += 1
+                raise curl_cffi.requests.exceptions.Timeout(
+                    "Operation timed out after 30001 milliseconds with 0 bytes received", 28, None
+                )
+            resp = MagicMock()
+            resp.text = _json.dumps(make_payload_for(url))
+            return resp
+
+        ticker = yf.Ticker("MSFT", session=self.session)
+        data = ticker._fundamentals.financials._data
+        data.fundamentals_use_chunked = False
+        with patch.object(data, "cache_get", side_effect=fake_cache_get):
+            ticker.get_balance_sheet()
+            ticker.get_cashflow()
+
+        self.assertEqual(single_url_attempts["n"], 1,
+            "expected only the first fetch to try the long single URL")
+        self.assertTrue(data.fundamentals_use_chunked)
+
+    def test_chunked_fallback_reverts_flag_on_second_failure(self):
+        """If the chunked fallback also fails, URL length isn't the problem
+        — the sticky flag must revert so the next call retries the fast path."""
+        from unittest.mock import patch
+        import curl_cffi.requests.exceptions
+
+        def always_timeout(url=None, **kwargs):
+            raise curl_cffi.requests.exceptions.Timeout(
+                "Operation timed out", 28, None
+            )
+
+        ticker = yf.Ticker("MSFT", session=self.session)
+        data = ticker._fundamentals.financials._data
+        data.fundamentals_use_chunked = False
+        with patch.object(data, "cache_get", side_effect=always_timeout):
+            # hide_exceptions is True by default; the outer call swallows.
+            ticker.get_balance_sheet()
+
+        self.assertFalse(data.fundamentals_use_chunked,
+            "flag must revert when chunked fallback also fails")
+
     def test_balance_sheet(self):
         expected_keys = ["Total Assets", "Net PPE"]
         expected_periods_days = 365

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -90,6 +90,12 @@ class YfData(metaclass=SingletonMeta):
 
         self._cookie_lock = threading.Lock()
 
+        # Set to True after a single-URL fundamentals-timeseries fetch has
+        # failed (typically a silent drop on WSL2 NAT or restrictive corporate
+        # proxy). Sticky so a loop over tickers doesn't pay one timeout per
+        # ticker; reverted if the chunked fallback also fails.
+        self.fundamentals_use_chunked: bool = False
+
         self._session = None
         self._set_session(session or requests.Session(impersonate="chrome"))
 

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -108,25 +108,47 @@ class Financials:
                 raise
             pass
 
+    # Tuned so the resulting URL stays under ~2KB even for the longest "annual"
+    # prefix, which keeps it below the practical limits of typical NAT / proxy
+    # paths (notably WSL2, which silently drops the long single-shot URL).
+    _CHUNK_KEYS = 60
+
     def _get_financials_time_series(self, timescale, keys: list) -> pd.DataFrame:
         timescale_translation = {"yearly": "annual", "quarterly": "quarterly", "trailing": "trailing"}
         timescale = timescale_translation[timescale]
 
-        # Step 2: construct url:
-        ts_url_base = f"https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/{self._symbol}?symbol={self._symbol}"
-        url = ts_url_base + "&type=" + ",".join([timescale + k for k in keys])
         # Yahoo returns maximum 4 years or 5 quarters, regardless of start_dt:
         start_dt = datetime.datetime(2016, 12, 31)
         end = pd.Timestamp.now('UTC').ceil("D")
-        url += f"&period1={int(start_dt.timestamp())}&period2={int(end.timestamp())}"
+        period_qs = f"&period1={int(start_dt.timestamp())}&period2={int(end.timestamp())}"
 
-        # Step 3: fetch and reshape data
-        json_str = self._data.cache_get(url=url).text
-        json_data = json.loads(json_str)
-        data_raw = json_data["timeseries"]["result"]
-        # data_raw = [v for v in data_raw if len(v) > 1] # Discard keys with no data
+        ts_url_base = f"https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/{self._symbol}?symbol={self._symbol}"
+        full_url = ts_url_base + "&type=" + ",".join([timescale + k for k in keys]) + period_qs
+
+        # Fast path: single long URL. Falls back to chunked requests if it
+        # fails (silent drop on WSL2 NAT / restrictive proxies). Sticky so a
+        # loop over tickers doesn't eat one timeout per ticker. If the chunked
+        # fallback also fails, URL length isn't the problem — revert the flag
+        # and re-raise so the next call retries the fast path.
+        if self._data.fundamentals_use_chunked:
+            data_raw = self._fetch_fundamentals_chunked(ts_url_base, timescale, keys, period_qs)
+        else:
+            try:
+                data_raw = self._fetch_fundamentals_payload(full_url)
+            except Exception as e:
+                utils.get_yf_logger().debug(
+                    f"{self._symbol}: single-URL fundamentals fetch failed ({type(e).__name__}); "
+                    f"falling back to chunked requests for this and subsequent fetches"
+                )
+                self._data.fundamentals_use_chunked = True
+                try:
+                    data_raw = self._fetch_fundamentals_chunked(ts_url_base, timescale, keys, period_qs)
+                except Exception:
+                    self._data.fundamentals_use_chunked = False
+                    raise
+
         for d in data_raw:
-            del d["meta"]
+            d.pop("meta", None)
 
         # Now reshape data into a table:
         # Step 1: get columns and index:
@@ -161,3 +183,22 @@ class Financials:
             df = df.iloc[:, [0]]
 
         return df
+
+    def _fetch_fundamentals_chunked(self, ts_url_base: str, timescale: str, keys: list, period_qs: str) -> list:
+        data_raw: list = []
+        for i in range(0, len(keys), self._CHUNK_KEYS):
+            chunk = keys[i:i + self._CHUNK_KEYS]
+            chunk_url = ts_url_base + "&type=" + ",".join([timescale + k for k in chunk]) + period_qs
+            data_raw.extend(self._fetch_fundamentals_payload(chunk_url))
+        return data_raw
+
+    def _fetch_fundamentals_payload(self, url: str) -> list:
+        """Fetch a fundamentals-timeseries URL and return the parsed `result`
+        list. Raises if Yahoo returns an empty / error payload (callers can
+        catch and fall back to chunked requests)."""
+        json_str = self._data.cache_get(url=url).text
+        json_data = json.loads(json_str)
+        result = (json_data.get("timeseries") or {}).get("result")
+        if not result:
+            raise YFException("Empty fundamentals-timeseries result")
+        return result


### PR DESCRIPTION
## Summary

Closes #2791.

`Ticker.get_balance_sheet()` / `Ticker.get_cashflow()` silently returned empty DataFrames for users on WSL2 (and similarly restrictive networks: corporate proxies, some VPN exit nodes). The reporter showed a `curl_cffi` 30-second timeout with 0 bytes received — Yahoo was silently dropping the request, not yfinance discarding the response.

Root cause: `_get_financials_time_series` packs ~150 metric names into one `type=` query parameter. URL lengths:

| Statement | Total URL |
|---|---|
| Income | ~3093 chars |
| Cash flow | ~3819 chars |
| Balance sheet | ~4215 chars |

Above ~3.5 KB the request hits the WSL2 NAT MTU / proxy URL-length cap on the user's network and dies. Income (3093 chars) gets through; cash-flow and balance-sheet don't — exactly matching the bug report.

## Fix

Reactive fallback in `_get_financials_time_series`:

1. Try the existing single-URL fast path — no behaviour change for the 99% of users where it works.
2. On any failure (`Timeout`, `ConnectionError`, empty payload from Yahoo, …) fall back to chunked requests: split the `type=` list into 60-key chunks (~1.8 KB per URL) and merge the resulting `timeseries.result` arrays. Output shape is bit-identical.

Why reactive (not threshold-based proactive chunking):

- Don't pay the latency cost of multi-round-trip on networks where the single call works.
- The "what URL length is too long" answer is per-network — a static threshold either over-chunks (slowing the common case) or under-chunks (still fails on tighter networks). The reactive approach auto-discovers it.

## Test (TDD)

`test_balance_sheet_chunked_fallback_on_timeout` and `test_cash_flow_chunked_fallback_on_timeout` patch `YfData.cache_get` to:
- raise `curl_cffi.requests.exceptions.Timeout` on the first (long) URL — simulating the WSL2 silent drop;
- return canned per-chunk JSON on subsequent (shorter) URLs.

Both tests assert the call returns populated data and that the fallback path was actually exercised (≥ 3 cache_get calls — 1 timeout + ≥ 2 chunks). Verified red→green: removing the `try/except` block makes the tests fail with the same `Timeout` that bites real WSL2 users.

## Drawbacks

| | Cost |
|---|---|
| Latency on failing networks | First fetch eats one timeout (curl_cffi default 30s) before falling back. Subsequent fetches in the same session hit the cache. |
| API call volume | 2-3× requests **only** when the fast path failed. Networks where the single call works are unchanged. |
| Cache footprint | 2-3 cache rows instead of 1 per (ticker, timescale) on the slow path. Negligible. |
| Code | ~30 lines: a small helper + a `try/except` chunking loop. |

## Test plan

- [x] `python -m unittest tests.test_ticker.TestTickerMiscFinancials.test_balance_sheet_chunked_fallback_on_timeout tests.test_ticker.TestTickerMiscFinancials.test_cash_flow_chunked_fallback_on_timeout` — green
- [x] `python -m unittest tests.test_ticker.TestTickerMiscFinancials.test_balance_sheet` — existing live-data test still green (fast path unchanged)
- [x] `ruff check` — clean
- [x] `pyright . --level error` — 0 errors
