### PR TITLE
Add opt-in polars output via pandas pipeline + boundary adapter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     extras_require={
         'nospam': ['requests_cache>=1.0', 'requests_ratelimiter>=0.3.1'],
         'repair': ['scipy>=1.6.3'],
+        'polars': ['polars>=1.0'],
     },
     # Include protobuf files for websocket support
     package_data={

--- a/tests/test_dataframe_backend.py
+++ b/tests/test_dataframe_backend.py
@@ -1,0 +1,378 @@
+"""Tests for the dataframe backend dispatch.
+
+Covers ``YfConfig.dataframe.backend`` validation and parity of every
+wrapped boundary in the codebase — using mocked-data unit tests so the
+suite stays network-independent.
+"""
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from yfinance._backend import df_to_backend, series_to_backend
+from yfinance.config import YfConfig
+from yfinance.lookup import Lookup
+
+
+_LOOKUP_RESPONSE = {
+    "finance": {
+        "result": [
+            {
+                "documents": [
+                    {"symbol": "AAPL", "longName": "Apple Inc.", "quoteType": "EQUITY"},
+                    {"symbol": "MSFT", "longName": "Microsoft", "quoteType": "EQUITY"},
+                ]
+            }
+        ]
+    }
+}
+
+
+def _polars_df_type():
+    import polars as pl
+    return pl.DataFrame
+
+
+# ---------------------------------------------------------------------------
+# YfConfig.dataframe.backend validation
+# ---------------------------------------------------------------------------
+class TestDataframeBackendConfig(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_default_backend_is_pandas(self):
+        self.assertEqual(YfConfig.dataframe.backend, "pandas")
+
+    def test_polars_backend_accepted(self):
+        YfConfig.dataframe.backend = "polars"
+        self.assertEqual(YfConfig.dataframe.backend, "polars")
+
+    def test_pandas_backend_accepted(self):
+        YfConfig.dataframe.backend = "polars"
+        YfConfig.dataframe.backend = "pandas"
+        self.assertEqual(YfConfig.dataframe.backend, "pandas")
+
+    def test_unknown_backend_raises(self):
+        with self.assertRaises(ValueError):
+            YfConfig.dataframe.backend = "modin"
+
+    def test_unknown_backend_does_not_corrupt_state(self):
+        try:
+            YfConfig.dataframe.backend = "modin"
+        except ValueError:
+            pass
+        self.assertEqual(YfConfig.dataframe.backend, "pandas")
+
+
+# ---------------------------------------------------------------------------
+# Helpers in _backend.py
+# ---------------------------------------------------------------------------
+class TestDfToBackend(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_pandas_is_passthrough(self):
+        df = pd.DataFrame({"x": [1, 2]})
+        out = df_to_backend(df)
+        self.assertIs(out, df)
+
+    def test_polars_returns_polars_frame(self):
+        YfConfig.dataframe.backend = "polars"
+        df = pd.DataFrame({"x": [1, 2]})
+        out = df_to_backend(df)
+        self.assertIsInstance(out, _polars_df_type())
+
+    def test_polars_promotes_named_index_to_column(self):
+        YfConfig.dataframe.backend = "polars"
+        df = pd.DataFrame({"v": [1, 2]}, index=pd.Index(["a", "b"], name="key"))
+        out = df_to_backend(df)
+        self.assertIn("key", out.columns)
+        self.assertEqual(out["key"].to_list(), ["a", "b"])
+
+    def test_polars_override_index_name(self):
+        YfConfig.dataframe.backend = "polars"
+        df = pd.DataFrame({"v": [1, 2]}, index=pd.Index(["a", "b"]))
+        out = df_to_backend(df, index_as_column="Date")
+        self.assertIn("Date", out.columns)
+
+    def test_polars_rangeindex_unnamed_is_dropped(self):
+        YfConfig.dataframe.backend = "polars"
+        df = pd.DataFrame({"v": [1, 2]})  # default RangeIndex, no name
+        out = df_to_backend(df)
+        self.assertNotIn("index", out.columns)
+        self.assertEqual(out["v"].to_list(), [1, 2])
+
+    def test_polars_empty_frame(self):
+        YfConfig.dataframe.backend = "polars"
+        out = df_to_backend(pd.DataFrame())
+        self.assertIsInstance(out, _polars_df_type())
+        self.assertEqual(out.shape, (0, 0))
+
+
+class TestSeriesToBackend(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_pandas_is_passthrough(self):
+        s = pd.Series([1, 2], name="x")
+        out = series_to_backend(s)
+        self.assertIs(out, s)
+
+    def test_polars_no_index_two_columns(self):
+        YfConfig.dataframe.backend = "polars"
+        s = pd.Series([1.0, 2.0], index=pd.Index(["a", "b"], name="Date"), name="Dividends")
+        out = series_to_backend(s, index_as_column="Date", value_name="Dividends")
+        self.assertIsInstance(out, _polars_df_type())
+        self.assertEqual(out.columns, ["Date", "Dividends"])
+        self.assertEqual(out["Dividends"].to_list(), [1.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# lookup.py
+# ---------------------------------------------------------------------------
+class TestLookupBackendParity(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_pandas_output_uses_symbol_index(self):
+        YfConfig.dataframe.backend = "pandas"
+        df = Lookup._parse_response(_LOOKUP_RESPONSE)
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(df.index.name, "symbol")
+        self.assertEqual(list(df.index), ["AAPL", "MSFT"])
+
+    def test_polars_output_keeps_symbol_column(self):
+        YfConfig.dataframe.backend = "polars"
+        df = Lookup._parse_response(_LOOKUP_RESPONSE)
+        self.assertIsInstance(df, _polars_df_type())
+        self.assertIn("symbol", df.columns)
+        self.assertEqual(df["symbol"].to_list(), ["AAPL", "MSFT"])
+
+    def test_empty_result_returns_empty_frame(self):
+        for backend in ("pandas", "polars"):
+            YfConfig.dataframe.backend = backend
+            df = Lookup._parse_response({"finance": {"result": []}})
+            self.assertEqual(len(df), 0, f"{backend}: expected empty frame")
+
+
+# ---------------------------------------------------------------------------
+# base.py wrappers — exercise the get_* methods directly with fake scrapers.
+# ---------------------------------------------------------------------------
+def _fake_ticker(scraper_attrs: dict) -> MagicMock:
+    """Build a TickerBase-like mock pre-populated with scraper attributes
+    so we can call get_* methods without network."""
+    from yfinance.base import TickerBase
+    t = TickerBase.__new__(TickerBase)
+    for k, v in scraper_attrs.items():
+        setattr(t, k, v)
+    return t
+
+
+class TestBaseGetterWrappers(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def _ticker_with_quote(self, **kwargs):
+        quote = MagicMock()
+        for k, v in kwargs.items():
+            setattr(quote, k, v)
+        return _fake_ticker({"_quote": quote})
+
+    def _ticker_with_holders(self, **kwargs):
+        holders = MagicMock()
+        for k, v in kwargs.items():
+            setattr(holders, k, v)
+        return _fake_ticker({"_holders": holders})
+
+    def _ticker_with_analysis(self, **kwargs):
+        analysis = MagicMock()
+        for k, v in kwargs.items():
+            setattr(analysis, k, v)
+        return _fake_ticker({"_analysis": analysis})
+
+    def _df(self):
+        return pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    def test_get_recommendations(self):
+        t = self._ticker_with_quote(recommendations=self._df())
+        YfConfig.dataframe.backend = "pandas"
+        self.assertIsInstance(t.get_recommendations(), pd.DataFrame)
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_recommendations(), _polars_df_type())
+
+    def test_get_upgrades_downgrades(self):
+        t = self._ticker_with_quote(upgrades_downgrades=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_upgrades_downgrades(), _polars_df_type())
+
+    def test_get_sustainability(self):
+        t = self._ticker_with_quote(sustainability=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_sustainability(), _polars_df_type())
+
+    def test_get_valuation_measures(self):
+        t = self._ticker_with_quote(valuation_measures=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_valuation_measures(), _polars_df_type())
+
+    def test_get_major_holders(self):
+        t = self._ticker_with_holders(major=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_major_holders(), _polars_df_type())
+
+    def test_get_institutional_holders(self):
+        t = self._ticker_with_holders(institutional=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_institutional_holders(), _polars_df_type())
+
+    def test_get_mutualfund_holders(self):
+        t = self._ticker_with_holders(mutualfund=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_mutualfund_holders(), _polars_df_type())
+
+    def test_get_insider_purchases(self):
+        t = self._ticker_with_holders(insider_purchases=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_insider_purchases(), _polars_df_type())
+
+    def test_get_insider_transactions(self):
+        t = self._ticker_with_holders(insider_transactions=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_insider_transactions(), _polars_df_type())
+
+    def test_get_insider_roster_holders(self):
+        t = self._ticker_with_holders(insider_roster=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_insider_roster_holders(), _polars_df_type())
+
+    def test_get_earnings_estimate(self):
+        t = self._ticker_with_analysis(earnings_estimate=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_earnings_estimate(), _polars_df_type())
+
+    def test_get_revenue_estimate(self):
+        t = self._ticker_with_analysis(revenue_estimate=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_revenue_estimate(), _polars_df_type())
+
+    def test_get_earnings_history(self):
+        t = self._ticker_with_analysis(earnings_history=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_earnings_history(), _polars_df_type())
+
+    def test_get_eps_trend(self):
+        t = self._ticker_with_analysis(eps_trend=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_eps_trend(), _polars_df_type())
+
+    def test_get_eps_revisions(self):
+        t = self._ticker_with_analysis(eps_revisions=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_eps_revisions(), _polars_df_type())
+
+    def test_get_growth_estimates(self):
+        t = self._ticker_with_analysis(growth_estimates=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_growth_estimates(), _polars_df_type())
+
+    def test_as_dict_short_circuit_returns_dict(self):
+        """`as_dict=True` must always return a plain dict regardless of backend."""
+        t = self._ticker_with_quote(recommendations=self._df())
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(t.get_recommendations(as_dict=True), dict)
+
+
+# ---------------------------------------------------------------------------
+# Cache invariant: changing backend mid-session must propagate to next access.
+# ---------------------------------------------------------------------------
+class TestBackendSwitchInvariant(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_lookup_repeated_parse_honors_current_backend(self):
+        YfConfig.dataframe.backend = "pandas"
+        pd_df = Lookup._parse_response(_LOOKUP_RESPONSE)
+        self.assertIsInstance(pd_df, pd.DataFrame)
+        YfConfig.dataframe.backend = "polars"
+        pl_df = Lookup._parse_response(_LOOKUP_RESPONSE)
+        self.assertIsInstance(pl_df, _polars_df_type())
+        YfConfig.dataframe.backend = "pandas"
+        pd_df_again = Lookup._parse_response(_LOOKUP_RESPONSE)
+        self.assertIsInstance(pd_df_again, pd.DataFrame)
+
+
+# ---------------------------------------------------------------------------
+# calendars.py — _cleanup_df + _to_backend
+# ---------------------------------------------------------------------------
+class TestCalendarsBackendParity(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def _make_calendars(self, calendar_type="sp_earnings"):
+        from yfinance.calendars import Calendars
+        # Synthetic raw frame matching what _create_df builds.
+        if calendar_type == "sp_earnings":
+            df = pd.DataFrame({
+                "Symbol": ["AAPL", "MSFT"],
+                "Company Name": ["Apple", "Microsoft"],
+                "Market Cap (Intraday)": [1.0, 2.0],
+                "Event Name": ["Q1", "Q2"],
+                "Event Start Date": ["2025-01-01", "2025-02-01"],
+                "Timing": ["BMO", "AMC"],
+                "EPS Estimate": [1.0, 2.0],
+                "Reported EPS": [1.1, 2.1],
+                "Surprise (%)": [0.1, 0.05],
+            })
+        c = Calendars()
+        c.calendars[calendar_type] = df
+        return c
+
+    def test_to_backend_pandas(self):
+        c = self._make_calendars()
+        df = c._to_backend("sp_earnings")
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(df.index.name, "Symbol")
+
+    def test_to_backend_polars_keeps_index_as_column(self):
+        YfConfig.dataframe.backend = "polars"
+        c = self._make_calendars()
+        df = c._to_backend("sp_earnings")
+        self.assertIsInstance(df, _polars_df_type())
+        self.assertIn("Symbol", df.columns)
+
+
+# ---------------------------------------------------------------------------
+# domain/sector.py
+# ---------------------------------------------------------------------------
+class TestSectorBackendParity(unittest.TestCase):
+
+    def tearDown(self):
+        YfConfig.dataframe.backend = "pandas"
+
+    def test_industries_property_switches_with_backend(self):
+        from yfinance.domain.sector import Sector
+        s = Sector.__new__(Sector)
+        s._industries = pd.DataFrame(
+            {"name": ["A", "B"], "symbol": ["X", "Y"], "market weight": [0.5, 0.5]},
+            index=pd.Index(["a", "b"], name="key"),
+        )
+        s._ensure_fetched = lambda *_a, **_kw: None  # type: ignore[assignment]
+
+        YfConfig.dataframe.backend = "pandas"
+        self.assertIsInstance(s.industries, pd.DataFrame)
+        YfConfig.dataframe.backend = "polars"
+        self.assertIsInstance(s.industries, _polars_df_type())
+        self.assertIn("key", s.industries.columns)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/_backend.py
+++ b/yfinance/_backend.py
@@ -1,0 +1,93 @@
+"""DataFrame backend dispatch.
+
+Strategy: yfinance pipelines are pandas-native end-to-end. Polars
+support is implemented as a thin output adapter — when
+``YfConfig.dataframe.backend == "polars"`` we convert the pandas
+DataFrame (or Series) at the public-API boundary via
+``df_to_backend`` / ``series_to_backend``. There is **one** code path
+internally; polars is never used to build or transform frames.
+
+This directly answers the maintenance concern raised on PR #2808:
+a parallel polars implementation doubles surface area; an output
+adapter does not.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Union
+
+import pandas as pd
+
+from .config import YfConfig
+
+if TYPE_CHECKING:
+    import polars as pl  # noqa: F401
+
+# Public return-type aliases for methods whose runtime type depends on
+# ``YfConfig.dataframe.backend``. Both polars symbols are quoted so
+# nothing is imported at runtime when the optional dep is absent.
+DataFrameLike = Union[pd.DataFrame, "pl.DataFrame"]
+SeriesLike = Union[pd.Series, "pl.DataFrame"]
+
+
+def current_backend() -> str:
+    """Active dataframe backend: ``"pandas"`` (default) or ``"polars"``."""
+    return YfConfig.dataframe.backend or "pandas"
+
+
+def _polars():
+    """Lazy-import polars. Raises a clear error if the user opted into
+    ``polars`` without installing the optional dependency."""
+    try:
+        import polars as pl
+    except ImportError as e:
+        raise ImportError(
+            "polars backend requires the optional dependency. "
+            "Install with: pip install yfinance[polars]"
+        ) from e
+    return pl
+
+
+def empty_df() -> Any:
+    """Empty DataFrame in the active backend."""
+    if current_backend() == "polars":
+        return _polars().DataFrame()
+    return pd.DataFrame()
+
+
+def df_to_backend(df: pd.DataFrame, *, index_as_column: str | None = None) -> Any:
+    """Convert a pandas DataFrame to the active backend at an output
+    boundary. Polars has no row index concept, so we always promote the
+    pandas index to a column on the polars side: ``index_as_column``
+    overrides the column name when provided, otherwise the existing
+    index name (or ``"index"``) is kept. Pass-through for pandas.
+    """
+    if current_backend() == "pandas":
+        return df
+    pl = _polars()
+    if df.empty and len(df.columns) == 0:
+        return pl.DataFrame()
+    df_reset = df.copy()
+    if index_as_column is not None and df_reset.index.name != index_as_column:
+        df_reset.index.name = index_as_column
+    if isinstance(df_reset.index, pd.RangeIndex) and df_reset.index.name is None:
+        return pl.from_pandas(df_reset)
+    return pl.from_pandas(df_reset.reset_index())
+
+
+def series_to_backend(s: pd.Series, *, index_as_column: str | None = None, value_name: str | None = None) -> Any:
+    """Convert a pandas Series to the active backend. Polars Series have
+    no index, so the result is a two-column frame
+    ``(index_as_column, value_name)`` when ``index_as_column`` is given.
+    Pass-through for pandas backend.
+    """
+    if current_backend() == "pandas":
+        return s
+    pl = _polars()
+    if index_as_column is not None:
+        df = s.reset_index()
+        if value_name is not None and df.columns[-1] != value_name:
+            df = df.rename(columns={df.columns[-1]: value_name})
+        if df.columns[0] != index_as_column:
+            df = df.rename(columns={df.columns[0]: index_as_column})
+        return pl.from_pandas(df)
+    return pl.from_pandas(s.to_frame())

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -31,6 +31,7 @@ from curl_cffi import requests
 
 
 from . import utils, cache
+from ._backend import DataFrameLike, SeriesLike, df_to_backend, series_to_backend
 from .const import _MIC_TO_YAHOO_SUFFIX, _SENTINEL_
 from .data import YfData
 from .config import YfConfig
@@ -125,7 +126,7 @@ class TickerBase:
         self.ws = None
 
     @utils.log_indent_decorator
-    def history(self, *args, **kwargs) -> pd.DataFrame:
+    def history(self, *args, **kwargs) -> DataFrameLike:
         return self._lazy_load_price_history().history(*args, **kwargs)
 
     # ------------------------
@@ -215,7 +216,7 @@ class TickerBase:
         data = self._quote.recommendations
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data)
 
     def get_recommendations_summary(self, as_dict=False):
         return self.get_recommendations(as_dict=as_dict)
@@ -229,7 +230,7 @@ class TickerBase:
         data = self._quote.upgrades_downgrades
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data, index_as_column='GradeDate')
 
     def get_calendar(self) -> dict:
         return self._quote.calendar
@@ -241,42 +242,42 @@ class TickerBase:
         data = self._holders.major
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data)
 
     def get_institutional_holders(self, as_dict=False):
         data = self._holders.institutional
         if data is not None:
             if as_dict:
                 return data.to_dict()
-            return data
+            return df_to_backend(data)
 
     def get_mutualfund_holders(self, as_dict=False):
         data = self._holders.mutualfund
         if data is not None:
             if as_dict:
                 return data.to_dict()
-            return data
+            return df_to_backend(data)
 
     def get_insider_purchases(self, as_dict=False):
         data = self._holders.insider_purchases
         if data is not None:
             if as_dict:
                 return data.to_dict()
-            return data
+            return df_to_backend(data)
 
     def get_insider_transactions(self, as_dict=False):
         data = self._holders.insider_transactions
         if data is not None:
             if as_dict:
                 return data.to_dict()
-            return data
+            return df_to_backend(data)
 
     def get_insider_roster_holders(self, as_dict=False):
         data = self._holders.insider_roster
         if data is not None:
             if as_dict:
                 return data.to_dict()
-            return data
+            return df_to_backend(data)
 
     def get_info(self) -> dict:
         data = self._quote.info
@@ -288,14 +289,13 @@ class TickerBase:
         return self._fast_info
 
     def get_valuation_measures(self):
-        data = self._quote.valuation_measures
-        return data
+        return df_to_backend(self._quote.valuation_measures)
 
     def get_sustainability(self, as_dict=False):
         data = self._quote.sustainability
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data)
 
     def get_analyst_price_targets(self) -> dict:
         """
@@ -310,7 +310,7 @@ class TickerBase:
         Columns:    numberOfAnalysts  avg  low  high  yearAgoEps  growth
         """
         data = self._analysis.earnings_estimate
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_revenue_estimate(self, as_dict=False):
         """
@@ -318,7 +318,7 @@ class TickerBase:
         Columns:    numberOfAnalysts  avg  low  high  yearAgoRevenue  growth
         """
         data = self._analysis.revenue_estimate
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_earnings_history(self, as_dict=False):
         """
@@ -326,7 +326,7 @@ class TickerBase:
         Columns:    epsEstimate  epsActual  epsDifference  surprisePercent
         """
         data = self._analysis.earnings_history
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_eps_trend(self, as_dict=False):
         """
@@ -335,7 +335,7 @@ class TickerBase:
         """
 
         data = self._analysis.eps_trend
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_eps_revisions(self, as_dict=False):
         """
@@ -344,7 +344,7 @@ class TickerBase:
         """
 
         data = self._analysis.eps_revisions
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_growth_estimates(self, as_dict=False):
         """
@@ -353,7 +353,7 @@ class TickerBase:
         """
 
         data = self._analysis.growth_estimates
-        return data.to_dict() if as_dict else data
+        return data.to_dict() if as_dict else df_to_backend(data)
 
     def get_earnings(self, as_dict=False, freq="yearly"):
         """
@@ -374,7 +374,7 @@ class TickerBase:
             dict_data['financialCurrency'] = 'USD' if 'financialCurrency' not in self._earnings else self._earnings[
                 'financialCurrency']
             return dict_data
-        return data
+        return df_to_backend(data)
 
     def get_income_stmt(self, as_dict=False, pretty=False, freq="yearly"):
         """
@@ -397,7 +397,7 @@ class TickerBase:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["EBIT", "EBITDA", "EPS", "NI"])
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data, index_as_column='metric')
 
     def get_incomestmt(self, as_dict=False, pretty=False, freq="yearly"):
         return self.get_income_stmt(as_dict, pretty, freq)
@@ -427,12 +427,12 @@ class TickerBase:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["PPE"])
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data, index_as_column='metric')
 
     def get_balancesheet(self, as_dict=False, pretty=False, freq="yearly"):
         return self.get_balance_sheet(as_dict, pretty, freq)
 
-    def get_cash_flow(self, as_dict=False, pretty=False, freq="yearly") -> Union[pd.DataFrame, dict]:
+    def get_cash_flow(self, as_dict=False, pretty=False, freq="yearly") -> Union[DataFrameLike, dict]:
         """
         :Parameters:
             as_dict: bool
@@ -454,28 +454,29 @@ class TickerBase:
             data.index = utils.camel2title(data.index, sep=' ', acronyms=["PPE"])
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data, index_as_column='metric')
 
     def get_cashflow(self, as_dict=False, pretty=False, freq="yearly"):
         return self.get_cash_flow(as_dict, pretty, freq)
 
-    def get_dividends(self, period="max") -> pd.Series:
-        return self._lazy_load_price_history().get_dividends(period=period)
+    def get_dividends(self, period="max") -> SeriesLike:
+        return series_to_backend(self._lazy_load_price_history().get_dividends(period=period), index_as_column='Date', value_name='Dividends')
 
-    def get_capital_gains(self, period="max") -> pd.Series:
-        return self._lazy_load_price_history().get_capital_gains(period=period)
+    def get_capital_gains(self, period="max") -> SeriesLike:
+        return series_to_backend(self._lazy_load_price_history().get_capital_gains(period=period), index_as_column='Date', value_name='Capital Gains')
 
-    def get_splits(self, period="max") -> pd.Series:
-        return self._lazy_load_price_history().get_splits(period=period)
+    def get_splits(self, period="max") -> SeriesLike:
+        return series_to_backend(self._lazy_load_price_history().get_splits(period=period), index_as_column='Date', value_name='Stock Splits')
 
-    def get_actions(self, period="max") -> pd.Series:
-        return self._lazy_load_price_history().get_actions(period=period)
+    def get_actions(self, period="max") -> SeriesLike:
+        actions = self._lazy_load_price_history().get_actions(period=period)
+        return df_to_backend(actions, index_as_column='Date') if hasattr(actions, 'columns') else series_to_backend(actions, index_as_column='Date')
 
-    def get_shares(self, as_dict=False) -> Union[pd.DataFrame, dict]:
+    def get_shares(self, as_dict=False) -> Union[DataFrameLike, dict]:
         data = self._fundamentals.shares
         if as_dict:
             return data.to_dict()
-        return data
+        return df_to_backend(data)
 
     @utils.log_indent_decorator
     def get_shares_full(self, start=None, end=None):
@@ -533,7 +534,7 @@ class TickerBase:
 
         df.index = df.index.tz_localize(tz)
         df = df.sort_index()
-        return df
+        return series_to_backend(df, index_as_column='Date', value_name='Shares')
 
     def get_isin(self) -> Optional[str]:
         # *** experimental ***
@@ -613,16 +614,16 @@ class TickerBase:
         self._news = [article for article in news if not article.get('ad', [])]
         return self._news
 
-    def get_earnings_dates(self, limit = 12, offset = 0) -> Optional[pd.DataFrame]:
+    def get_earnings_dates(self, limit = 12, offset = 0) -> Optional[DataFrameLike]:
         if limit > 100:
             raise ValueError("Yahoo caps limit at 100")
 
         if self._earnings_dates and limit in self._earnings_dates:
-            return self._earnings_dates[limit]
+            return df_to_backend(self._earnings_dates[limit], index_as_column='Earnings Date')
 
         df = self._get_earnings_dates_using_scrape(limit, offset)
         self._earnings_dates[limit] = df
-        return df
+        return df_to_backend(df, index_as_column='Earnings Date') if df is not None else df
 
     @utils.log_indent_decorator
     def _get_earnings_dates_using_scrape(self, limit = 12, offset = 0) -> Optional[pd.DataFrame]:

--- a/yfinance/calendars.py
+++ b/yfinance/calendars.py
@@ -7,6 +7,7 @@ from requests import Session, Response, exceptions
 import pandas as pd
 from datetime import datetime, date, timedelta
 
+from ._backend import DataFrameLike, df_to_backend
 from .const import _QUERY1_URL_
 from .utils import log_indent_decorator, get_yf_logger, _parse_user_dt
 from .screener import screen
@@ -219,7 +220,7 @@ class Calendars:
 
     def _get_data(
         self, calendar_type: str, query: CalendarQuery, limit=12, offset=0, force=False
-    ) -> pd.DataFrame:
+    ) -> DataFrameLike:
         if calendar_type not in PREDEFINED_CALENDARS:
             raise YFException(f"Unknown calendar type: {calendar_type}")
 
@@ -256,7 +257,11 @@ class Calendars:
             raise YFException(json_data.get("finance", {}).get("error", {}))
 
         self.calendars[calendar_type] = self._create_df(json_data)
-        return self._cleanup_df(calendar_type)
+        return self._to_backend(calendar_type)
+
+    def _to_backend(self, calendar_type: str):
+        df = self._cleanup_df(calendar_type)
+        return df_to_backend(df, index_as_column=PREDEFINED_CALENDARS[calendar_type]["df_index"])
 
     def _create_df(self, json_data: dict) -> pd.DataFrame:
         columns = []
@@ -365,7 +370,7 @@ class Calendars:
         limit=12,
         offset=0,
         force=False,
-    ) -> pd.DataFrame:
+    ) -> DataFrameLike:
         """
         Retrieve earnings calendar from YF as a DataFrame.
         Will re-query every time it is called, overwriting previous data.
@@ -429,7 +434,7 @@ class Calendars:
     @log_indent_decorator
     def get_ipo_info_calendar(
         self, start=None, end=None, limit=12, offset=0, force=False
-    ) -> pd.DataFrame:
+    ) -> DataFrameLike:
         """
         Retrieve IPOs calendar from YF as a Dataframe.
 
@@ -471,7 +476,7 @@ class Calendars:
     @log_indent_decorator
     def get_economic_events_calendar(
         self, start=None, end=None, limit=12, offset=0, force=False
-    ) -> pd.DataFrame:
+    ) -> DataFrameLike:
         """
         Retrieve Economic Events calendar from YF as a DataFrame.
 
@@ -495,7 +500,7 @@ class Calendars:
     @log_indent_decorator
     def get_splits_calendar(
         self, start=None, end=None, limit=12, offset=0, force=False
-    ) -> pd.DataFrame:
+    ) -> DataFrameLike:
         """
         Retrieve Splits calendar from YF as a DataFrame.
 
@@ -519,29 +524,29 @@ class Calendars:
     ### Easy / Default getter functions:
 
     @property
-    def earnings_calendar(self) -> pd.DataFrame:
+    def earnings_calendar(self) -> DataFrameLike:
         """Earnings calendar with default settings."""
         if "sp_earnings" in self.calendars:
-            return self.calendars["sp_earnings"]
+            return self._to_backend("sp_earnings")
         return self.get_earnings_calendar()
 
     @property
-    def ipo_info_calendar(self) -> pd.DataFrame:
+    def ipo_info_calendar(self) -> DataFrameLike:
         """IPOs calendar with default settings."""
         if "ipo_info" in self.calendars:
-            return self.calendars["ipo_info"]
+            return self._to_backend("ipo_info")
         return self.get_ipo_info_calendar()
 
     @property
-    def economic_events_calendar(self) -> pd.DataFrame:
+    def economic_events_calendar(self) -> DataFrameLike:
         """Economic events calendar with default settings."""
         if "economic_event" in self.calendars:
-            return self.calendars["economic_event"]
+            return self._to_backend("economic_event")
         return self.get_economic_events_calendar()
 
     @property
-    def splits_calendar(self) -> pd.DataFrame:
+    def splits_calendar(self) -> DataFrameLike:
         """Splits calendar with default settings."""
         if "splits" in self.calendars:
-            return self.calendars["splits"]
+            return self._to_backend("splits")
         return self.get_splits_calendar()

--- a/yfinance/config.py
+++ b/yfinance/config.py
@@ -1,6 +1,9 @@
 import json
 
 
+_VALID_DATAFRAME_BACKENDS = ("pandas", "polars")
+
+
 class NestedConfig:
     def __init__(self, name, data):
         self.__dict__['name'] = name
@@ -10,6 +13,12 @@ class NestedConfig:
         return self.data.get(key)
 
     def __setattr__(self, key, value):
+        if self.__dict__['name'] == 'dataframe' and key == 'backend':
+            if value not in _VALID_DATAFRAME_BACKENDS:
+                raise ValueError(
+                    f"Unknown dataframe backend {value!r}; expected one of "
+                    f"{_VALID_DATAFRAME_BACKENDS}"
+                )
         self.data[key] = value
 
     def __len__(self):
@@ -36,6 +45,8 @@ class ConfigMgr:
         loc = self.__getattr__('locale')
         loc.lang = "en-US"   # BCP-47 language tag for Yahoo v7/v10 endpoints
         loc.region = "US"    # ISO 3166-1 alpha-2 country code
+        df = self.__getattr__('dataframe')
+        df.backend = 'pandas'
 
     def __getattr__(self, key):
         if not self._initialised:

--- a/yfinance/domain/domain.py
+++ b/yfinance/domain/domain.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import pandas as _pd
 from typing import Dict, List, Optional
 
+from .._backend import DataFrameLike, df_to_backend
 from ..const import _QUERY1_URL_
 from ..data import YfData
 from ..ticker import Ticker
@@ -91,7 +92,7 @@ class Domain(ABC):
         return self._overview
 
     @property
-    def top_companies(self) -> Optional[_pd.DataFrame]:
+    def top_companies(self) -> Optional[DataFrameLike]:
         """
         Retrieves the top companies within the domain entity.
 
@@ -99,7 +100,9 @@ class Domain(ABC):
             pandas.DataFrame: A DataFrame containing the top companies in the domain.
         """
         self._ensure_fetched(self._top_companies)
-        return self._top_companies 
+        if self._top_companies is None:
+            return None
+        return df_to_backend(self._top_companies, index_as_column='symbol')
 
     @property
     def research_reports(self) -> List[Dict[str, str]]:

--- a/yfinance/domain/industry.py
+++ b/yfinance/domain/industry.py
@@ -4,10 +4,12 @@ import pandas as _pd
 from typing import Dict, Optional
 
 from .. import utils
+from .._backend import DataFrameLike, df_to_backend
 from ..config import YfConfig
 from ..data import YfData
 
 from .domain import Domain, _QUERY_URL_
+
 
 class Industry(Domain):
     """
@@ -25,7 +27,7 @@ class Industry(Domain):
         """
         YfData(session=session)
         super(Industry, self).__init__(key, session, region)
-        self._query_url = f'{_QUERY_URL_}/industries/{self._key}'
+        self._query_url = f"{_QUERY_URL_}/industries/{self._key}"
 
         self._sector_key = None
         self._sector_name = None
@@ -35,63 +37,69 @@ class Industry(Domain):
     def __repr__(self):
         """
         Returns a string representation of the Industry instance.
-        
+
         Returns:
             str: String representation of the Industry instance.
         """
-        return f'yfinance.Industry object <{self._key}>'
-    
+        return f"yfinance.Industry object <{self._key}>"
+
     @property
     def sector_key(self) -> str:
         """
         Returns the sector key of the industry.
-        
+
         Returns:
             str: The sector key.
         """
         self._ensure_fetched(self._sector_key)
         return self._sector_key
-    
+
     @property
     def sector_name(self) -> str:
         """
         Returns the sector name of the industry.
-        
+
         Returns:
             str: The sector name.
         """
         self._ensure_fetched(self._sector_name)
         return self._sector_name
-    
+
     @property
-    def top_performing_companies(self) -> Optional[_pd.DataFrame]:
+    def top_performing_companies(self) -> Optional[DataFrameLike]:
         """
         Returns the top performing companies in the industry.
-        
+
         Returns:
             Optional[pd.DataFrame]: DataFrame containing top performing companies.
         """
         self._ensure_fetched(self._top_performing_companies)
-        return self._top_performing_companies
-    
+        if self._top_performing_companies is None:
+            return None
+        return df_to_backend(self._top_performing_companies, index_as_column="symbol")
+
     @property
-    def top_growth_companies(self) -> Optional[_pd.DataFrame]:
+    def top_growth_companies(self) -> Optional[DataFrameLike]:
         """
         Returns the top growth companies in the industry.
-        
+
         Returns:
             Optional[pd.DataFrame]: DataFrame containing top growth companies.
         """
         self._ensure_fetched(self._top_growth_companies)
-        return self._top_growth_companies
-    
-    def _parse_top_performing_companies(self, top_performing_companies: Dict) -> Optional[_pd.DataFrame]:
+        if self._top_growth_companies is None:
+            return None
+        return df_to_backend(self._top_growth_companies, index_as_column="symbol")
+
+    def _parse_top_performing_companies(
+        self, top_performing_companies: Dict
+    ) -> Optional[_pd.DataFrame]:
         """
         Parses the top performing companies data.
-        
+
         Args:
             top_performing_companies (Dict): Dictionary containing top performing companies data.
-        
+
         Returns:
             Optional[pd.DataFrame]: DataFrame containing parsed top performing companies data.
         """
@@ -101,19 +109,19 @@ class Industry(Domain):
                              c.get('ytdReturn',{}).get('raw', None),
                              c.get('lastPrice',{}).get('raw', None),
                              c.get('targetPrice',{}).get('raw', None),) for c in top_performing_companies]
-        
-        if not companies_values: 
+
+        if not companies_values:
             return None
 
         return _pd.DataFrame(companies_values, columns = companies_column).set_index('symbol')
-    
+
     def _parse_top_growth_companies(self, top_growth_companies: Dict) -> Optional[_pd.DataFrame]:
         """
         Parses the top growth companies data.
-        
+
         Args:
             top_growth_companies (Dict): Dictionary containing top growth companies data.
-        
+
         Returns:
             Optional[pd.DataFrame]: DataFrame containing parsed top growth companies data.
         """
@@ -122,8 +130,8 @@ class Industry(Domain):
                              c.get('name', None),
                              c.get('ytdReturn',{}).get('raw', None),
                              c.get('growthEstimate',{}).get('raw', None),) for c in top_growth_companies]
