### PR TITLE
Fix Auth.check_login() always returning False

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,137 @@
+"""Unit tests for yfinance.data.Auth login detection.
+
+These are pure unit tests: the Yahoo homepage response is mocked, so they run
+offline and require no Yahoo Finance login cookies. They lock in the fix for
+``check_login()`` (which previously looked for the client-side-only
+``<script id="nimbus-benji-config">`` element and therefore always returned
+``False``) by parsing the server-rendered ``window.YAHOO.context`` object.
+"""
+import unittest
+from unittest import mock
+
+from yfinance.data import Auth, _extract_window_yahoo_context
+
+
+# --- Synthetic fixtures (no real personal data) -----------------------------
+# Mimic the real page: window.YAHOO.context is assigned inside a <script>.
+_LOGGED_IN_HTML = """<!doctype html><html><head><script>
+(function(){if(!window.YAHOO){window.YAHOO={}};window.YAHOO.context = {"authed":"1","user":{"age":"","alias":"unit-test@example.com","crumb":"abc123","firstName":"Unit","gender":"","guid":"ABCDEFGHIJKLMNOPQRSTUV1234","login":"unit-test@example.com","year":""},"feature":{}};})();
+</script></head><body></body></html>"""
+
+_LOGGED_OUT_HTML = """<!doctype html><html><head><script>
+(function(){if(!window.YAHOO){window.YAHOO={}};window.YAHOO.context = {"authed":"0","user":{"age":"","crumb":"abc123","firstName":"","gender":"","year":""},"feature":{}};})();
+</script></head><body></body></html>"""
+
+_NO_CONTEXT_HTML = "<!doctype html><html><body><p>nothing here</p></body></html>"
+
+# A logged-in context whose string values contain braces, to exercise the
+# string-aware brace matching in _extract_window_yahoo_context.
+_BRACES_IN_STRING_HTML = (
+    """<script>window.YAHOO.context = """
+    """{"authed":"1","user":{"guid":"GUID0000000000000000000000","""
+    """"firstName":"a}b{c","alias":"x@y.com"}};</script>"""
+)
+
+# A decoy assignment inside a JS string literal appears BEFORE the real one;
+# the real assignment must still be found.
+_FALSE_MATCH_FIRST_HTML = (
+    """<script>var s = "window.YAHOO.context = {fake}"; """
+    """window.YAHOO.context = {"authed":"1","user":{"guid":"REALGUID000000000000000AB"}};"""
+    """</script>"""
+)
+
+# A context assignment whose body is not valid JSON.
+_INVALID_JSON_HTML = """<script>window.YAHOO.context = {not valid json,,};</script>"""
+
+# Edge cases for the check_login decision logic.
+_USER_NOT_DICT_HTML = """<script>window.YAHOO.context = {"authed":"1","user":"oops"};</script>"""
+_AUTHED_MISSING_HTML = """<script>window.YAHOO.context = {"user":{"guid":"G000000000000000000000000"}};</script>"""
+_EMPTY_GUID_HTML = """<script>window.YAHOO.context = {"authed":"1","user":{"guid":""}};</script>"""
+
+
+def _auth_returning(html):
+    """Build an Auth whose underlying data layer returns the given HTML."""
+    auth = Auth()
+    auth._user = None
+    auth._data = mock.MagicMock()
+    auth._data.get.return_value = mock.MagicMock(text=html)
+    return auth
+
+
+class TestExtractWindowYahooContext(unittest.TestCase):
+    def test_parses_logged_in_context(self):
+        ctx = _extract_window_yahoo_context(_LOGGED_IN_HTML)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx["authed"], "1")
+        self.assertEqual(ctx["user"]["guid"], "ABCDEFGHIJKLMNOPQRSTUV1234")
+
+    def test_handles_braces_inside_strings(self):
+        ctx = _extract_window_yahoo_context(_BRACES_IN_STRING_HTML)
+        self.assertIsNotNone(ctx)
+        # The '}' and '{' inside the string value must not terminate the object.
+        self.assertEqual(ctx["user"]["firstName"], "a}b{c")
+        self.assertEqual(ctx["authed"], "1")
+
+    def test_skips_false_match_in_string_literal(self):
+        # The decoy "window.YAHOO.context = {fake}" must be skipped in favour of
+        # the real, parseable assignment that follows it.
+        ctx = _extract_window_yahoo_context(_FALSE_MATCH_FIRST_HTML)
+        self.assertIsNotNone(ctx)
+        self.assertEqual(ctx["user"]["guid"], "REALGUID000000000000000AB")
+
+    def test_returns_none_on_invalid_json(self):
+        self.assertIsNone(_extract_window_yahoo_context(_INVALID_JSON_HTML))
+
+    def test_returns_none_when_absent(self):
+        self.assertIsNone(_extract_window_yahoo_context(_NO_CONTEXT_HTML))
+
+
+class TestAuthCheckLogin(unittest.TestCase):
+    def test_true_when_logged_in(self):
+        auth = _auth_returning(_LOGGED_IN_HTML)
+        self.assertTrue(auth.check_login())
+
+    def test_false_when_logged_out(self):
+        auth = _auth_returning(_LOGGED_OUT_HTML)
+        self.assertFalse(auth.check_login())
+
+    def test_false_when_context_absent(self):
+        auth = _auth_returning(_NO_CONTEXT_HTML)
+        self.assertFalse(auth.check_login())
+
+    def test_false_when_user_not_dict(self):
+        # A truthy non-dict 'user' must not crash and must be treated as not logged in.
+        auth = _auth_returning(_USER_NOT_DICT_HTML)
+        self.assertFalse(auth.check_login())
+
+    def test_false_when_authed_missing(self):
+        # guid present but authed flag absent -> not logged in.
+        auth = _auth_returning(_AUTHED_MISSING_HTML)
+        self.assertFalse(auth.check_login())
+
+    def test_false_when_guid_empty(self):
+        # authed '1' but empty guid (a half-rendered/logged-out shape) -> False.
+        auth = _auth_returning(_EMPTY_GUID_HTML)
+        self.assertFalse(auth.check_login())
+
+    def test_user_property_populated_when_logged_in(self):
+        auth = _auth_returning(_LOGGED_IN_HTML)
+        user = auth.user
+        self.assertIsInstance(user, dict)
+        self.assertEqual(user["guid"], "ABCDEFGHIJKLMNOPQRSTUV1234")
+        self.assertEqual(user["alias"], "unit-test@example.com")
+
+    def test_user_property_none_when_logged_out(self):
+        auth = _auth_returning(_LOGGED_OUT_HTML)
+        self.assertIsNone(auth.user)
+
+    def test_check_login_caches_and_short_circuits(self):
+        auth = _auth_returning(_LOGGED_IN_HTML)
+        self.assertTrue(auth.check_login())
+        self.assertTrue(auth.check_login())
+        # Second call must use the cached self._user, not refetch.
+        self.assertEqual(auth._data.get.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -1,6 +1,7 @@
 import functools
 from functools import lru_cache
 import socket
+import re
 import time as _time
 import json as _json
 
@@ -552,6 +553,51 @@ class YfData(metaclass=SingletonMeta):
         )
         return response
 
