### PR TITLE
Determine login and subscription tier via the subscriptions API

### DIFF
--- a/doc/source/reference/examples/auth.py
+++ b/doc/source/reference/examples/auth.py
@@ -3,16 +3,20 @@ import os
 
 auth = yf.Auth()
 
-# Set log in cookies from browser
-auth.set_login_cookies(os.getenv("COOKIE_T"), os.getenv("COOKIE_Y"))
-
-# Check if the cookies worked
-if auth.check_login():
+# Set login cookies obtained from your browser. The call stores them, validates
+# them with a live login check, and returns whether the account is logged in.
+if auth.set_login_cookies(os.getenv("COOKIE_T"), os.getenv("COOKIE_Y")):
     print("Logged in")
 else:
-    print("Invalid cookie")
+    print("Invalid or expired cookies")
 
-# Every subsequent request sent to Yahoo Finance will now be under the logged-in user.
+# Every subsequent request sent to Yahoo Finance is now under the logged-in user.
 
-# Access user information
-auth.user
+# Re-check the live login state at any time (re-queried each call, never cached).
+auth.check_login()        # -> True / False
+
+# Yahoo Finance subscription tier of the logged-in account.
+auth.subscription_tier()  # -> 'gold' / 'silver' / 'bronze' / 'free' / None
+
+# Access user information.
+auth.user                 # -> {'guid': ...} or None

--- a/doc/source/reference/yfinance.auth.rst
+++ b/doc/source/reference/yfinance.auth.rst
@@ -11,7 +11,8 @@ Authentication
 
 Class
 ------------
-The `Auth` module, allows you to login to Yahoo! Finance.
+The `Auth` module lets you log in to Yahoo! Finance, check the login state and
+read the account's subscription tier.
 
 .. autosummary::
    :toctree: api/
@@ -20,7 +21,7 @@ The `Auth` module, allows you to login to Yahoo! Finance.
 
 Auth Sample Code
 ------------------