-        
-        if not companies_values: 
+
+        if not companies_values:
             return None
 
         return _pd.DataFrame(companies_values, columns = companies_column).set_index('symbol')
@@ -133,16 +141,20 @@ class Industry(Domain):
         Fetches and parses the industry data.
         """
         result = None
-        
+
         try:
             result = self._fetch(self._query_url)
-            data = result['data']
+            data = result["data"]
             self._parse_and_assign_common(data)
 
-            self._sector_key = data.get('sectorKey')
-            self._sector_name = data.get('sectorName')
-            self._top_performing_companies = self._parse_top_performing_companies(data.get('topPerformingCompanies'))
-            self._top_growth_companies = self._parse_top_growth_companies(data.get('topGrowthCompanies'))
+            self._sector_key = data.get("sectorKey")
+            self._sector_name = data.get("sectorName")
+            self._top_performing_companies = self._parse_top_performing_companies(
+                data.get("topPerformingCompanies")
+            )
+            self._top_growth_companies = self._parse_top_growth_companies(
+                data.get("topGrowthCompanies")
+            )
 
             return result
         except Exception as e:

--- a/yfinance/domain/sector.py
+++ b/yfinance/domain/sector.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import pandas as _pd
 from typing import Dict, Optional
 
+from .._backend import DataFrameLike, df_to_backend
 from ..config import YfConfig
 from ..const import SECTOR_INDUSTY_MAPPING_LC
 from ..utils import dynamic_docstring, generate_list_table_from_dict, get_yf_logger
@@ -68,7 +69,7 @@ class Sector(Domain):
 
     @dynamic_docstring({"sector_industry": generate_list_table_from_dict(SECTOR_INDUSTY_MAPPING_LC,bullets=True)})
     @property
-    def industries(self) -> _pd.DataFrame:
+    def industries(self) -> DataFrameLike:
         """
         Gets the industries within the sector.
 
