### PR TITLE
ci: re-enable pytest, splitting offline tests from live ones

### DIFF
--- a/.github/workflows/pytest-network.yml
+++ b/.github/workflows/pytest-network.yml
@@ -1,22 +1,24 @@
-name: Pytest
+name: Pytest (live)
 
 on:
-  pull_request:
-    branches:
-      - master
-      - main
-      - dev
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
+  network:
+    # Live tests against Yahoo. Flaky by nature, so scheduled-only (off PRs).
     runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: "3.12"
         cache: 'pip'
@@ -27,7 +29,7 @@ jobs:
         pip install -r requirements.txt pytest
 
     - name: Run non-cache tests
-      run: pytest tests/ --ignore tests/test_cache.py --ignore tests/test_price_repair.py
+      run: pytest -m network --ignore tests/test_cache.py --ignore tests/test_price_repair.py
 
     - name: Run cache tests
       run: |

--- a/.github/workflows/pytest-network.yml
+++ b/.github/workflows/pytest-network.yml
@@ -1,16 +1,20 @@
-name: Pytest
+name: Pytest (live)
 
 on:
-  pull_request:
-    branches:
-      - master
-      - main
-      - dev
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
-  test:
+  network:
+    # Live tests against Yahoo. Flaky by nature, so scheduled-only (off PRs).
     runs-on: ubuntu-latest
     strategy:
+      # One flaky version must not cancel the others.
+      fail-fast: false
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
@@ -36,7 +40,22 @@ jobs:
       run: uv venv
 
     - name: Install dependencies
-      run: uv pip install -e ".[dev]"
+      # repair extra: some live tests exercise the scipy/sklearn repair path.
+      run: uv pip install -e ".[dev,repair]"
 
-    - name: Run tests
-      run: uv run pytest tests/ -x -q --tb=short --ignore=tests/test_price_repair.py
+    - name: Run non-cache tests
+      # Cache tests need their own process: they mutate global cache state.
+      run: >
+        uv run pytest -m network
+        --ignore tests/test_cache.py
+        --ignore tests/test_cache_noperms.py
+        --ignore tests/test_price_repair.py
+
+    - name: Run cache tests
+      run: |
+        uv run pytest -m network tests/test_cache.py
+        uv run pytest -m network tests/test_cache_noperms.py
+
+    - name: Run price repair tests
+      # Kept separate: the noisiest live tests, so they don't mask the rest.
+      run: uv run pytest -m network tests/test_price_repair.py

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,33 @@
+name: Pytest
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  offline:
+    # Deterministic tests with no Yahoo access.
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Set up Python
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      with:
+        python-version: "3.12"
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt pytest
+
+    - name: Run offline tests
+      run: pytest -m "not network"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,42 @@
+name: Pytest
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  offline:
+    # Deterministic tests with no Yahoo access.
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      # Verify: curl -s "https://api.github.com/repos/actions/checkout/commits?sha=v7&until=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')&per_page=1" | jq -r '.[0].sha'
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+
+    - name: Install uv
+      # Verify: curl -s "https://api.github.com/repos/astral-sh/setup-uv/commits?sha=v9.0.0&until=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')&per_page=1" | jq -r '.[0].sha'
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      with:
+        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "pyproject.toml"
+
+    - name: Set up Python
+      run: uv python install 3.12
+
+    - name: Create virtual environment
+      run: uv venv
+
+    - name: Install dependencies
+      run: uv pip install -e ".[dev]"
+
+    - name: Run offline tests
+      run: uv run pytest -m "not network"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ yfinance = ["pricing.proto", "pricing_pb2.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "network: requires live Yahoo Finance network access",
+]
 
 [tool.setuptools]
 include-package-data = true

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+testpaths = tests
+markers =
+    network: requires live Yahoo Finance network access

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+# Live tests import tests.context; the rest are offline unit tests. Auto-mark
+# the live ones so PR CI can run `-m "not network"`.
+_OFFLINE_MODULES = {
+    "test_auth", "test_data", "test_http",
+    "test_live", "test_screener", "test_utils",
+}
+
+
+def pytest_collection_modifyitems(config, items):
+    for item in items:
+        module = item.module.__name__.rsplit(".", 1)[-1]
+        if module not in _OFFLINE_MODULES:
+            item.add_marker(pytest.mark.network)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+# Live tests import tests.context; the rest are offline unit tests. Auto-mark
+# the live ones so PR CI can run `-m "not network"`. New modules default to
+# offline, so they gate PRs instead of silently landing in the weekly job.
+_NETWORK_MODULES = {
+    "test_cache", "test_cache_noperms", "test_calendars",
+    "test_download_concurrency", "test_lookup", "test_market",
+    "test_multi", "test_price_repair", "test_prices", "test_search",
+    "test_sector_region", "test_ticker", "test_ticker_locale",
+}
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        module = getattr(item, "module", None)
+        if module is not None and module.__name__.rsplit(".", 1)[-1] in _NETWORK_MODULES:
+            item.add_marker(pytest.mark.network)

