### PR TITLE
Expose upcoming Split Date/Ratio/Type and Is Earnings Date Estimate in calendar

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -872,8 +872,52 @@ class TestTickerMiscFinancials(unittest.TestCase):
         if self.ticker.ticker != "GOOGL":
             self.assertIn("Dividend Date", data.keys(), "data missing expected key")
         # ex-dividend date is not always available
+        # isEarningsDateEstimate is present in the raw payload whenever
+        # earnings info is known; surface it when Yahoo provides it.
+        if "Is Earnings Date Estimate" in data:
+            self.assertIsInstance(data["Is Earnings Date Estimate"], bool)
         data_cached = self.ticker.calendar
         self.assertIs(data, data_cached, "data not cached")
+
+    def test_calendar_split_from_corporate_actions(self):
+        """Mock the quoteSummary payload so the test is independent of any
+        live ticker happening to have an announced split today."""
+        from unittest.mock import patch
+        # 1779163200000 ms = 2026-05-19 04:00 UTC -> calendar date 2026-05-19
+        # regardless of the host machine's local timezone.
+        fake_payload = {"quoteSummary": {"result": [{
+            "calendarEvents": {"earnings": {"earningsDate": []}},
+            "corporateActions": {"corporateActions": [{
+                "header": "Reverse stock split",
+                "message": "FAKE announces 1 for 20 split effective May. 19, 2026",
+                "meta": {
+                    "eventType": "SPLIT",
+                    "dateEpochMs": 1779163200000,
+                    "splitRatio": "1:20",
+                },
+            }]},
+        }], "error": None}}
+        ticker = yf.Ticker("FAKE", session=self.session)
+        with patch.object(ticker._quote, "_fetch", return_value=fake_payload):
+            cal = ticker.calendar
+        import datetime as _dt
+        self.assertEqual(cal["Split Date"], _dt.date(2026, 5, 19))
+        self.assertEqual(cal["Split Ratio"], "1:20")
+        self.assertEqual(cal["Split Type"], "Reverse stock split")
+
+    def test_calendar_no_split_when_corporate_actions_empty(self):
+        """No SPLIT in corporateActions -> no Split* keys leak into calendar."""
+        from unittest.mock import patch
+        fake_payload = {"quoteSummary": {"result": [{
+            "calendarEvents": {"earnings": {"earningsDate": []}},
+            "corporateActions": {"corporateActions": []},
+        }], "error": None}}
+        ticker = yf.Ticker("FAKE2", session=self.session)
+        with patch.object(ticker._quote, "_fetch", return_value=fake_payload):
+            cal = ticker.calendar
+        self.assertNotIn("Split Date", cal)
+        self.assertNotIn("Split Ratio", cal)
+        self.assertNotIn("Split Type", cal)
 
     # # sustainability stopped working
     # def test_sustainability(self):

