### PR TITLE
Preserve user login cookies across cookie-strategy switches

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -8,7 +8,7 @@ The call is made live each time (not cached), so the answer never goes stale.
 import unittest
 from unittest import mock
 
-from yfinance.data import Auth, _SUBSCRIPTIONS_URL
+from yfinance.data import Auth, SingletonMeta, YfData, _SUBSCRIPTIONS_URL
 
 _GUID = "ABCDEFGHIJKLMNOPQRSTUV1234"
 
@@ -28,6 +28,13 @@ def _auth(status=200, result=None):
     auth._data = mock.MagicMock()
     auth._data.get.return_value = resp
     return auth
+
+
+def tearDownModule():
+    # _auth() builds a real Auth() (which registers a YfData singleton) before
+    # swapping in a mock, so drop the singleton afterwards to avoid leaking a
+    # stale instance into other test modules.
+    SingletonMeta._instances.pop(YfData, None)
 
 
 class TestAuthLogin(unittest.TestCase):
@@ -117,6 +124,33 @@ class TestSetLoginCookies(unittest.TestCase):
         with mock.patch("yfinance.data.utils.get_yf_logger") as get_logger:
             auth.set_login_cookies("bad", "bad")
             get_logger.return_value.warning.assert_called_once()
+
+
+class TestLoggedInFlag(unittest.TestCase):
+    """Auth reconciles YfData._logged_in with the verified login state."""
+
+    def test_entitlement_marks_logged_in_when_valid(self):
+        auth = _auth(200, _result())
+        auth.check_login()
+        auth._data._set_logged_in.assert_called_with(True)
+
+    def test_entitlement_marks_logged_out_when_anonymous(self):
+        auth = _auth(401)
+        auth.check_login()
+        auth._data._set_logged_in.assert_called_with(False)
+
+    def test_logged_in_unchanged_on_transient_error(self):
+        # A transient exception can't confirm login, so the cookie-preservation
+        # flag must NOT be touched (neither up nor down) — whether the error is
+        # hidden or re-raised depends on config, but either way _set_logged_in
+        # must not be called.
+        auth = _auth()
+        auth._data.get.side_effect = ConnectionError("boom")
+        try:
+            auth.check_login()
+        except ConnectionError:
+            pass
+        auth._data._set_logged_in.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -65,5 +65,63 @@ class TestYfDataLoginCookies(unittest.TestCase):
             SingletonMeta._instances.pop(YfData, None)
 
 
+class TestCookieStrategyLoginPreservation(unittest.TestCase):
+    """The csrf->basic strategy toggle must not wipe user-set login cookies.
+
+    Uses a throwaway YfData (the class is a SingletonMeta singleton) so the test
+    cookies / login flag don't leak into the shared session other tests use.
+    """
+
+    def setUp(self):
+        SingletonMeta._instances.pop(YfData, None)
+        self.data = YfData()
+        self.data._cookie_strategy = 'csrf'
+        self.data._cookie = None
+        self.data._crumb = None
+        self.data._logged_in = False
+        self.data._session.cookies.clear()
+        self.data._session.cookies.update({"T": "tval", "Y": "yval", "A3": "a3val"})
+
+    def tearDown(self):
+        SingletonMeta._instances.pop(YfData, None)
+
+    def test_logged_in_switch_keeps_login_cookies(self):
+        self.data._logged_in = True
+        self.data._set_cookie_strategy('basic')  # csrf->basic == the clearing branch
+        self.assertEqual(self.data._session.cookies.get("T"), "tval")
+        self.assertEqual(self.data._session.cookies.get("Y"), "yval")
+
+    def test_logged_out_switch_still_clears_jar(self):
+        # Not logged in: the toggle clears as before, so a bad/anonymous session
+        # can recover a fresh anonymous cookie.
+        self.data._logged_in = False
+        self.data._set_cookie_strategy('basic')
+        self.assertIsNone(self.data._session.cookies.get("T"))
+        self.assertIsNone(self.data._session.cookies.get("Y"))
+
+    def test_switch_resets_crumb_even_when_logged_in(self):
+        # The anonymous cookie/crumb refresh path must stay intact.
+        self.data._logged_in = True
+        self.data._crumb = "stale-crumb"
+        self.data._set_cookie_strategy('basic')
+        self.assertIsNone(self.data._crumb)
+
+    def test_set_login_cookies_marks_logged_in(self):
+        self.data._logged_in = False
+        self.data.set_login_cookies("T-v", "Y-v")
+        self.assertTrue(self.data._logged_in)
+
+    def test_optimistic_login_survives_strategy_toggle(self):
+        # set_login_cookies marks _logged_in True optimistically; a strategy
+        # toggle that fires before check_login confirms (e.g. the subscriptions
+        # request itself 4xx-ing) must still keep the freshly-set T/Y.
+        self.data._session.cookies.clear()
+        self.data.set_login_cookies("T-opt", "Y-opt")  # -> _logged_in = True
+        self.data._cookie_strategy = 'csrf'
+        self.data._set_cookie_strategy('basic')
+        self.assertEqual(self.data._session.cookies.get("T"), "T-opt")
+        self.assertEqual(self.data._session.cookies.get("Y"), "Y-opt")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -80,6 +80,11 @@ class YfData(metaclass=SingletonMeta):
     def __init__(self, session=None):
         self._crumb = None
         self._cookie = None
