### PR TITLE
Restore Ticker.earnings via quoteSummary 'earnings' module + add eps_history

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -403,6 +403,56 @@ class TestTickerEarnings(unittest.TestCase):
         self.assertIsInstance(data, pd.DataFrame, "data has wrong type")
         self.assertFalse(data.empty, "data is empty")
 
+    def test_earnings_chart_from_mocked_payload(self):
+        """Inject a synthetic 'earnings' quoteSummary payload and assert that
+        revenue+earnings (yearly/quarterly) and the EPS chart all surface."""
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"quoteSummary": {"result": [{
+            "earnings": {
+                "financialCurrency": "USD",
+                "financialsChart": {
+                    "yearly": [
+                        {"date": 2024, "revenue": {"raw": 100}, "earnings": {"raw": 25}, "profitMargin": {"raw": 0.25}},
+                        {"date": 2025, "revenue": {"raw": 120}, "earnings": {"raw": 30}, "profitMargin": {"raw": 0.25}},
+                    ],
+                    "quarterly": [
+                        {"date": "1Q2025", "revenue": {"raw": 30}, "earnings": {"raw": 8}, "profitMargin": {"raw": 0.27}},
+                    ],
+                },
+                "earningsChart": {
+                    "quarterly": [
+                        {"date": "1Q2025", "actual": {"raw": 2.1}, "estimate": {"raw": 2.0},
+                         "surprisePct": "5.00", "periodEndDate": {"raw": 1743379200},
+                         "reportedDate": {"raw": 1745971200}},
+                    ],
+                },
+            },
+        }]}}
+
+        ticker = yf.Ticker("FAKE", session=self.session)
+        with patch.object(ticker._fundamentals._data, "get", return_value=fake_resp):
+            earn = ticker.earnings
+            qearn = ticker.quarterly_earnings
+            eps = ticker.eps_history
+
+        self.assertEqual(list(earn.columns), ["Revenue", "Earnings", "Profit Margin"])
+        self.assertEqual(earn.loc[2025, "Revenue"], 120)
+        self.assertEqual(qearn.loc["1Q2025", "Earnings"], 8)
+        self.assertEqual(eps.loc["1Q2025", "EPS Actual"], 2.1)
+        self.assertEqual(eps.loc["1Q2025", "Surprise %"], 5.0)
+        self.assertEqual(str(eps.loc["1Q2025", "Period End"].date()), "2025-03-31")
+
+    def test_earnings_empty_payload_returns_empty_frames(self):
+        """If Yahoo returns no earnings block, properties return empty frames
+        with the expected columns rather than raising."""
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {"quoteSummary": {"result": [{}]}}
+        ticker = yf.Ticker("EMPTY", session=self.session)
+        with patch.object(ticker._fundamentals._data, "get", return_value=fake_resp):
+            self.assertTrue(ticker.earnings.empty)
+            self.assertTrue(ticker.eps_history.empty)
+            self.assertEqual(list(ticker.earnings.columns), ["Revenue", "Earnings", "Profit Margin"])
+
     def test_earnings_dates_with_limit(self):
         # use ticker with lots of historic earnings
         ticker = yf.Ticker("IBM")

--- a/yfinance/scrapers/fundamentals.py
+++ b/yfinance/scrapers/fundamentals.py
@@ -1,13 +1,17 @@
 import datetime
 import json
-import warnings
 
 import pandas as pd
 
 from yfinance import utils, const
 from yfinance.config import YfConfig
+from yfinance.const import _BASE_URL_
 from yfinance.data import YfData
 from yfinance.exceptions import YFException, YFNotImplementedError
+
+
+_QUOTE_SUMMARY_URL_ = f"{_BASE_URL_}/v10/finance/quoteSummary/"
+
 
 class Fundamentals:
 
@@ -16,6 +20,7 @@ class Fundamentals:
         self._symbol = symbol
 
         self._earnings = None