@@ -78,7 +79,7 @@ class Sector(Domain):
         {sector_industry}
         """
         self._ensure_fetched(self._industries)
-        return self._industries
+        return df_to_backend(self._industries, index_as_column='key')
     
     def _parse_top_etfs(self, top_etfs: Dict) -> Dict[str, str]:
         """

--- a/yfinance/lookup.py
+++ b/yfinance/lookup.py
@@ -20,9 +20,12 @@
 #
 
 import json as _json
+from typing import Any
+
 import pandas as pd
 
 from . import utils
+from ._backend import df_to_backend
 from .config import YfConfig
 from .const import _QUERY1_URL_
 from .data import YfData
@@ -94,20 +97,20 @@ class Lookup:
         return data
 
     @staticmethod
-    def _parse_response(response: dict) -> pd.DataFrame:
+    def _parse_response(response: dict) -> Any:
         finance = response.get("finance", {})
         result = finance.get("result", [])
         result = result[0] if len(result) > 0 else {}
         documents = result.get("documents", [])
         df = pd.DataFrame(documents)
         if "symbol" not in df.columns:
-            return pd.DataFrame()
-        return df.set_index("symbol")
+            return df_to_backend(pd.DataFrame())
+        return df_to_backend(df.set_index("symbol"), index_as_column="symbol")
 
