### PR TITLE
Add IndexQuery/FutureQuery/CryptoQuery/CurrencyQuery to screener

### DIFF
--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,7 +1,14 @@
+import json
 import unittest
 from unittest.mock import patch, MagicMock
 from yfinance.screener.screener import screen
-from yfinance.screener.query import EquityQuery
+from yfinance.screener.query import (
+    EquityQuery,
+    IndexQuery,
+    FutureQuery,
+    CryptoQuery,
+    CurrencyQuery,
+)
 
 
 class TestScreener(unittest.TestCase):
@@ -33,6 +40,36 @@ class TestScreener(unittest.TestCase):
 
         response = screen(self.predefined)
         self.assertEqual(response, {'key': 'value'})
+
+    @patch('yfinance.data.YfData.post')
+    def test_extra_quotetypes_set_correct_quote_type(self, mock_post):
+        """Each non-EQUITY/FUND/ETF query class must dispatch to the matching
+        Yahoo quoteType. We assert by inspecting the JSON body that screen()
+        POSTs."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'finance': {'result': [{'key': 'value'}]}}
+        mock_post.return_value = mock_response
+
+        cases = [
+            (IndexQuery('gt', ['intradayprice', 0]), 'INDEX'),
+            (FutureQuery('gt', ['intradayprice', 0]), 'FUTURE'),
+            (CryptoQuery('gt', ['intradaymarketcap', 1]), 'CRYPTOCURRENCY'),
+            (CurrencyQuery('gt', ['intradayprice', 0]), 'CURRENCY'),
+        ]
+        for q, expected in cases:
+            mock_post.reset_mock()
+            screen(q)
+            self.assertEqual(mock_post.call_count, 1)
+            sent_body = json.loads(mock_post.call_args.kwargs['data'])
+            self.assertEqual(sent_body['quoteType'], expected,
+                f'{type(q).__name__} should dispatch quoteType={expected!r}')
+
+    def test_currency_rejects_unknown_field(self):
+        """The empirical field schema must reject fields not in the verified
+        intersection — e.g. CURRENCY has no marketcap."""
+        with self.assertRaises(ValueError):
+            CurrencyQuery('gt', ['intradaymarketcap', 1])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/yfinance/__init__.py
+++ b/yfinance/__init__.py
@@ -35,7 +35,7 @@ from .domain.market import Market, MarketRegion
 from .config import YfConfig as config
 from .data import Auth
 
-from .screener.query import EquityQuery, FundQuery, ETFQuery
+from .screener.query import EquityQuery, FundQuery, ETFQuery, IndexQuery, FutureQuery, CryptoQuery, CurrencyQuery
 from .screener.screener import screen, PREDEFINED_SCREENER_QUERIES
 
 __version__ = version.version
@@ -47,7 +47,7 @@ warnings.filterwarnings('default', category=DeprecationWarning, module='^yfinanc
 __all__ = ['download', 'Market', 'MarketRegion', 'Search', 'Lookup', 'Ticker', 'Tickers', 'enable_debug_mode', 'set_tz_cache_location',
            'Sector', 'Industry', 'WebSocket', 'AsyncWebSocket', 'Calendars', 'Auth']
 # screener stuff:
-__all__ += ['EquityQuery', 'FundQuery', 'ETFQuery', 'screen', 'PREDEFINED_SCREENER_QUERIES']
+__all__ += ['EquityQuery', 'FundQuery', 'ETFQuery', 'IndexQuery', 'FutureQuery', 'CryptoQuery', 'CurrencyQuery', 'screen', 'PREDEFINED_SCREENER_QUERIES']
 
 # Config stuff:
 _NOTSET=object()

--- a/yfinance/const.py
+++ b/yfinance/const.py
@@ -1135,6 +1135,38 @@ ETF_SCREENER_FIELDS = {
 }
 ETF_SCREENER_FIELDS = merge_two_level_dicts(ETF_SCREENER_FIELDS, COMMON_SCREENER_FIELDS)
 
+
+# Field sets for the non-EQUITY/FUND/ETF screeners. These were discovered
+# empirically against Yahoo's screener API (POST /v1/finance/screener with
+# quoteType=INDEX / FUTURE / CRYPTOCURRENCY / CURRENCY). Yahoo does not
+# document the per-quoteType field schema, so the lists below are the
+# verified intersection of what the API accepts -- pull requests adding
+# more once discovered are welcome.
+
+INDEX_SCREENER_FIELDS = {
+    "price": {"eodprice", "intradayprice", "intradaypricechange"},
+    "keystats": {"avgdailyvol3m", "dayvolume", "fiftytwowkpercentchange", "percentchange"},
+    "eq_fields": {"region", "exchange", "ticker", "sector", "industry"},
+}
+
+FUTURE_SCREENER_FIELDS = {
+    "price": {"eodprice", "intradayprice", "intradaypricechange"},
+    "keystats": {"avgdailyvol3m", "dayvolume", "fiftytwowkpercentchange", "percentchange"},
+    "eq_fields": {"region", "exchange", "ticker"},
+}
+
+CRYPTO_SCREENER_FIELDS = {
+    "price": {"eodprice", "intradayprice", "intradaypricechange"},
+    "keystats": {"avgdailyvol3m", "dayvolume", "fiftytwowkpercentchange", "percentchange", "intradaymarketcap"},
+    "eq_fields": {"currency", "exchange", "ticker"},
+}
+
+CURRENCY_SCREENER_FIELDS = {
+    "price": {"eodprice", "intradayprice", "intradaypricechange"},
+    "keystats": {"avgdailyvol3m", "dayvolume", "percentchange"},
+    "eq_fields": {"ticker"},
+}
+
 USER_AGENTS = [
     # Chrome
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",

--- a/yfinance/screener/query.py
+++ b/yfinance/screener/query.py
@@ -5,6 +5,12 @@ from typing import List, Union, Dict, TypeVar, Literal
 from yfinance.const import EQUITY_SCREENER_EQ_MAP, EQUITY_SCREENER_FIELDS
 from yfinance.const import FUND_SCREENER_EQ_MAP, FUND_SCREENER_FIELDS
 from yfinance.const import ETF_SCREENER_EQ_MAP, ETF_SCREENER_FIELDS
+from yfinance.const import (
+    INDEX_SCREENER_FIELDS,
+    FUTURE_SCREENER_FIELDS,
+    CRYPTO_SCREENER_FIELDS,
+    CURRENCY_SCREENER_FIELDS,
+)
 from yfinance.exceptions import YFNotImplementedError
 from ..utils import dynamic_docstring, generate_list_table_from_dict_universal
 
@@ -257,3 +263,150 @@ class ETFQuery(QueryBase):
         {valid_values_table}
         """
         return ETF_SCREENER_EQ_MAP
