### PR TITLE
Add tz= kwarg to history() and download()

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -298,6 +298,64 @@ class TestTickerHistory(unittest.TestCase):
         self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 
+    def test_history_output_tz_none_is_noop(self):
+        # Regression guard: tz=None must not touch the index.
+        baseline = self.ticker.history(period="5d", interval="1h")
+        same = self.ticker.history(period="5d", interval="1h", tz=None)
+        self.assertEqual(str(baseline.index.tz), str(same.index.tz))
+
+    def test_history_output_tz_daily_warns(self):
+        # Daily/weekly bars shift calendar dates when converted -> must warn.
+        with self.assertLogs("yfinance", level="WARNING") as cm:
+            self.ticker.history(period="1mo", interval="1d", tz="UTC")
+        self.assertTrue(any("tz='UTC'" in m and "interval='1d'" in m for m in cm.output),
+            f"expected daily-tz warning, got: {cm.output}")
+
+    def test_history_output_tz(self):
+        # Default: exchange tz preserved (IBM = NYSE).
+        baseline = self.ticker.history(period="5d", interval="1h")
+        self.assertIsNotNone(baseline.index.tz)
+        baseline_tz_name = str(baseline.index.tz)
+        self.assertNotEqual(baseline_tz_name, "UTC")
+
+        # tz="UTC" converts the index, same moments in time.
+        utc = self.ticker.history(period="5d", interval="1h", tz="UTC")
+        self.assertEqual(str(utc.index.tz), "UTC")
+        # Same bars, just re-expressed in UTC.
+        self.assertEqual(len(utc), len(baseline))
+        for a, b in zip(baseline.index, utc.index):
+            self.assertEqual(a, b)
+
+        # tzinfo object is accepted too.
+        try:
+            from zoneinfo import ZoneInfo
+        except ImportError:
+            from backports.zoneinfo import ZoneInfo  # type: ignore
+        rome = self.ticker.history(period="5d", interval="1h", tz=ZoneInfo("Europe/Rome"))
+        self.assertEqual(str(rome.index.tz), "Europe/Rome")
+
+        # Invalid tz must raise, not silently fall back.
+        with self.assertRaises(Exception):
+            self.ticker.history(period="5d", interval="1h", tz="Not/AZone")
+
+    def test_download_output_tz(self):
+        # Default: exchange tz preserved (multi-tz fallback aside).
+        utc = yf.download("IBM", period="5d", interval="1h", session=self.session,
+                          progress=False, tz="UTC")
+        self.assertIsNotNone(utc.index.tz)
+        self.assertEqual(str(utc.index.tz), "UTC")
+
+        # tz wins over ignore_tz auto-default (daily would normally drop tz).
+        daily_utc = yf.download("IBM", period="1mo", interval="1d", session=self.session,
+                                progress=False, tz="UTC")
+        self.assertIsNotNone(daily_utc.index.tz)
+        self.assertEqual(str(daily_utc.index.tz), "UTC")
+
+        # Explicit conflict: ignore_tz=True + tz=... must raise, not silently pick one.
+        with self.assertRaises(ValueError):
+            yf.download("IBM", period="5d", interval="1h", session=self.session,
+                        progress=False, ignore_tz=True, tz="UTC")
+
     def test_history_metadata(self):
         # Mainly testing that if user requested price repair, 
         # that any metadata refetch also uses repaired data.

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -55,7 +55,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
              ignore_tz=None, group_by='column', auto_adjust=True, back_adjust=False,
              repair=False, keepna=False, progress=True, period=period_default, interval="1d",
              prepost=False, rounding=False, timeout=10, session=None,
-             multi_level_index=True) -> Union[_pd.DataFrame, None]:
+             multi_level_index=True, tz=None) -> Union[_pd.DataFrame, None]:
     """
     Download yahoo tickers
     :Parameters:
@@ -105,6 +105,11 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             Optional. Pass your own session object to be used for all requests
         multi_level_index: bool
             Optional. Always return a MultiIndex DataFrame? Default is True
+        tz: str or datetime.tzinfo
+            Optional. Convert the output index to this timezone (e.g. "UTC",
+            "Europe/Rome"). Default is None: preserve the exchange tz for
+            single-tz results, or use UTC when combining multi-tz tickers.
+            Overrides ignore_tz.
     """
     return _download_impl(
         _DownloadCtx(),
@@ -112,7 +117,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
         ignore_tz=ignore_tz, group_by=group_by, auto_adjust=auto_adjust,
         back_adjust=back_adjust, repair=repair, keepna=keepna, progress=progress,
         period=period, interval=interval, prepost=prepost, rounding=rounding,
-        timeout=timeout, session=session, multi_level_index=multi_level_index,
+        timeout=timeout, session=session, multi_level_index=multi_level_index, tz=tz,
     )
 
 
@@ -120,7 +125,7 @@ def _download_impl(ctx, tickers, start=None, end=None, actions=False, threads=Tr
                    ignore_tz=None, group_by='column', auto_adjust=True, back_adjust=False,
                    repair=False, keepna=False, progress=True, period=period_default, interval="1d",
                    prepost=False, rounding=False, timeout=10, session=None,
-                   multi_level_index=True):
+                   multi_level_index=True, tz=None):
     logger = utils.get_yf_logger()
     session = session or requests.Session(impersonate="chrome")
 