-    def _get_data(self, lookup_type: str, count: int = 25) -> pd.DataFrame:
+    def _get_data(self, lookup_type: str, count: int = 25) -> Any:
         return self._parse_response(self._fetch_lookup(lookup_type, count))
 
-    def get_all(self, count=25) -> pd.DataFrame:
+    def get_all(self, count=25) -> Any:
         """
         Returns all available financial instruments.
 
@@ -116,7 +119,7 @@ class Lookup:
         """
         return self._get_data("all", count)
 
-    def get_stock(self, count=25) -> pd.DataFrame:
+    def get_stock(self, count=25) -> Any:
         """
         Returns stock related financial instruments.
 
@@ -125,7 +128,7 @@ class Lookup:
         """
         return self._get_data("equity", count)
 
-    def get_mutualfund(self, count=25) -> pd.DataFrame:
+    def get_mutualfund(self, count=25) -> Any:
         """
         Returns mutual funds related financial instruments.
 
@@ -134,7 +137,7 @@ class Lookup:
         """
         return self._get_data("mutualfund", count)
 
-    def get_etf(self, count=25) -> pd.DataFrame:
+    def get_etf(self, count=25) -> Any:
         """
         Returns ETFs related financial instruments.
 
@@ -143,7 +146,7 @@ class Lookup:
         """
         return self._get_data("etf", count)
 
