### PR TITLE
Remove `sample` executable from package install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,11 +75,6 @@ setup(
     },
     include_package_data=True,
     # Note: Pandas.read_html() needs html5lib & beautifulsoup4
-    entry_points={
-        'console_scripts': [
-            'sample=sample:main',
-        ],
-    },
 )
 
 print("""


### PR DESCRIPTION
Currently, the `yfinance` package includes an executable shim named `sample`. As this executable shim wraps a non-existent module, this was likely added in error. Given that this executable serves no purpose, as a small item of clean-up, the following change drops this executable from the set of installed artifacts.