+        # Whether the user has supplied login cookies (see set_login_cookies).
+        # When logged in, the cookie-strategy toggle must not wipe the jar, or
+        # it would silently log the user out. Auth corrects this flag to reflect
+        # the real login state once it has been verified.
+        self._logged_in = False
 
         # Default to using 'basic' strategy
         self._cookie_strategy = 'basic'
@@ -98,11 +103,23 @@ class YfData(metaclass=SingletonMeta):
                 "Y": cookie_y
             })
             self._cookie = True
+            # Optimistically mark as logged in so a transient 4xx during the
+            # initial login verification can't wipe these cookies. Auth.check_login
+            # corrects this to the real state right after.
+            self._logged_in = True
             # Drop any cached crumb: it may have been minted under a different
             # (e.g. anonymous, or another account's) login state. Forcing a
             # re-mint on the next request keeps the crumb matched to these
             # cookies, so the login takes effect cleanly mid-process.
             self._crumb = None
+
+    def _set_logged_in(self, value):
+        """Thread-safe update of the login flag (also read under this lock in
+        _set_cookie_strategy). Auth calls this after verifying the real login
+        state, possibly from another thread, so the write must be serialized to
+        avoid a stale value clobbering a concurrent fresh login."""
+        with self._cookie_lock:
+            self._logged_in = value
 
     def _set_session(self, session):
         if session is None:
@@ -139,7 +156,12 @@ class YfData(metaclass=SingletonMeta):
         try:
             if self._cookie_strategy == 'csrf':
                 utils.get_yf_logger().debug(f'toggling cookie strategy {self._cookie_strategy} -> basic')
-                self._session.cookies.clear()
+                # Don't clear the jar while logged in: that would drop the
+                # user-set login cookies (T/Y) and silently log them out. The
+                # toggle still resets the anonymous cookie/crumb below, so the
+                # anonymous refresh path is unaffected.
+                if not self._logged_in:
+                    self._session.cookies.clear()
                 self._cookie_strategy = 'basic'
             else:
                 utils.get_yf_logger().debug(f'toggling cookie strategy {self._cookie_strategy} -> csrf')
@@ -621,20 +643,31 @@ class Auth:
         """
         try:
             response = self._data.get(_SUBSCRIPTIONS_URL)
-            if response.status_code != 200:
-                return None
-            result = (response.json() or {}).get("result")
-            if isinstance(result, dict) and result.get("guid"):
-                return result
+            if response.status_code == 200:
+                result = (response.json() or {}).get("result")
+                if isinstance(result, dict) and result.get("guid"):
+                    # Confirmed logged in: keep the login cookies protected.
+                    self._data._set_logged_in(True)
+                    return result
+            # A definitive non-logged-in answer (e.g. 401/403, or 200 without a
+            # guid): let the cookie-strategy toggle clear the stale jar again.
+            self._data._set_logged_in(False)
             return None
         except Exception as e:
+            # Transient/network error can't confirm login state either way, so
+            # leave _logged_in unchanged rather than flipping a valid login off.
             if not YfConfig.debug.hide_exceptions:
                 raise
             utils.get_yf_logger().error(f"Error confirming login: {e}")
             return None
 
     def check_login(self) -> bool:
-        """Check whether the user is logged in to Yahoo Finance."""
+        """Check whether the user is logged in to Yahoo Finance.
+
+        Note: ``False`` during a transient error (e.g. Yahoo briefly
+        unreachable) means "could not confirm" rather than "logged out" — the
+        stored login cookies are kept and remain protected in that case.
+        """
         return self._fetch_entitlement() is not None
 
     def subscription_tier(self) -> str | None:


### PR DESCRIPTION
The <code> csrf -> basic </code> strategy toggle cleared the whole cookie jar, dropping the user-set T/Y login cookies and silently logging out a valid session on roughly every other >=400 response (This is the pre-existing issue found while working on #2845 ). Gate the clear on a <code> _logged_in </code> flag (set optimistically by <code>set_login_cookies</code>, reconciled by Auth after verifying login state), the anonymous cookie/crumb refresh path is unaffected. 