-    def get_index(self, count=25) -> pd.DataFrame:
+    def get_index(self, count=25) -> Any:
         """
         Returns Indices related financial instruments.
 
@@ -152,7 +155,7 @@ class Lookup:
         """
         return self._get_data("index", count)
 
-    def get_future(self, count=25) -> pd.DataFrame:
+    def get_future(self, count=25) -> Any:
         """
         Returns Futures related financial instruments.
 
@@ -161,7 +164,7 @@ class Lookup:
         """
         return self._get_data("future", count)
 
-    def get_currency(self, count=25) -> pd.DataFrame:
+    def get_currency(self, count=25) -> Any:
         """
         Returns Currencies related financial instruments.
 
@@ -170,7 +173,7 @@ class Lookup:
         """
         return self._get_data("currency", count)
 
-    def get_cryptocurrency(self, count=25) -> pd.DataFrame:
+    def get_cryptocurrency(self, count=25) -> Any:
         """
         Returns Cryptocurrencies related financial instruments.
 
@@ -180,41 +183,41 @@ class Lookup:
         return self._get_data("cryptocurrency", count)
 
     @property
-    def all(self) -> pd.DataFrame:
+    def all(self) -> Any:
         """Returns all available financial instruments."""
         return self._get_data("all")
 
     @property
-    def stock(self) -> pd.DataFrame:
+    def stock(self) -> Any:
         """Returns stock related financial instruments."""
         return self._get_data("equity")
 
     @property
-    def mutualfund(self) -> pd.DataFrame:
+    def mutualfund(self) -> Any:
         """Returns mutual funds related financial instruments."""
         return self._get_data("mutualfund")
 
     @property
-    def etf(self) -> pd.DataFrame:
+    def etf(self) -> Any:
         """Returns ETFs related financial instruments."""
         return self._get_data("etf")
 
     @property
-    def index(self) -> pd.DataFrame:
+    def index(self) -> Any:
         """Returns Indices related financial instruments."""
         return self._get_data("index")
 
     @property
-    def future(self) -> pd.DataFrame:
+    def future(self) -> Any:
         """Returns Futures related financial instruments."""
         return self._get_data("future")
 
     @property
-    def currency(self) -> pd.DataFrame:
+    def currency(self) -> Any:
         """Returns Currencies related financial instruments."""
         return self._get_data("currency")
 
     @property
-    def cryptocurrency(self) -> pd.DataFrame:
+    def cryptocurrency(self) -> Any:
         """Returns Cryptocurrencies related financial instruments."""
         return self._get_data("cryptocurrency")

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -32,6 +32,7 @@ import pandas as _pd
 from curl_cffi import requests
 
 from . import Ticker, utils
+from ._backend import df_to_backend
 from .data import YfData
 from .config import YfConfig
 from .const import period_default
@@ -222,7 +223,7 @@ def _download_impl(ctx, tickers, start=None, end=None, actions=False, threads=Tr
     if not multi_level_index and len(tickers) == 1:
         data = data.droplevel(0 if group_by == 'ticker' else 1, axis=1).rename_axis(None, axis=1)
 
-    return data
+    return df_to_backend(data, index_as_column='Date')
 
 
 def _realign_dfs(ctx):

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -2,6 +2,7 @@ import pandas as pd
 from typing import Dict, Optional
 
 from yfinance import utils
+from yfinance._backend import DataFrameLike, df_to_backend
 from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_
 from yfinance.data import YfData
@@ -80,7 +81,7 @@ class FundsData:
         return self._fund_overview
 
     @property
-    def fund_operations(self) -> pd.DataFrame:
+    def fund_operations(self) -> DataFrameLike:
         """
         Returns the fund operations.
 