@@ -134,7 +139,12 @@ def _download_impl(ctx, tickers, start=None, end=None, actions=False, threads=Tr
         if progress:
             progress = False
 
-    if ignore_tz is None:
+    if tz is not None:
+        if ignore_tz is True:
+            raise ValueError("download(): tz= and ignore_tz=True are mutually exclusive — a tz-aware output index cannot also be tz-stripped.")
+        # Explicit output tz wins over ignore_tz auto-default.
+        ignore_tz = False
+    elif ignore_tz is None:
         ignore_tz = interval[-1] not in ('m', 'h')
 
     tickers = tickers if isinstance(
@@ -213,6 +223,10 @@ def _download_impl(ctx, tickers, start=None, end=None, actions=False, threads=Tr
         data = _pd.concat(ctx.dfs.values(), axis=1, sort=True,
                           keys=ctx.dfs.keys(), names=['Ticker', 'Price'])
     data.index = _pd.to_datetime(data.index, utc=not ignore_tz)
+    if tz is not None and data.index.tz is not None:
+        # pandas validates: bad tz strings/types raise here (UnknownTimeZoneError
+        # / TypeError). We do not catch — silent fallback would corrupt the index.
+        data.index = data.index.tz_convert(tz)
     data.rename(columns=ctx.isins, inplace=True)
 
     if group_by == 'column':

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -39,7 +39,7 @@ class PriceHistory:
                 start=None, end=None, prepost=False, actions=True,
                 auto_adjust=True, back_adjust=False, repair=False, keepna=False,
                 rounding=False, timeout=10,
-                raise_errors=False) -> pd.DataFrame:
+                raise_errors=False, tz=None) -> pd.DataFrame:
         """
         :Parameters:
             period : str
@@ -80,8 +80,17 @@ class PriceHistory:
               | Default: 10 seconds
             raise_errors : bool
                 If True, then raise errors as Exceptions instead of logging.
+            tz : str or datetime.tzinfo
+              | Optional: convert the output index to this timezone.
+              | Accepts an IANA name (e.g. "UTC", "Europe/Rome") or a tzinfo object.
+              | Default: None (keep the exchange's timezone).
+              | Note: for daily/weekly bars, converting to a tz that differs from
+              | the exchange will shift the calendar date of each bar.
         """
         logger = utils.get_yf_logger()
+
+        # Capture before internal code shadows the name with the exchange tz.
+        _output_tz = tz
 
         if raise_errors:
             warnings.warn("'raise_errors' deprecated, do: yf.config.debug.hide_exceptions = False", DeprecationWarning, stacklevel=5)
@@ -540,6 +549,19 @@ class PriceHistory:
 
         if self._reconstruct_start_interval is not None and self._reconstruct_start_interval == interval:
             self._reconstruct_start_interval = None
+
+        if _output_tz is not None and not df.empty and df.index.tz is not None:
+            if interval_user in ("1d", "5d", "1wk", "1mo", "3mo"):
+                logger.warning(
+                    f"{self.ticker}: tz={_output_tz!r} on interval={interval_user!r}: "
+                    "daily/weekly bars are anchored to midnight at the exchange, so "
+                    "converting will shift their calendar date."
+                )
+            # pandas validates the tz here — bad strings raise UnknownTimeZoneError,
+            # bad types raise TypeError. We do not catch: silent fallback would
+            # corrupt the index.
+            df.index = df.index.tz_convert(_output_tz)
+
         return df
 
     def _get_history_cache(self, period="max", interval="1d", repair=False) -> pd.DataFrame:


### PR DESCRIPTION
## Summary
Lets callers choose the timezone of the returned DataFrame's index, instead of always getting the exchange tz on `Ticker.history()` or UTC on `download()`.

```python
yf.Ticker('SPY').history(period='5d', interval='1h', tz='UTC')
yf.download('IBM', period='1mo', interval='1d', tz='Europe/Rome')
```

Accepts an IANA name (`"UTC"`, `"Europe/Rome"`) or any `tzinfo` (e.g. `zoneinfo.ZoneInfo`). Bad values propagate from pandas — no silent fallback.

### Design notes
- Input parsing (naive `start`/`end` interpreted in exchange tz) is **decoupled** from output formatting (`tz=`). The exchange tz is still used to interpret user-provided dates; only the output index is converted.
- The existing internal `tz` local in `PriceHistory.history` (exchange tz) is preserved as-is; the new kwarg is captured into `_output_tz` at the top of the function to avoid shadowing.
- On `download()`, `tz=` overrides the `ignore_tz` auto-default (so daily intervals can also opt into a specific tz). Passing both `tz=...` and `ignore_tz=True` raises `ValueError` rather than silently picking one.
- A `WARNING` is logged when the user converts daily/weekly bars to a non-exchange tz, since midnight-at-exchange bars will shift their calendar date.

Addresses the follow-up request in #2327.

## Test plan
- [x] `tz=None` is a no-op (regression guard)
- [x] `tz="UTC"` on intraday converts the index, same moments in time
- [x] `tz=ZoneInfo("Europe/Rome")` works equally
- [x] Invalid tz string raises
- [x] Daily interval with `tz=` emits warning
- [x] `download(tz="UTC")` on daily interval overrides `ignore_tz` auto-default
- [x] `download(ignore_tz=True, tz="UTC")` raises `ValueError`
- [x] `ruff check` clean