-The `Auth` module, allows you to login to Yahoo! Finance.
+Logging in with browser cookies, then checking the login state and subscription tier:
 
 .. literalinclude:: examples/auth.py
    :language: python

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,123 @@
+"""Unit tests for yfinance.data.Auth (login state + subscription tier).
+
+Pure unit tests: the OBI subscriptions endpoint response is mocked, so they run
+offline with no Yahoo login cookies. Auth derives both login state and the
+subscription tier from a single lightweight JSON call (no web-page scraping).
+The call is made live each time (not cached), so the answer never goes stale.
+"""
+import unittest
+from unittest import mock
+
+from yfinance.data import Auth, _SUBSCRIPTIONS_URL
+
+_GUID = "ABCDEFGHIJKLMNOPQRSTUV1234"
+
+
+def _result(guid=_GUID, tier=None, action="ACTIVE"):
+    """Build a subscriptions ``result`` with an optional subscription tier id."""
+    view = [{"action": action, "tier": tier}] if tier is not None else []
+    return {"guid": guid, "subscriptionView": view}
+
+
+def _auth(status=200, result=None):
+    """Build an Auth whose subscriptions call returns the given status/result."""
+    resp = mock.MagicMock()
+    resp.status_code = status
+    resp.json.return_value = {"result": result} if result is not None else {}
+    auth = Auth()
+    auth._data = mock.MagicMock()
+    auth._data.get.return_value = resp
+    return auth
+
+
+class TestAuthLogin(unittest.TestCase):
+    def test_logged_in_when_200_with_guid(self):
+        auth = _auth(200, _result())
+        self.assertTrue(auth.check_login())
+        self.assertEqual(auth.user, {"guid": _GUID})
+
+    def test_not_logged_in_when_401(self):
+        auth = _auth(401)
+        self.assertFalse(auth.check_login())
+        self.assertIsNone(auth.user)
+
+    def test_not_logged_in_when_403(self):
+        auth = _auth(403)
+        self.assertFalse(auth.check_login())
+        self.assertIsNone(auth.user)
+
+    def test_not_logged_in_when_200_without_guid(self):
+        auth = _auth(200, {"subscriptionView": []})  # 200 but no guid -> not logged in
+        self.assertFalse(auth.check_login())
+        self.assertIsNone(auth.user)
+
+    def test_not_logged_in_on_transient_error(self):
+        # A 429/5xx can't confirm login; report not-logged-in for that call.
+        self.assertFalse(_auth(429).check_login())
+        self.assertFalse(_auth(500).check_login())
+
+    def test_probe_is_a_single_subscriptions_get(self):
+        # Login state comes from one lightweight GET to the subscriptions
+        # endpoint; a 401/403 is the "not logged in" answer.
+        auth = _auth(401)
+        auth.check_login()
+        auth._data.get.assert_called_once_with(_SUBSCRIPTIONS_URL)
+
+    def test_check_login_is_live_not_cached(self):
+        # Each call re-queries: a session that goes valid/invalid between calls
+        # is reflected immediately rather than served from a stale cache.
+        auth = _auth(401)
+        self.assertFalse(auth.check_login())
+        self.assertFalse(auth.check_login())
+        self.assertEqual(auth._data.get.call_count, 2)
+
+
+class TestAuthSubscriptionTier(unittest.TestCase):
+    def test_free_when_logged_in_no_subscription(self):
+        self.assertEqual(_auth(200, _result()).subscription_tier(), "free")
+
+    def test_bronze(self):
+        self.assertEqual(_auth(200, _result(tier=3)).subscription_tier(), "bronze")
+
+    def test_silver(self):
+        self.assertEqual(_auth(200, _result(tier=5)).subscription_tier(), "silver")
+
+    def test_gold(self):
+        self.assertEqual(_auth(200, _result(tier=6)).subscription_tier(), "gold")
+
+    def test_premium_for_unmarketed_tier(self):
+        # tier 4 exists in tierRanking but has no marketed name -> generic premium.
+        self.assertEqual(_auth(200, _result(tier=4)).subscription_tier(), "premium")
+
+    def test_free_when_subscription_not_active(self):
+        # A cancelled/expired (non-ACTIVE) subscription -> effectively free.
+        auth = _auth(200, _result(tier=6, action="CANCELLED"))
+        self.assertEqual(auth.subscription_tier(), "free")
+
+    def test_none_when_not_logged_in(self):
+        self.assertIsNone(_auth(401).subscription_tier())
+
+
+class TestSetLoginCookies(unittest.TestCase):
+    def test_returns_true_and_validates_when_logged_in(self):
+        auth = _auth(200, _result())
+        self.assertTrue(auth.set_login_cookies("T-val", "Y-val"))
+        # cookies stored on the shared client...
+        auth._data.set_login_cookies.assert_called_once_with("T-val", "Y-val")
+        # ...and validated via a live login check.
+        self.assertTrue(auth._data.get.called)
+
+    def test_returns_false_when_not_logged_in(self):
+        auth = _auth(401)
+        self.assertFalse(auth.set_login_cookies("bad", "bad"))
+        auth._data.set_login_cookies.assert_called_once_with("bad", "bad")
+
+    def test_warns_when_not_logged_in(self):
+        auth = _auth(401)
+        with mock.patch("yfinance.data.utils.get_yf_logger") as get_logger:
+            auth.set_login_cookies("bad", "bad")
+            get_logger.return_value.warning.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,7 @@
 import unittest
 from functools import lru_cache
 
-from yfinance.data import lru_cache_freezeargs
+from yfinance.data import SingletonMeta, YfData, lru_cache_freezeargs
 from yfinance.utils import frozendict
 
 
@@ -47,6 +47,22 @@ class TestFrozenDict(unittest.TestCase):
         self.assertEqual(call_count["n"], 1)
         self.assertEqual(fn({"a": 1, "b": 3}), 4)
         self.assertEqual(call_count["n"], 2)
