### PR TITLE
Normalize configured proxy strings

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,8 +2,26 @@
 import unittest
 from functools import lru_cache
 
-from yfinance.data import SingletonMeta, YfData, lru_cache_freezeargs
+from yfinance.data import SingletonMeta, YfData, _normalize_proxy, lru_cache_freezeargs
 from yfinance.utils import frozendict
+
+
+class TestProxyConfig(unittest.TestCase):
+    def test_proxy_string_applies_to_http_and_https(self):
+        proxy = "http://user:pass@example.com:8080"
+
+        self.assertEqual(
+            _normalize_proxy(proxy),
+            {"http": proxy, "https": proxy},
+        )
+
+    def test_proxy_mapping_is_preserved(self):
+        proxy = {"http": "http://proxy:8080", "https": "https://proxy:8443"}
+
+        self.assertIs(_normalize_proxy(proxy), proxy)
+
+    def test_proxy_none_is_preserved(self):
+        self.assertIsNone(_normalize_proxy(None))
 
 
 class TestFrozenDict(unittest.TestCase):

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -30,6 +30,12 @@ def _is_transient_error(exception):
 cache_maxsize = 64
 
 
+def _normalize_proxy(proxy):
+    if isinstance(proxy, str):
+        return {"http": proxy, "https": proxy}
+    return proxy
+
+
 def lru_cache_freezeargs(func):
     """
     Decorator transforms mutable dictionary and list arguments into immutable types
@@ -145,7 +151,7 @@ class YfData(metaclass=SingletonMeta):
         with self._cookie_lock:
             self._session = session
             if YfConfig.network.proxy is not None:
-                self._session.proxies = YfConfig.network.proxy
+                self._session.proxies = _normalize_proxy(YfConfig.network.proxy)
 
     def _set_cookie_strategy(self, strategy, have_lock=False):
         if strategy == self._cookie_strategy:
@@ -434,7 +440,7 @@ class YfData(metaclass=SingletonMeta):
         utils.get_yf_logger().debug(f'params={params}')
 
         # sync with config
-        self._session.proxies = YfConfig.network.proxy
+        self._session.proxies = _normalize_proxy(YfConfig.network.proxy)
 
         if params is None:
             params = {}


### PR DESCRIPTION
## Summary
- normalize string values assigned to `YfConfig.network.proxy` into an `http`/`https` proxy mapping before applying them to the session
- keep existing mapping, `ProxySpec`, and `None` proxy values unchanged
- add regression coverage for proxy normalization

Closes #2729.

## Validation
- `python -m pytest tests\test_data.py tests\test_http.py -q`
- `git diff --check`
- manual proxy smoke test with a local HTTP CONNECT forwarding proxy: `yf.config.network.proxy = "http://127.0.0.1:<port>"`; `yf.Ticker("AAPL").history(period="1d")` returned 1 row and the proxy observed CONNECTs to `fc.yahoo.com:443`, `query1.finance.yahoo.com:443`, and `query2.finance.yahoo.com:443`