--- a/yfinance/const.py
+++ b/yfinance/const.py
@@ -142,6 +142,7 @@ quote_summary_valid_modules = (
     "defaultKeyStatistics",  # KPIs (PE, enterprise value, EPS, EBITA, and more)
     "financialData",  # Financial KPIs (revenue, gross margins, operating cash flow, free cash flow, and more)
     "calendarEvents",  # future earnings date
+    "corporateActions",  # announced upcoming corporate actions (splits, etc.)
     "secFilings",  # SEC filings, such as 10K and 10Q reports
     "upgradeDowngradeHistory",  # upgrades and downgrades that analysts have given a company's stock
     "institutionOwnership",  # institutional ownership, holders and shares outstanding

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -759,24 +759,73 @@ class Quote:
                 else:
                     self.info[k] = None
 
+    def _apply_split_from_corporate_actions(self, ca_block):
+        """Extract the next upcoming split from the 'corporateActions' payload
+        and populate Split Date / Split Ratio / Split Type on self._calendar.
+
+        Yahoo's payload shape:
+            {"corporateActions": [{"meta": {"eventType": "SPLIT",
+                                            "dateEpochMs": <ms>,
+                                            "splitRatio": "1:20"}, ...}],
+             "maxAge": 1}
+
+        Multiple actions can be present; we pick the earliest SPLIT.
+        """
+        if not ca_block:
+            return
+        actions = ca_block.get('corporateActions') or []
+        splits = [a for a in actions if (a.get('meta') or {}).get('eventType') == 'SPLIT'
+                  and (a.get('meta') or {}).get('dateEpochMs')]
+        if not splits:
+            return
+        next_split = min(splits, key=lambda a: a['meta']['dateEpochMs'])
+        meta = next_split['meta']
+        # dateEpochMs is milliseconds since epoch; resolve in UTC so the
+        # calendar date doesn't shift on machines in negative-offset zones.
+        self._calendar['Split Date'] = datetime.datetime.fromtimestamp(
+            meta['dateEpochMs'] / 1000, tz=datetime.timezone.utc
+        ).date()
+        if meta.get('splitRatio'):
+            self._calendar['Split Ratio'] = meta['splitRatio']
+        # 'header' carries the human-readable type ("Forward stock split" /
+        # "Reverse stock split"); preserve it verbatim so we don't have to
+        # second-guess Yahoo's classification.
+        if next_split.get('header'):
+            self._calendar['Split Type'] = next_split['header']
+
     def _fetch_calendar(self):
         # secFilings return too old data, so not requesting it for now
-        result = self._fetch(modules=['calendarEvents'])
+        result = self._fetch(modules=['calendarEvents', 'corporateActions'])
         if result is None:
             self._calendar = {}
             return
 
         try:
             self._calendar = dict()
-            _events = result["quoteSummary"]["result"][0]["calendarEvents"]
+            _result0 = result["quoteSummary"]["result"][0]
+            _events = _result0["calendarEvents"]
             if 'dividendDate' in _events:
                 self._calendar['Dividend Date'] = datetime.datetime.fromtimestamp(_events['dividendDate']).date()
             if 'exDividendDate' in _events:
                 self._calendar['Ex-Dividend Date'] = datetime.datetime.fromtimestamp(_events['exDividendDate']).date()
-            # splits = _events.get('splitDate')  # need to check later, i will add code for this if found data
+            # Upcoming splits ship via the 'corporateActions' module (richer
+            # payload with ratio + type), not 'calendarEvents.splitDate' which
+            # is almost always absent. Fall back to calendarEvents.splitDate
+            # only if corporateActions is missing.
+            self._apply_split_from_corporate_actions(_result0.get('corporateActions'))
+            if 'Split Date' not in self._calendar and _events.get('splitDate'):
+                self._calendar['Split Date'] = datetime.datetime.fromtimestamp(_events['splitDate']).date()
             earnings = _events.get('earnings')
             if earnings is not None:
                 self._calendar['Earnings Date'] = [datetime.datetime.fromtimestamp(d).date() for d in earnings.get('earningsDate', [])]
+                # Yahoo's 'isEarningsDateEstimate' flag distinguishes confirmed
+                # dates from estimates — useful for downstream filtering. Note:
+                # earningsCallDate is intentionally *not* surfaced: in observed
+                # payloads it can point to a past quarter's call rather than
+                # the next one, so exposing it without disambiguation would
+                # mislead callers.
+                if 'isEarningsDateEstimate' in earnings:
+                    self._calendar['Is Earnings Date Estimate'] = earnings['isEarningsDateEstimate']
                 self._calendar['Earnings High'] = earnings.get('earningsHigh', None)
                 self._calendar['Earnings Low'] = earnings.get('earningsLow', None)
                 self._calendar['Earnings Average'] = earnings.get('earningsAverage', None)


### PR DESCRIPTION
## Summary
Surfaces upcoming-event fields that Yahoo's quoteSummary already returns but yfinance was dropping:

- **`Split Date` / `Split Ratio` / `Split Type`** — from the previously-unwhitelisted `corporateActions` module. Yahoo populates it whenever a forward/reverse split is announced. The legacy `calendarEvents.splitDate` is kept as a fallback. Date is resolved in **UTC** so the calendar day doesn't shift on machines in negative-offset zones.
- **`Is Earnings Date Estimate`** — boolean from `calendarEvents.earnings`. Lets callers tell a confirmed earnings date from an estimate.

No new HTTP call: `_fetch_calendar` requests both modules in one `quoteSummary` round-trip. Picks off the splits part of #1308. Mergers stay out of scope — Yahoo doesn't surface them via `quoteSummary`.

`earningsCallDate` was investigated but is intentionally **not** surfaced: in observed payloads it can point to a past quarter's call rather than the next one (e.g. AAPL returns 2026-04-30 while `Earnings Date` is 2026-07-30), so exposing it without disambiguation would mislead callers.

## Verified on real tickers

| Ticker | Split Date | Ratio | Type | Is Earnings Date Estimate |
|---|---|---|---|---|
| CCWYF | 2026-05-19 | 1:20 | Reverse stock split | – |
| BYOGF | 2026-05-20 | 1:30 | Reverse stock split | True |
| AAPL | – | – | – | True |
| NVDA | – | – | – | False |
| MSFT | – | – | – | True |

Verified that already-completed splits (GMEX/GREH/TLIH/GPUSF, split 2026-05-01) do **not** appear — Yahoo filters server-side, no client-side guard needed.

## Test plan
- [x] Existing `test_calendar` still passes (live, GOOGL)
- [x] Mocked `test_calendar_split_from_corporate_actions` — injects a fake SPLIT payload and asserts Date/Ratio/Type populate (no live dependency)
- [x] Mocked `test_calendar_no_split_when_corporate_actions_empty` — asserts no Split* keys leak when actions list is empty
- [x] Sanity-checked across CCWYF, BYOGF (with upcoming splits) and AAPL/NVDA/MSFT (no split — guard kicks in, keys absent)
- [x] `ruff check` clean