+def _extract_window_yahoo_context(html: str) -> dict | None:
+    """Extract the server-rendered ``window.YAHOO.context`` object from a Yahoo Finance page.
+
+    The logged-in user identity is rendered server-side as a JavaScript
+    assignment ``window.YAHOO.context = {...}``. (The older
+    ``<script id="nimbus-benji-config">`` element is constructed client-side
+    only and is therefore absent from the fetched HTML.) Each candidate
+    assignment is brace-matched - ignoring braces inside string literals - and
+    the first one that parses as JSON is returned, so a stray occurrence inside
+    a JavaScript string literal is skipped rather than aborting the search.
+
+    Args:
+        html (str): Raw HTML of the Yahoo Finance homepage.
+
+    Returns:
+        dict | None: The parsed context object, or ``None`` if absent or unparseable.
+    """
+    for match in re.finditer(r"window\.YAHOO\.context\s*=\s*\{", html):
+        start = match.end() - 1  # index of the '{' captured by the regex
+        depth = 0
+        in_string = False
+        escaped = False
+        for i in range(start, len(html)):
+            ch = html[i]
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+            elif ch == '"':
+                in_string = True
+            elif ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return _json.loads(html[start:i + 1])
+                    except (ValueError, TypeError):
+                        break  # not valid JSON; try the next candidate match
+    return None
+
+
 class Auth:
     def __init__(self, session=None):
         self._session = session
