### PR TITLE
DOC: clarify unsupported caching sessions

### DIFF
--- a/doc/source/advanced/caching.rst
+++ b/doc/source/advanced/caching.rst
@@ -16,3 +16,14 @@ You can direct cache to use a different location with :attr:`set_tz_cache_locati
 
     import yfinance as yf
     yf.set_tz_cache_location("custom/cache/location")
+
+Custom Session Caching
+----------------------
+
+Do not pass a caching session, such as ``requests_cache.CachedSession``, to
+yfinance. Those sessions wrap ``requests.Session`` and are not compatible with
+yfinance's ``curl_cffi`` session handling. They can also miss when Yahoo rotates
+cookies or crumbs.
+
+For yfinance's supported persistent cache, leave ``session`` unset and configure
+the cache location with :attr:`set_tz_cache_location <yfinance.set_tz_cache_location>`.

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -70,6 +70,16 @@ class TestHttpBackend(unittest.TestCase):
         self.assertTrue(mod.is_supported_session(_stdlib_requests.Session()))
         self.assertFalse(mod.is_supported_session(object()))
 
+    def test_yfdata_rejects_caching_sessions(self):
+        from yfinance.data import YfData
+        from yfinance.exceptions import YFDataException
+
+        class CachingSession:
+            cache = object()
+
+        with self.assertRaisesRegex(YFDataException, "requests_cache.CachedSession"):
+            YfData(session=CachingSession())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -116,7 +116,13 @@ class YfData(metaclass=SingletonMeta):
             self._session_is_caching = True
             # requests_cache wraps the stdlib Session; it doesn't work with
             # curl_cffi and tends to miss anyway because the Yahoo crumb rotates.
-            raise YFDataException("Caching sessions (e.g. requests_cache) are not supported. Solution: stop setting session, let yfinance handle.")
+            raise YFDataException(
+                "Caching sessions such as requests_cache.CachedSession are not supported. "
+                "They wrap a requests.Session, which is incompatible with yfinance's curl_cffi "
+                "session and can miss when Yahoo rotates cookies or crumbs. "
+                "Do not set a caching session; let yfinance manage the session and use "
+                "set_tz_cache_location() to configure the built-in persistent cache."
+            )
 
         if not is_supported_session(session):
             raise YFDataException(f"Unsupported session type {type(session)}; expected curl_cffi or requests Session. Solution: stop setting session, let yfinance handle.")


### PR DESCRIPTION
Closes #2486.

## Summary

Clarify that caching sessions such as `requests_cache.CachedSession` are unsupported.

The current code already rejects sessions with a `.cache` attribute. This updates the exception text and the advanced caching docs to explain why those sessions are not supported with yfinance's `curl_cffi` session handling, and points users toward yfinance's built-in persistent cache configuration instead.

This also adds a small regression test for the caching-session rejection path.

## Tests

- `python3 -m py_compile yfinance/data.py tests/test_http.py`
- `git diff --check`

Could not run the target unittest locally because this environment is missing repository dependencies (`requests` / `pandas`).