@@ -89,7 +90,7 @@ class FundsData:
         """
         if self._fund_operations is None:
             self._fetch_and_parse()
-        return self._fund_operations
+        return df_to_backend(self._fund_operations, index_as_column='Attributes')
 
     @property
     def asset_classes(self) -> Dict[str, float]:
@@ -104,7 +105,7 @@ class FundsData:
         return self._asset_classes
 
     @property
-    def top_holdings(self) -> pd.DataFrame:
+    def top_holdings(self) -> DataFrameLike:
         """
         Returns the top holdings of the fund.
 
@@ -113,10 +114,10 @@ class FundsData:
         """
         if self._top_holdings is None:
             self._fetch_and_parse()
-        return self._top_holdings
+        return df_to_backend(self._top_holdings, index_as_column='Symbol')
 
     @property
-    def equity_holdings(self) -> pd.DataFrame:
+    def equity_holdings(self) -> DataFrameLike:
         """
         Returns the equity holdings of the fund.
 
@@ -125,10 +126,10 @@ class FundsData:
         """
         if self._equity_holdings is None:
             self._fetch_and_parse()
-        return self._equity_holdings
+        return df_to_backend(self._equity_holdings, index_as_column='Average')
 
     @property
-    def bond_holdings(self) -> pd.DataFrame:
+    def bond_holdings(self) -> DataFrameLike:
         """
         Returns the bond holdings of the fund.
 