@@ -586,20 +632,22 @@ class Auth:
 
         try:
             response = self._data.get("https://finance.yahoo.com/")
-            soup = BeautifulSoup(response.text, 'html.parser')
-
-            script_tag = soup.find('script', id='nimbus-benji-config')
-            if not script_tag:
+            context = _extract_window_yahoo_context(response.text)
+            if context is None:
                 return False
 
-            config_json = script_tag.string
-            config_data = _json.loads(config_json).get('i13n')
-
-            if "user" in config_data and "guid" in config_data["user"]:
-                self._user = config_data["user"]
+            user = context.get("user")
+            # Both 'authed' == '1' and a populated 'guid' only appear when the
+            # session is logged in; a logged-out page reports authed '0' and a
+            # 'user' object without a 'guid'.
+            if (
+                context.get("authed") == "1"
+                and isinstance(user, dict)
+                and user.get("guid")
+            ):
+                self._user = user
                 return True
-            else:
-                return False
+            return False
         except Exception as e:
             if not YfConfig.debug.hide_exceptions:
                 raise


### PR DESCRIPTION
## Problem
`Auth.check_login()` always returns `False`, even with valid login cookies set
via `set_login_cookies()`.

It looks for `<script id="nimbus-benji-config">` and reads `i13n.user.guid`.
That element is built **client-side by JS at runtime** (via
`document.getElementById("nimbus-benji-config")`), so it is **absent from the
server-fetched HTML**. `soup.find(...)` is therefore always `None` and the
method returns `False` regardless of login state.

Verified on `dev` with a real logged-in session (cookies set via
`Auth.set_login_cookies`): `check_login()` returns `False` even though
authenticated requests succeed.

## Fix
Parse the **server-rendered** `window.YAHOO.context` object instead, and treat
the session as logged in when `authed == "1"` and `user.guid` is present.

Observed difference (same homepage, anonymised):
- logged in:  `authed == "1"`, `user` has `guid` / `alias` / `login`
- logged out: `authed == "0"`, `user` has no `guid`

After the fix `check_login()` returns `True` for a logged-in session and
populates `Auth.user` (which also carries the per-session `crumb` already
present in that object).

### Notes
- `window.YAHOO.context` is a JS assignment, not a JSON `<script>`, so it is
  located by regex and sliced out with string-aware brace matching. Each
  candidate match is tried, so a stray occurrence inside a JS string literal is
  skipped; any parse failure fails safe to `False`.
- No reliable login-only API endpoint exists (`/v1/test/getcrumb` returns a
  crumb for anonymous sessions too), so the server-rendered context is the most
  reliable signal.
  crumb for anonymous sessions too), so the server-rendered context is the most
  reliable signal.
- The helper is module-level (mirroring `_is_transient_error`) so it can be
  unit-tested directly.

## Backward compatibility
No public API change. `check_login() -> bool` and `Auth.user -> dict | None`
keep their signatures, semantics, and the `self._user` caching short-circuit.
The old path never succeeded, so no caller observed the previous `_user` shape.

## Tests
Adds `tests/test_auth.py` — offline pure unit tests (mocked homepage, no login
cookies needed), 14 cases: logged-in / logged-out / missing context / non-dict
user / missing authed / empty guid / invalid JSON / decoy-string match /
`user` property / caching. Run: `python -m unittest tests.test_auth`.