### PR TITLE
Complementary info: guard against empty or malformed timeseries

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1085,6 +1085,45 @@ class TestTickerInfo(unittest.TestCase):
         data2 = self.tickers[2].info
         self.assertIsInstance(data2['trailingPegRatio'], float)
 
+    def test_complementary_info_sparse_timeseries(self):
+        # Yahoo sometimes returns the requested complementary key with an
+        # empty list, or a final entry missing 'reportedValue'/'raw'. The
+        # previous code did keydict[k][-1]["reportedValue"]["raw"]
+        # unconditionally, raising IndexError/KeyError and breaking .info
+        # for the whole ticker. It should degrade to None instead, matching
+        # the commented reference logic above the live code.
+        from yfinance.scrapers.quote import Quote
+
+        degrade_to_none = [
+            # key present but empty list -> would raise IndexError
+            '{"timeseries": {"error": null, "result": [{"trailingPegRatio": []}]}}',
+            # last entry missing 'reportedValue' -> would raise KeyError
+            '{"timeseries": {"error": null, "result": [{"trailingPegRatio": [{}]}]}}',
+            # 'reportedValue' present but missing 'raw' -> would raise KeyError
+            '{"timeseries": {"error": null, "result": [{"trailingPegRatio": [{"reportedValue": {}}]}]}}',
+            # key absent entirely -> existing else-branch
+            '{"timeseries": {"error": null, "result": [{}]}}',
+        ]
+        for payload in degrade_to_none:
+            data = MagicMock()
+            data.cache_get.return_value.text = payload
+            q = Quote(data, "TEST")
+            q._info = {}
+            with patch.object(Quote, "_fetch_info", return_value=None):
+                q._fetch_complementary()
+            self.assertIsNone(q._info["trailingPegRatio"],
+                              f"Expected None for payload: {payload}")
+
+        # Happy path still extracts the raw value
+        payload = '{"timeseries": {"error": null, "result": [{"trailingPegRatio": [{"reportedValue": {"raw": 1.23}}]}]}}'
+        data = MagicMock()
+        data.cache_get.return_value.text = payload
+        q = Quote(data, "TEST")
+        q._info = {}
+        with patch.object(Quote, "_fetch_info", return_value=None):
+            q._fetch_complementary()
+        self.assertEqual(q._info["trailingPegRatio"], 1.23)
+
     def test_isin_info(self):
         isin_list = {"ES0137650018": True,
                      "does_not_exist": True,  # Nonexistent but doesn't raise an error

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -754,10 +754,10 @@ class Quote:
                 raise YFException("Failed to parse json response from Yahoo Finance: " + str(json_result["error"]))
             for k in keys:
                 keydict = json_result["result"][0]
-                if k in keydict:
-                    self._info[k] = keydict[k][-1]["reportedValue"]["raw"]
+                if k in keydict and keydict[k]:
+                    self._info[k] = keydict[k][-1].get("reportedValue", {}).get("raw")
                 else:
-                    self.info[k] = None
+                    self._info[k] = None
 
     def _fetch_calendar(self):
         # secFilings return too old data, so not requesting it for now


### PR DESCRIPTION
### Summary

`Quote._fetch_complementary` parses Yahoo's fundamentals-timeseries response with `keydict[k][-1]["reportedValue"]["raw"]` and no guard on the value:

```python
if k in keydict:
    self._info[k] = keydict[k][-1]["reportedValue"]["raw"]
else:
    self.info[k] = None
```

When Yahoo returns the requested key but with an empty list, the `[-1]` raises `IndexError`. When the last entry is missing `reportedValue` or `raw`, it raises `KeyError`. This path fetches `trailingPegRatio` behind `Ticker.info`, so a single sparse symbol breaks `.info` entirely for that ticker.

This restores the empty/missing handling the original author already documented in the commented-out reference block directly above the live code (which checks `len(key_stats[k]) == 0` and falls back to `None`):

```python
if k in keydict and keydict[k]:
    self._info[k] = keydict[k][-1].get("reportedValue", {}).get("raw")
else:
    self._info[k] = None
```

`.get()` makes a malformed last entry degrade to `None` instead of raising. The else branch also had a latent typo (`self.info` instead of `self._info`); it is harmless today because the `info` property returns the same backing dict, but it should write the field directly.

This mirrors the earlier hardening in commit `06fd351` ("Fix JSON access to prevent KeyError"), which guarded the outer `json_data` access on these exact lines but left the inner value chain unguarded.

### Testing

Added `tests/test_ticker.py::TestTickerInfo::test_complementary_info_sparse_timeseries`, a mock-based unit test (no network) covering empty list, missing `reportedValue`, missing `raw`, absent key, and the happy path. Confirmed it fails on the old code (`IndexError: list index out of range`) and passes with the fix.

- `python -m unittest tests.test_ticker.TestTickerInfo.test_complementary_info_sparse_timeseries` -> OK
- `python -m pytest "tests/test_ticker.py::TestTickerInfo::test_complementary_info_sparse_timeseries"` -> 1 passed
- `ruff check yfinance/scrapers/quote.py tests/test_ticker.py` -> All checks passed
- `git diff --check` -> clean
- `python -m py_compile yfinance/scrapers/quote.py tests/test_ticker.py` -> ok