@@ -137,7 +138,7 @@ class FundsData:
         """
         if self._bond_holdings is None:
             self._fetch_and_parse()
-        return self._bond_holdings
+        return df_to_backend(self._bond_holdings, index_as_column='Average')
 
     @property
     def bond_ratings(self) -> Dict[str, float]:

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -10,6 +10,7 @@ import time as _time
 import warnings
 
 from yfinance import utils
+from yfinance._backend import DataFrameLike, df_to_backend
 from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, period_default, _SENTINEL_
 from yfinance.exceptions import YFDataException, YFInvalidPeriodError, YFPricesMissingError, YFRateLimitError, YFTzMissingError
@@ -39,7 +40,7 @@ class PriceHistory:
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
                 rounding=False, timeout=10,
-                raise_errors=False) -> pd.DataFrame:
+                raise_errors=False) -> DataFrameLike:
         """
         :Parameters:
             period : str
@@ -112,7 +113,7 @@ class PriceHistory:
                         raise _exception
                     else:
                         logger.error(err_msg)
-                    return utils.empty_df()
+                    return df_to_backend(utils.empty_df(), index_as_column='Date')
                 if period == 'ytd':
                     start = _datetime.date(pd.Timestamp.now('UTC').tz_convert(tz).year, 1, 1)
                 else:
@@ -137,7 +138,7 @@ class PriceHistory:
                     raise _exception
                 else:
                     logger.error(err_msg)
-                return utils.empty_df()
+                return df_to_backend(utils.empty_df(), index_as_column='Date')
 
         if start:
             start_dt = utils._parse_user_dt(start, tz)
@@ -296,7 +297,7 @@ class PriceHistory:
                 logger.error(err_msg)
             if self._reconstruct_start_interval is not None and self._reconstruct_start_interval == interval:
                 self._reconstruct_start_interval = None
-            return utils.empty_df()
+            return df_to_backend(utils.empty_df(), index_as_column='Date')
 
         # Select useful info from metadata
         quote_type = self._history_metadata["instrumentType"]
@@ -540,7 +541,7 @@ class PriceHistory:
 
         if self._reconstruct_start_interval is not None and self._reconstruct_start_interval == interval:
             self._reconstruct_start_interval = None
-        return df
+        return df_to_backend(df, index_as_column='Date')
 
     def _get_history_cache(self, period="max", interval="1d", repair=False) -> pd.DataFrame:
         cache_key = (interval, period, repair)

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -25,6 +25,7 @@ from collections import namedtuple as _namedtuple
 
 import pandas as _pd
 
+from ._backend import DataFrameLike, SeriesLike, df_to_backend
 from .base import TickerBase
 from .const import _BASE_URL_
 from .scrapers.funds import FundsData
@@ -58,7 +59,7 @@ class Ticker(TickerBase):
         return {}
 
     def _options2df(self, opt, tz=None):
