### PR TITLE
Fix 404 Developer Guide link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,4 +57,4 @@ Tests have been written using the built-in Python module `unittest`. Examples:
 
 https://ranaroussi.github.io/yfinance/development/testing.html
 
-> See the [Developer Guide](https://ranaroussi.github.io/yfinance/development/contributing.html#GIT-STUFF) for more information.
+> See the [Developer Guide](https://ranaroussi.github.io/yfinance/development/code.html#git-stuff) for more information.


### PR DESCRIPTION
Fixes #2787

The closing line of `CONTRIBUTING.md` linked to `development/contributing.html#GIT-STUFF`, which returns **404** — `contributing.html` no longer exists (the dev docs were restructured, see #2659) and the git section now lives at `development/code.html#git-stuff`.

The same link earlier in the file (the `git rebase` bullet) already uses `development/code.html#git-stuff`, so this just aligns the closing link with it.

Verified: `development/contributing.html` → 404, `development/code.html` → 200, and the `#git-stuff` anchor exists on that page.

Scope is intentionally limited to the one broken link (the other doc links in the file resolve fine).