+
+
+class IndexQuery(QueryBase):
+    """
+    The `IndexQuery` class constructs filters for indices (``quoteType=INDEX``).
+
+    Start with value operations: `EQ` (equals), `IS-IN` (is in), `BTWN` (between), `GT` (greater than), `LT` (less than), `GTE` (greater or equal), `LTE` (less or equal).
+
+    Combine them with logical operations: `AND`, `OR`.
+
+    The accepted field set was discovered empirically against Yahoo's screener API;
+    Yahoo does not document it. Pull requests adding more verified fields are welcome.
+
+    Example:
+
+        .. code-block:: python
+
+            from yfinance import IndexQuery
+
+            IndexQuery('and', [
+                IndexQuery('eq', ['region', 'us']),
+                IndexQuery('gt', ['percentchange', 1])
+            ])
+    """
+    @dynamic_docstring({"valid_operand_fields_table": generate_list_table_from_dict_universal(INDEX_SCREENER_FIELDS)})
+    @property
+    def valid_fields(self) -> Dict:
+        """
+        Valid operands, grouped by category.
+        {valid_operand_fields_table}
+        """
+        return INDEX_SCREENER_FIELDS
+
+    @property
+    def valid_values(self) -> Dict:
+        """No EQ value enum is currently mapped for this quote type; Yahoo will
+        reject invalid values at request time."""
+        return {}
+
+
+class FutureQuery(QueryBase):
+    """
+    The `FutureQuery` class constructs filters for futures (``quoteType=FUTURE``).
+
+    Start with value operations: `EQ` (equals), `IS-IN` (is in), `BTWN` (between), `GT` (greater than), `LT` (less than), `GTE` (greater or equal), `LTE` (less or equal).
+
+    Combine them with logical operations: `AND`, `OR`.
+
+    The accepted field set was discovered empirically against Yahoo's screener API;
+    Yahoo does not document it. Pull requests adding more verified fields are welcome.
+
+    Example:
+
+        .. code-block:: python
+
+            from yfinance import FutureQuery
+
+            FutureQuery('and', [
+                FutureQuery('eq', ['region', 'us']),
+                FutureQuery('gt', ['intradayprice', 0])
+            ])
+    """
+    @dynamic_docstring({"valid_operand_fields_table": generate_list_table_from_dict_universal(FUTURE_SCREENER_FIELDS)})
+    @property
+    def valid_fields(self) -> Dict:
+        """
+        Valid operands, grouped by category.
+        {valid_operand_fields_table}
+        """
+        return FUTURE_SCREENER_FIELDS
+
+    @property
+    def valid_values(self) -> Dict:
+        """No EQ value enum is currently mapped for this quote type; Yahoo will
+        reject invalid values at request time."""
+        return {}
+
+
+class CryptoQuery(QueryBase):
+    """
+    The `CryptoQuery` class constructs filters for crypto (``quoteType=CRYPTOCURRENCY``).
+
+    Start with value operations: `EQ` (equals), `IS-IN` (is in), `BTWN` (between), `GT` (greater than), `LT` (less than), `GTE` (greater or equal), `LTE` (less or equal).
+
+    Combine them with logical operations: `AND`, `OR`.
+
+    Crypto rows use the ``currency`` field (e.g. ``USD``) in place of ``region``.
+
+    Example:
+
+        .. code-block:: python
+
+            from yfinance import CryptoQuery
+
+            CryptoQuery('and', [
+                CryptoQuery('eq', ['currency', 'USD']),
+                CryptoQuery('gt', ['intradaymarketcap', 1_000_000_000])
+            ])
+    """
+    @dynamic_docstring({"valid_operand_fields_table": generate_list_table_from_dict_universal(CRYPTO_SCREENER_FIELDS)})
+    @property
+    def valid_fields(self) -> Dict:
+        """
+        Valid operands, grouped by category.
+        {valid_operand_fields_table}
+        """
+        return CRYPTO_SCREENER_FIELDS
+
+    @property
+    def valid_values(self) -> Dict:
+        """No EQ value enum is currently mapped for this quote type; Yahoo will
+        reject invalid values at request time."""
+        return {}
+
+
+class CurrencyQuery(QueryBase):
+    """
+    The `CurrencyQuery` class constructs filters for FX pairs (``quoteType=CURRENCY``).
+
+    Start with value operations: `EQ` (equals), `IS-IN` (is in), `BTWN` (between), `GT` (greater than), `LT` (less than), `GTE` (greater or equal), `LTE` (less or equal).
+
+    Combine them with logical operations: `AND`, `OR`.
+
+    Note: ``intradaymarketcap`` is not accepted by Yahoo for this quoteType.
+
+    Example:
+
+        .. code-block:: python
+
+            from yfinance import CurrencyQuery
+
+            CurrencyQuery('gt', ['percentchange', 0])
+    """
+    @dynamic_docstring({"valid_operand_fields_table": generate_list_table_from_dict_universal(CURRENCY_SCREENER_FIELDS)})
+    @property
+    def valid_fields(self) -> Dict:
+        """
+        Valid operands, grouped by category.
+        {valid_operand_fields_table}
+        """
+        return CURRENCY_SCREENER_FIELDS
+
+    @property
+    def valid_values(self) -> Dict:
+        """No EQ value enum is currently mapped for this quote type; Yahoo will
+        reject invalid values at request time."""
+        return {}