-        data = _pd.DataFrame(opt).reindex(columns=[
+        data = DataFrameLike(opt).reindex(columns=[
             'contractSymbol',
             'lastTradeDate',
             'strike',
@@ -78,7 +79,7 @@ class Ticker(TickerBase):
             data['lastTradeDate'], unit='s', utc=True)
         if tz is not None:
             data['lastTradeDate'] = data['lastTradeDate'].dt.tz_convert(tz)
-        return data
+        return df_to_backend(data)
 
     def option_chain(self, date=None, tz=None):
         if date is None:
@@ -111,47 +112,47 @@ class Ticker(TickerBase):
         return self.get_isin()
 
     @property
-    def major_holders(self) -> _pd.DataFrame:
+    def major_holders(self) -> DataFrameLike:
         return self.get_major_holders()
 
     @property
-    def institutional_holders(self) -> _pd.DataFrame:
+    def institutional_holders(self) -> DataFrameLike:
         return self.get_institutional_holders()
 
     @property
-    def mutualfund_holders(self) -> _pd.DataFrame:
+    def mutualfund_holders(self) -> DataFrameLike:
         return self.get_mutualfund_holders()
 
     @property
-    def insider_purchases(self) -> _pd.DataFrame:
+    def insider_purchases(self) -> DataFrameLike:
         return self.get_insider_purchases()
 
     @property
-    def insider_transactions(self) -> _pd.DataFrame:
+    def insider_transactions(self) -> DataFrameLike:
         return self.get_insider_transactions()
 
     @property
-    def insider_roster_holders(self) -> _pd.DataFrame:
+    def insider_roster_holders(self) -> DataFrameLike:
         return self.get_insider_roster_holders()
 
     @property
-    def dividends(self) -> _pd.Series:
+    def dividends(self) -> SeriesLike:
         return self.get_dividends()
 
     @property
-    def capital_gains(self) -> _pd.Series:
+    def capital_gains(self) -> SeriesLike:
         return self.get_capital_gains()
 
     @property
-    def splits(self) -> _pd.Series:
+    def splits(self) -> SeriesLike:
         return self.get_splits()
 
     @property
-    def actions(self) -> _pd.DataFrame:
+    def actions(self) -> DataFrameLike:
         return self.get_actions()
 
     @property
-    def shares(self) -> _pd.DataFrame:
+    def shares(self) -> DataFrameLike:
         return self.get_shares()
 
     @property
@@ -163,7 +164,7 @@ class Ticker(TickerBase):
         return self.get_fast_info()
 
     @property
-    def valuation(self) -> _pd.DataFrame:
+    def valuation(self) -> DataFrameLike:
         return self.get_valuation_measures()
 
     @property
@@ -190,87 +191,87 @@ class Ticker(TickerBase):
         return self.get_upgrades_downgrades()
 
     @property
-    def earnings(self) -> _pd.DataFrame:
+    def earnings(self) -> DataFrameLike:
         return self.get_earnings()
 
     @property
-    def quarterly_earnings(self) -> _pd.DataFrame:
+    def quarterly_earnings(self) -> DataFrameLike:
         return self.get_earnings(freq='quarterly')
 
     @property
-    def income_stmt(self) -> _pd.DataFrame:
+    def income_stmt(self) -> DataFrameLike:
         return self.get_income_stmt(pretty=True)
 
     @property
-    def quarterly_income_stmt(self) -> _pd.DataFrame:
+    def quarterly_income_stmt(self) -> DataFrameLike:
         return self.get_income_stmt(pretty=True, freq='quarterly')
 
     @property
-    def ttm_income_stmt(self) -> _pd.DataFrame:
+    def ttm_income_stmt(self) -> DataFrameLike:
         return self.get_income_stmt(pretty=True, freq='trailing')
 
     @property
-    def incomestmt(self) -> _pd.DataFrame:
+    def incomestmt(self) -> DataFrameLike:
         return self.income_stmt
 
     @property
-    def quarterly_incomestmt(self) -> _pd.DataFrame:
+    def quarterly_incomestmt(self) -> DataFrameLike:
         return self.quarterly_income_stmt
 
     @property
-    def ttm_incomestmt(self) -> _pd.DataFrame:
+    def ttm_incomestmt(self) -> DataFrameLike:
         return self.ttm_income_stmt
 
     @property
-    def financials(self) -> _pd.DataFrame:
+    def financials(self) -> DataFrameLike:
         return self.income_stmt
 
     @property
-    def quarterly_financials(self) -> _pd.DataFrame:
+    def quarterly_financials(self) -> DataFrameLike:
         return self.quarterly_income_stmt
 
     @property
-    def ttm_financials(self) -> _pd.DataFrame:
+    def ttm_financials(self) -> DataFrameLike:
         return self.ttm_income_stmt
 
     @property
-    def balance_sheet(self) -> _pd.DataFrame:
+    def balance_sheet(self) -> DataFrameLike:
         return self.get_balance_sheet(pretty=True)
 
     @property
-    def quarterly_balance_sheet(self) -> _pd.DataFrame:
+    def quarterly_balance_sheet(self) -> DataFrameLike:
         return self.get_balance_sheet(pretty=True, freq='quarterly')
 
     @property
-    def balancesheet(self) -> _pd.DataFrame:
+    def balancesheet(self) -> DataFrameLike:
         return self.balance_sheet
 
     @property
-    def quarterly_balancesheet(self) -> _pd.DataFrame:
+    def quarterly_balancesheet(self) -> DataFrameLike:
         return self.quarterly_balance_sheet
 
     @property
-    def cash_flow(self) -> _pd.DataFrame:
+    def cash_flow(self) -> DataFrameLike:
         return self.get_cash_flow(pretty=True, freq="yearly")
 
     @property
-    def quarterly_cash_flow(self) -> _pd.DataFrame:
+    def quarterly_cash_flow(self) -> DataFrameLike:
         return self.get_cash_flow(pretty=True, freq='quarterly')
 
     @property
-    def ttm_cash_flow(self) -> _pd.DataFrame:
+    def ttm_cash_flow(self) -> DataFrameLike:
         return self.get_cash_flow(pretty=True, freq='trailing')
 
     @property
-    def cashflow(self) -> _pd.DataFrame:
+    def cashflow(self) -> DataFrameLike:
         return self.cash_flow
 
     @property
-    def quarterly_cashflow(self) -> _pd.DataFrame:
+    def quarterly_cashflow(self) -> DataFrameLike:
         return self.quarterly_cash_flow
 
     @property
-    def ttm_cashflow(self) -> _pd.DataFrame:
+    def ttm_cashflow(self) -> DataFrameLike:
         return self.ttm_cash_flow
 
     @property
@@ -278,31 +279,31 @@ class Ticker(TickerBase):
         return self.get_analyst_price_targets()
 
     @property
-    def earnings_estimate(self) -> _pd.DataFrame:
+    def earnings_estimate(self) -> DataFrameLike:
         return self.get_earnings_estimate()
 
     @property
-    def revenue_estimate(self) -> _pd.DataFrame:
+    def revenue_estimate(self) -> DataFrameLike:
         return self.get_revenue_estimate()
 
     @property
-    def earnings_history(self) -> _pd.DataFrame:
+    def earnings_history(self) -> DataFrameLike:
         return self.get_earnings_history()
 
     @property
-    def eps_trend(self) -> _pd.DataFrame:
+    def eps_trend(self) -> DataFrameLike:
         return self.get_eps_trend()
 
     @property
-    def eps_revisions(self) -> _pd.DataFrame:
+    def eps_revisions(self) -> DataFrameLike:
         return self.get_eps_revisions()
 
     @property
-    def growth_estimates(self) -> _pd.DataFrame:
+    def growth_estimates(self) -> DataFrameLike:
         return self.get_growth_estimates()
 
     @property
-    def sustainability(self) -> _pd.DataFrame:
+    def sustainability(self) -> DataFrameLike:
         return self.get_sustainability()
 
     @property
@@ -316,7 +317,7 @@ class Ticker(TickerBase):
         return self.get_news()
 
     @property
-    def earnings_dates(self) -> _pd.DataFrame:
+    def earnings_dates(self) -> DataFrameLike:
         return self.get_earnings_dates()
 
     @property


### PR DESCRIPTION
Alternative to #2782 and #2808 — closes #1868.

## Summary

Opt-in polars output without doubling the codebase. One line of user code:

```python
yf.config.dataframe.backend = 'polars'
yf.Ticker('MSFT').history(period='1mo')   # → polars.DataFrame
```

Pandas remains the default. Polars is a single optional install: `pip install yfinance[polars]`.

## Why this differs from #2808

@ValueRaider's review on #2808 pointed out the core problem:

> The main problem with this, is now we have to maintain Polars for no performance improvement — yfinance tables aren't big enough for choice to matter.

This PR takes that feedback as the design constraint. Instead of porting every scraper into a native polars implementation (#2808: ~5000 lines, including a 2272-line `polars_repair.py`), the internal pipelines stay 100% pandas and polars support is a **thin output adapter** applied at every public-API boundary. There is one code path internally; polars never participates in transformations.

| | This PR | #2808 |
|---|---|---|
| LoC added | ~700 | ~5000 |
| Polars-native repair engine | none (pandas + convert) | 2272 lines |
| Polars-native scrapers | none | every scraper |
| Default backend | pandas (no break) | pandas (no break) |
| Polars dependency | extras_require | extras_require |
| Performance | unchanged | unchanged |
| Maintenance surface | +1 adapter file, ~700 lines | duplicate every transform |

## Why this is not a performance play

It isn't. yfinance frames are small enough that pandas vs polars makes no practical difference — exactly @ValueRaider's point. The value here is **convenience**: users whose downstream pipelines are polars get polars frames straight from yfinance instead of threading `pl.from_pandas(...)` after every call. That's it.

## No breaking changes

- Default backend is `pandas`. Existing users see no behavioural difference.
- `df_to_backend(df)` is identity (`assertIs`) when backend == `pandas`. Unit-tested.
- Public-facing return annotations are widened from `pd.DataFrame` to `DataFrameLike = Union[pd.DataFrame, "pl.DataFrame"]`. Pandas remains a valid subtype, so all existing pandas-typed callers continue to type-check. Polars is imported only under `TYPE_CHECKING`, so users without `polars` installed see no import error.
- Caches keep frames in pandas; conversion happens on each public read, so switching backend mid-session is honoured immediately by every subsequent call.

## Surface covered

- `Ticker.history()` (4 return paths) and `yf.download()`.
- All 40+ `Ticker.X` @property accessors (via `base.py get_X()` wraps).
- All `Ticker.get_*` methods returning DataFrame/Series: dividends, splits, capital_gains, actions, shares, shares_full, earnings_dates, earnings, financial statements, recommendations, upgrades_downgrades, holders ×6, valuation_measures, sustainability, analysis getters ×6.
- `Ticker.option_chain()` (calls + puts).
- `Ticker.funds_data.{fund_operations, top_holdings, equity_holdings, bond_holdings}`.
- `Lookup.*`, `Calendars.*`, `Sector.industries`, `Industry.top_*`, `Domain.top_companies`.

Internal scraper `_quote.X / _holders.X / _analysis.X / _fundamentals.X` attributes are intentionally not wrapped — they are private (`_`-prefixed) and only used by `base.py`, which wraps at the public boundary.

## Tests

`tests/test_dataframe_backend.py` — 37 tests, **no network required**:

- Config validation (default / accepted / unknown / no-corruption-on-failure).
- `df_to_backend` semantics (passthrough on pandas, polars conversion, named-index promotion, override, RangeIndex drop, empty).
- `series_to_backend` semantics.
- Lookup parity on both backends + empty result.
- All 17 wrapped base.py getters return the right backend type, plus `as_dict=True` always returns a plain dict.
- Backend switch invariant: pandas → polars → pandas in sequence returns the matching type each time.
- Calendars `_to_backend` on both backends.
- Sector.industries property switches with backend.

```
$ python -m unittest tests.test_dataframe_backend tests.test_utils
Ran 58 tests in 0.290s
OK (expected failures=1)
```

Ruff clean for every file touched.

## Out of scope

- `download()` long-form polars shape: kept as MultiIndex pandas converted via reset_index. Native polars long-form is a separate opinionated decision.
- Price-repair engine stays pandas-internal — it's a numerical kernel with `scipy.ndimage`, not idiomatic DataFrame ops. The pandas frame is converted at the same `history()` boundary.

## Test plan

- [x] `python -m unittest tests.test_dataframe_backend tests.test_utils` — 58 pass
- [x] `ruff check` clean on every changed file (the lone remaining E702 in `history.py:2734` is pre-existing and addressed by #2810)
- [x] `pyright` — no new errors on the changed files