--- a/tests/context.py
+++ b/tests/context.py
@@ -5,8 +5,12 @@ import datetime as _dt
 import sys
 import os
 import yfinance
+from yfinance.config import YfConfig
 # from requests_ratelimiter import LimiterSession
 # from pyrate_limiter import Duration, RequestRate, Limiter
+
+# Retry throttled/empty responses from Yahoo on CI IPs.
+YfConfig.network.retries = 2
 
 _parent_dp = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 _src_dp = _parent_dp

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -27,6 +27,11 @@ def _is_transient_error(exception):
     }
     return error_type_name in transient_error_types
 
+
+def _is_empty_response(response):
+    """Empty 2xx body (Yahoo throttling); retryable."""
+    return response.status_code < 400 and not response.content
+
 cache_maxsize = 64
 
 
@@ -463,6 +468,9 @@ class YfData(metaclass=SingletonMeta):
         for attempt in range(YfConfig.network.retries + 1):
             try:
                 response = request_method(**request_args)
+                if _is_empty_response(response) and attempt < YfConfig.network.retries:
+                    _time.sleep(2 ** attempt)
+                    continue
                 break
             except Exception as e:
                 if _is_transient_error(e) and attempt < YfConfig.network.retries:

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -27,6 +27,12 @@ def _is_transient_error(exception):
     }
     return error_type_name in transient_error_types
 
+
+def _is_empty_response(response):
+    """Empty 200 body (Yahoo throttling); retryable."""
+    return response.status_code == 200 and not response.content
+
+
 cache_maxsize = 64
 
 
@@ -448,6 +454,9 @@ class YfData(metaclass=SingletonMeta):
         for attempt in range(YfConfig.network.retries + 1):
             try:
                 response = request_method(**request_args)
+                if _is_empty_response(response) and attempt < YfConfig.network.retries:
+                    _time.sleep(2 ** attempt)
+                    continue
                 break
             except Exception as e:
                 if _is_transient_error(e) and attempt < YfConfig.network.retries:


### PR DESCRIPTION
The pytest workflow was disabled because almost every test fetches from Yahoo and live fetches fail intermittently on CI IPs (`JSONDecodeError` on empty/throttled bodies). But 69 of 255 tests are offline unit tests that never touch the network: `tests/conftest.py` now marks the live ones `network`, so PRs run `pytest -m "not network"` (fast, deterministic) while the live suite moves to a scheduled job (`pytest-network.yml`, plus `workflow_dispatch`). `data.py` additionally retries empty 200 bodies (the throttling failure mode) under the existing `retries` config, which `tests/context.py` enables for the test run.

Rebased onto current `dev`: the live job keeps the uv setup and the version matrix from the disabled workflow, and the cache and price-repair tests each get their own step so their global state and their flakiness stay isolated. The `network` marker is registered in `pyproject.toml` next to `testpaths`.

Worth flagging: the inherited matrix includes 3.6-3.9, where `uv python install` has no builds for 3.6/3.7 and `pytest>=9.0.3` from the `dev` extra needs 3.10+. Those legs will fail regardless of this PR; `fail-fast: false` keeps the others running.

Closes #2261