--- a/yfinance/screener/screener.py
+++ b/yfinance/screener/screener.py
@@ -10,6 +10,10 @@ from ..utils import dynamic_docstring, generate_list_table_from_dict_universal
 from .query import EquityQuery as EqyQy
 from .query import FundQuery as FndQy
 from .query import ETFQuery as EtfQy
+from .query import IndexQuery as IdxQy
+from .query import FutureQuery as FutQy
+from .query import CryptoQuery as CryQy
+from .query import CurrencyQuery as CurQy
 from .query import QueryBase, EquityQuery, FundQuery, ETFQuery
 
 _SCREENER_URL_ = f"{_QUERY1_URL_}/v1/finance/screener"
@@ -205,6 +209,14 @@ def screen(query: Union[str, EquityQuery, FundQuery, ETFQuery],
         post_query['quoteType'] = 'MUTUALFUND'
     elif isinstance(post_query['query'], EtfQy):
         post_query['quoteType'] = 'ETF'
+    elif isinstance(post_query['query'], IdxQy):
+        post_query['quoteType'] = 'INDEX'
+    elif isinstance(post_query['query'], FutQy):
+        post_query['quoteType'] = 'FUTURE'
+    elif isinstance(post_query['query'], CryQy):
+        post_query['quoteType'] = 'CRYPTOCURRENCY'
+    elif isinstance(post_query['query'], CurQy):
+        post_query['quoteType'] = 'CURRENCY'
     post_query['query'] = post_query['query'].to_dict()
     data = dumps(post_query, separators=(",", ":"), ensure_ascii=False)
 


### PR DESCRIPTION
## Summary
Yahoo's screener endpoint accepts `quoteType` values beyond EQUITY/MUTUALFUND/ETF — `INDEX`, `FUTURE`, `CRYPTOCURRENCY`, `CURRENCY` all return data when posted directly. yfinance was rejecting these in the dispatch in `screener.py` because the corresponding `QueryBase` subclasses didn't exist.

This adds the four classes, mirroring the existing `EquityQuery`/`FundQuery`/`ETFQuery` pattern (`dynamic_docstring` on `valid_fields`, `valid_values` returning an empty dict because no EQ value enum is known for these types yet).

## Field schemas (discovered empirically)

Yahoo does not document per-`quoteType` field schemas, so the lists in `const.py` are the verified intersection of what each accepts:

| quoteType | Fields |
|---|---|
| INDEX | region, exchange, ticker, sector, industry + price/keystats |
| FUTURE | region, exchange, ticker + price/keystats |
| CRYPTOCURRENCY | currency, exchange, ticker, intradaymarketcap + price/keystats |
| CURRENCY | ticker + price/keystats (no marketcap) |

Pull requests adding more verified fields are welcome.

## Verified live against Yahoo

```python
yf.IndexQuery('and', [
    yf.IndexQuery('eq', ['region', 'us']),
    yf.IndexQuery('gt', ['percentchange', 0]),
])
# -> 4949 results
```

| Query | Total | Sample |
|---|---|---|
| `IndexQuery(region=us, percentchange>0)` | 4949 | ^CEFD-AD, ^SMHB-AD, ^VINXE |
| `FutureQuery(intradayprice>0)` | 1510 | 0BTZ99.CME, BTCZ26.CME, BTCU26.CME |
| `CryptoQuery(currency=USD, marketcap>1B)` | 82 | BTC-USD, ETH-USD, USDT-USD |
| `CurrencyQuery(intradayprice>0)` | 2898 | GBPIRR=X, CHFIRR=X, EURIRR=X |

Addresses #2231.

## Test plan
- [x] Existing tests still pass (`test_set_large_size_in_body`, `test_fetch_query`, `test_fetch_predefined`)
- [x] Mocked `test_extra_quotetypes_set_correct_quote_type` — for each new class, assert `screen()` POSTs the right `quoteType` value (INDEX/FUTURE/CRYPTOCURRENCY/CURRENCY)
- [x] Mocked `test_currency_rejects_unknown_field` — CurrencyQuery must reject `intradaymarketcap` (verified Yahoo rejects it too)
- [x] Live smoke test on all 4 quoteTypes against Yahoo — returns expected sample tickers
- [x] `ruff check` clean