+
+
+class TestYfDataLoginCookies(unittest.TestCase):
+    def test_set_login_cookies_invalidates_crumb(self):
+        # Logging in (or switching accounts) must drop a crumb minted under a
+        # different login state so the next request re-mints a matched crumb.
+        # Use a throwaway instance (YfData is a singleton) to avoid leaking the
+        # test cookies into the shared session other tests rely on.
+        SingletonMeta._instances.pop(YfData, None)
+        try:
+            data = YfData()
+            data._crumb = "stale-crumb-sentinel"
+            data.set_login_cookies("T-test-value", "Y-test-value")
+            self.assertIsNone(data._crumb)
+        finally:
+            SingletonMeta._instances.pop(YfData, None)
 
 
 if __name__ == "__main__":

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -2,7 +2,6 @@ import functools
 from functools import lru_cache
 import socket
 import time as _time
-import json as _json
 
 from ._http import requests, new_session, is_supported_session, cookie_jar
 from urllib.parse import urlsplit, urljoin
@@ -99,6 +98,11 @@ class YfData(metaclass=SingletonMeta):
                 "Y": cookie_y
             })
             self._cookie = True
+            # Drop any cached crumb: it may have been minted under a different
+            # (e.g. anonymous, or another account's) login state. Forcing a
+            # re-mint on the next request keeps the crumb matched to these
+            # cookies, so the login takes effect cleanly mid-process.
+            self._crumb = None
 
     def _set_session(self, session):
         if session is None:
@@ -552,16 +556,24 @@ class YfData(metaclass=SingletonMeta):
         )
         return response
 
+_SUBSCRIPTIONS_URL = "https://query1.finance.yahoo.com/ws/obi-integration/v1/subscriptions"
+
+# Yahoo Finance subscription tier ids. The subscriptions response reports the
+# account's tier as an integer in subscriptionView[].tier; tierRanking is
+# [3, 4, 5, 6] (there is no tier 1/2, and tier 4 is unmarketed). Reading the id
+# is more stable than inferring from granted features, which Yahoo reshuffles
+# between tiers for marketing reasons.
+_TIER_NAMES = {6: "gold", 5: "silver", 3: "bronze"}
+
+
 class Auth:
     def __init__(self, session=None):
         self._session = session
         self._data = YfData(session)
 
-        self._user: dict | None = None
-
-    def set_login_cookies(self, cookie_t: str, cookie_y: str) -> None:
+    def set_login_cookies(self, cookie_t: str, cookie_y: str) -> bool:
         """
-        Set the login cookies to indicate that the user is logged in.
+        Set the login cookies and verify they are valid.
 
         How to Obtain the Cookies:
             1. Open your browser (e.g., Chrome, Firefox).
@@ -576,35 +588,76 @@ class Auth:
         Args:
             cookie_t (str): The value for the 'T' cookie.
             cookie_y (str): The value for the 'Y' cookie.
+
+        Returns:
+            bool: ``True`` if the cookies are valid (the account is logged in),
+            ``False`` otherwise (also emitted as a warning). The cookies are
+            stored regardless. ``False`` can also mean Yahoo was transiently
+            unreachable, so it is not treated as a hard error.
         """
         self._data.set_login_cookies(cookie_t, cookie_y)
+        logged_in = self.check_login()
+        if not logged_in:
+            utils.get_yf_logger().warning(
+                "set_login_cookies: the provided cookies are not logged in "
+                "(or Yahoo is unreachable)."
+            )
+        return logged_in
 
-    def check_login(self) -> bool:
-        """Check whether the user is logged in to Yahoo Finance."""
-        if self._user:
-            return True
+    def _fetch_entitlement(self) -> dict | None:
+        """Fetch the account's subscription entitlement (live, not cached).
 
+        A single lightweight JSON call to the OBI subscriptions endpoint
+        determines both login state and subscription tier, avoiding any
+        consumer-web-page scraping. The result is intentionally not cached:
+        the endpoint is cheap and Yahoo does not rate-limit it at any realistic
+        volume, so a fresh call each time keeps the answer from going stale
+        (e.g. if the login session expires part-way through a long-running
+        process).
+
+        Returns:
+            dict | None: The entitlement ``result`` object when logged in, or
+            ``None`` when not logged in (anonymous sessions return HTTP 401).
+        """
         try:
-            response = self._data.get("https://finance.yahoo.com/")
-            soup = BeautifulSoup(response.text, 'html.parser')
-
-            script_tag = soup.find('script', id='nimbus-benji-config')
-            if not script_tag:
-                return False
-
-            config_json = script_tag.string
-            config_data = _json.loads(config_json).get('i13n')
-
-            if "user" in config_data and "guid" in config_data["user"]:
-                self._user = config_data["user"]
-                return True
-            else:
-                return False
+            response = self._data.get(_SUBSCRIPTIONS_URL)
+            if response.status_code != 200:
+                return None
+            result = (response.json() or {}).get("result")
+            if isinstance(result, dict) and result.get("guid"):
+                return result
+            return None
         except Exception as e:
             if not YfConfig.debug.hide_exceptions:
                 raise
             utils.get_yf_logger().error(f"Error confirming login: {e}")
-            return False
+            return None
+
+    def check_login(self) -> bool:
+        """Check whether the user is logged in to Yahoo Finance."""
+        return self._fetch_entitlement() is not None
+
+    def subscription_tier(self) -> str | None:
+        """Return the Yahoo Finance subscription tier of the logged-in account.
+
+        Read directly from the account's tier id in ``subscriptionView`` (the
+        value the account is billed against) rather than inferring it from the
+        granted feature set, which Yahoo reshuffles between tiers.
+
+        Returns:
+            str | None: ``'gold'``, ``'silver'`` or ``'bronze'`` for a named
+            subscription (``'premium'`` for a subscribed tier with no marketed
+            name), ``'free'`` when logged in without a subscription, or ``None``
+            when not logged in.
+        """
+        entitlement = self._fetch_entitlement()
+        if entitlement is None:
+            return None
+        active = [s for s in (entitlement.get("subscriptionView") or [])
+                  if s.get("action") == "ACTIVE"]
+        if not active:
+            return "free"
+        return _TIER_NAMES.get(active[0].get("tier"), "premium")
 
     @property
     def user(self) -> dict | None:
@@ -612,9 +665,7 @@ class Auth:
         Get the logged-in user's details.
 
         Returns:
-            dict | None: A dictionary containing the user's details if logged in, or None if not logged in.
+            dict | None: ``{'guid': ...}`` if logged in, or ``None`` if not.
         """
-        if self._user is not None or self.check_login():
-            return self._user
-
-        return None
+        entitlement = self._fetch_entitlement()
+        return {"guid": entitlement["guid"]} if entitlement else None


### PR DESCRIPTION
Auth.check_login() parsed the finance.yahoo.com homepage for a 'nimbus-benji-config' element, which Yahoo builds client-side and is absent from the fetched HTML, so it always returned False even when logged in. Query the OBI subscriptions endpoint instead (/ws/obi-integration/v1/subscriptions): a lightweight JSON request (Yahoo rate-limits scraping of its large consumer web pages far more aggressively than its JSON APIs) where HTTP 200 with a guid means logged in and 401 means not.

Also add Auth.subscription_tier() -> 'gold'|'silver'|'bronze'|'free'|None, with the tier inferred from granted feature flags (stable across Yahoo's non-contiguous tier numbering). Auth.user returns {'guid': ...}.

The check is made live on each call rather than cached: the endpoint is cheap and not rate-limited at realistic volumes, so a fresh call keeps the answer correct after a runtime login/upgrade/expiry and lets the caller swap login cookies mid-process.

Add an allow_strategy_switch flag to YfData.get/_make_request; the login probe passes False so an expected 401 does not trigger the cookie-strategy toggle (which clears the session cookies, wiping T/Y). set_login_cookies() now also clears the cached crumb so the next request mints a crumb matched to the new login.