+        self._eps_history = None
         self._financials = None
         self._shares = None
 
@@ -30,8 +35,82 @@ class Fundamentals:
 
     @property
     def earnings(self) -> dict:
-        warnings.warn("'Ticker.earnings' is deprecated as not available via API. Look for \"Net Income\" in Ticker.income_stmt.", DeprecationWarning)
-        return None
+        """Revenue + earnings + profit margin from the Yahoo ``earnings``
+        quoteSummary module. Mirrors the chart shown on the quote page.
+
+        Returns a dict with keys ``yearly`` and ``quarterly`` mapping to
+        DataFrames (columns: Revenue, Earnings, Profit Margin), plus
+        ``financialCurrency``."""
+        if self._earnings is None:
+            self._fetch_earnings()
+        return self._earnings
+
+    @property
+    def eps_history(self) -> pd.DataFrame:
+        """Quarterly EPS history (actual vs estimate, surprise %, period end
+        and reported date) from the Yahoo ``earnings`` quoteSummary module.
+        The earnings-call beat/miss chart on the quote page."""
+        if self._eps_history is None:
+            self._fetch_earnings()
+        return self._eps_history
+
+    def _fetch_earnings(self) -> None:
+        """Single-shot fetch of the ``earnings`` module: populates both
+        ``self._earnings`` (revenue + earnings) and ``self._eps_history``
+        (EPS chart) so callers don't pay two HTTP calls."""
+        try:
+            resp = self._data.get(
+                url=_QUOTE_SUMMARY_URL_ + self._symbol,
+                params={"modules": "earnings"},
+            )
+            payload = resp.json()
+            block = (payload.get("quoteSummary") or {}).get("result") or []
+            block = block[0].get("earnings") if block else None
+        except Exception as e:
+            if not YfConfig.debug.hide_exceptions:
+                raise
+            utils.get_yf_logger().error(f"{self._symbol}: failed fetching earnings module: {e}")
+            block = None
+
+        currency = (block or {}).get("financialCurrency", "USD")
+        self._earnings = {
+            "yearly": self._parse_financials_chart((block or {}).get("financialsChart", {}).get("yearly", [])),
+            "quarterly": self._parse_financials_chart((block or {}).get("financialsChart", {}).get("quarterly", [])),
+            "financialCurrency": currency,
+        }
+        self._eps_history = self._parse_earnings_chart((block or {}).get("earningsChart", {}).get("quarterly", []))
+
+    @staticmethod
+    def _parse_financials_chart(rows: list) -> pd.DataFrame:
+        if not rows:
+            return pd.DataFrame(columns=["Revenue", "Earnings", "Profit Margin"])
+        df = pd.DataFrame([
+            {
+                "date": row.get("date"),
+                "Revenue": (row.get("revenue") or {}).get("raw"),
+                "Earnings": (row.get("earnings") or {}).get("raw"),
+                "Profit Margin": (row.get("profitMargin") or {}).get("raw"),
+            }
+            for row in rows
+        ])
+        return df.set_index("date")
+
+    @staticmethod
+    def _parse_earnings_chart(rows: list) -> pd.DataFrame:
+        if not rows:
+            return pd.DataFrame(columns=["EPS Actual", "EPS Estimate", "Surprise %", "Period End", "Reported Date"])
+        df = pd.DataFrame([
+            {
+                "date": row.get("date"),
+                "EPS Actual": (row.get("actual") or {}).get("raw"),
+                "EPS Estimate": (row.get("estimate") or {}).get("raw"),
+                "Surprise %": (float(row["surprisePct"]) if row.get("surprisePct") not in (None, "") else None),
+                "Period End": pd.to_datetime((row.get("periodEndDate") or {}).get("raw"), unit="s", errors="coerce"),
+                "Reported Date": pd.to_datetime((row.get("reportedDate") or {}).get("raw"), unit="s", errors="coerce"),
+            }
+            for row in rows
+        ])
+        return df.set_index("date")
 
     @property
     def shares(self) -> pd.DataFrame:

--- a/yfinance/ticker.py
+++ b/yfinance/ticker.py
@@ -198,6 +198,12 @@ class Ticker(TickerBase):
         return self.get_earnings(freq='quarterly')
 
     @property
+    def eps_history(self) -> _pd.DataFrame:
+        """Quarterly EPS history (actual vs estimate, surprise %, period end
+        and reported date) from the Yahoo ``earnings`` quoteSummary module."""
+        return self._fundamentals.eps_history
+
+    @property
     def income_stmt(self) -> _pd.DataFrame:
         return self.get_income_stmt(pretty=True)
 


### PR DESCRIPTION
## Summary
`Ticker.earnings` was deprecated in 57dac67 (2024-07) with the rationale *"not available via API"* — but that diagnosis was inaccurate. The HTML-page scraper that historically populated `self._earnings` had broken when Yahoo redesigned the quote page, and instead of porting to the JSON quoteSummary endpoint, the property was bypassed and marked deprecated. The `quoteSummary?modules=earnings` endpoint has been live the whole time and exposes exactly the data the deprecated property used to: yearly + quarterly revenue, earnings and profit margin.

This PR ports `Ticker.earnings` to that endpoint and also adds `Ticker.eps_history` (the quarterly EPS beat/miss chart Yahoo shows on the quote page — `Actual`, `Estimate`, `Surprise %`, `Period End`, `Reported Date`) which closes the long-standing request to surface this data programmatically (#1737).

## Example
```python
>>> import yfinance as yf
>>> t = yf.Ticker('AAPL')

>>> t.earnings
           Revenue      Earnings  Profit Margin
date
2022  394328000000   99803000000       0.253096
2023  383285000000   96995000000       0.253062
2024  391035000000   93736000000       0.239713
2025  416161000000  112010000000       0.269151

>>> t.quarterly_earnings
             Revenue     Earnings  Profit Margin
date
2Q2025   94036000000  23434000000       0.249202
3Q2025  102466000000  27466000000       0.268050
4Q2025  143756000000  42097000000       0.292836
1Q2026  111184000000  29578000000       0.266027

>>> t.eps_history
        EPS Actual  EPS Estimate  Surprise % Period End       Reported Date
date
2Q2025        1.57       1.42572       10.12 2025-06-30 2025-07-31 20:30:25
3Q2025        1.85       1.76993        4.52 2025-09-30 2025-10-30 20:30:00
4Q2025        2.84       2.67080        6.34 2025-12-31 2026-01-29 21:30:00
1Q2026        2.01       1.94275        3.46 2026-03-31 2026-04-30 20:30:00
```

## Design notes
- A single `_fetch_earnings` HTTP call populates both `earnings` (revenue/earnings DataFrames + currency) and `eps_history` — so the two new properties cost one round-trip total.
- The yearly/quarterly DataFrames are returned with Yahoo's period-label index (`2024` for yearly, `"1Q2026"` for quarterly). Mirrors the shape `get_earnings(freq=...)` historically expected, so the existing `Ticker.earnings` / `Ticker.quarterly_earnings` shells in `ticker.py` just work.
- Empty payload path returns empty DataFrames with the canonical columns, not `None` — caller code doesn't need to special-case absence.

## Verified
- Smoke-tested on AAPL, MSFT, TSLA, BRK-B, BABA, XOM — all return 4 yearly / 4 quarterly / 4 EPS rows (Yahoo's standard window).
- Two mocked tests in `tests/test_ticker.py::TestTickerEarnings`:
  - `test_earnings_chart_from_mocked_payload` — synthetic full payload, asserts all three views surface with correct values, types and dates.
  - `test_earnings_empty_payload_returns_empty_frames` — Yahoo returns no `earnings` block, properties return empty DataFrames with canonical columns rather than raising.
- `ruff check` clean.

Closes #1737.
