### PR TITLE
Fix capital gains parsing when events include a currency field

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 import unittest
 
-from yfinance.utils import is_valid_period_format, _dts_in_same_interval, _parse_user_dt
+from yfinance.utils import is_valid_period_format, _dts_in_same_interval, _parse_user_dt, parse_actions
 
 
 class TestPandas(unittest.TestCase):
@@ -59,6 +59,26 @@ class TestUtils(unittest.TestCase):
         self.assertFalse(is_valid_period_format(None))    # None input
         self.assertFalse(is_valid_period_format("0d"))    # Zero is invalid
         self.assertTrue(is_valid_period_format("999mo"))  # Large number valid
+
+
+class TestParseActions(unittest.TestCase):
+    def test_capital_gains_with_currency_field(self):
+        # Yahoo returns capital-gains events with the same shape as dividends,
+        # i.e. {date, amount, currency} (funds/ETFs). The currency column has to
+        # be handled the same way dividends already are; otherwise the positional
+        # `capital_gains.columns = ["Capital Gains"]` assignment raises
+        # "Length mismatch" on the extra column and crashes Ticker.history().
+        data = {
+            "events": {
+                "capitalGains": {
+                    "1577854800": {"date": 1577854800, "amount": 1.5, "currency": ""},
+                    "1609477200": {"date": 1609477200, "amount": 2.0, "currency": ""},
+                }
+            }
+        }
+        _dividends, _splits, capital_gains = parse_actions(data)
+        self.assertEqual(list(capital_gains.columns), ["Capital Gains"])
+        self.assertEqual(capital_gains["Capital Gains"].tolist(), [1.5, 2.0])
 
 
 class TestDateIntervalCheck(unittest.TestCase):

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -584,7 +584,10 @@ def parse_actions(data):
             capital_gains.set_index("date", inplace=True)
             capital_gains.index = _pd.to_datetime(capital_gains.index, unit="s")
             capital_gains.sort_index(inplace=True)
-            capital_gains.columns = ["Capital Gains"]
+            if 'currency' in capital_gains.columns and (capital_gains['currency'] == '').all():
+                # Currency column useless, drop it.
+                capital_gains = capital_gains.drop('currency', axis=1)
+            capital_gains = capital_gains.rename(columns={'amount': 'Capital Gains'})
 
         if "splits" in data["events"] and len(data["events"]['splits']) > 0:
             splits = _pd.DataFrame(


### PR DESCRIPTION
### Problem

`Ticker.history()` raises `ValueError: Length mismatch: Expected axis has 2 elements, new values have 1 elements` for funds/ETFs whose chart data carries capital-gains events with a `currency` field.

Yahoo returns capital-gains events with the same shape as dividends, i.e. `{date, amount, currency}`. In `parse_actions()` the dividends branch already handles that extra `currency` column, but the capital-gains branch assigns column names positionally:

```python
capital_gains.columns = ["Capital Gains"]
```

When `currency` is present the frame has two columns (`amount`, `currency`), so a single-element assignment blows up. The crash happens inside `parse_actions()` (called from `PriceHistory._get_price_history()`) before the `expect_capital_gains` check, so it takes down the whole `history()` call.

### Fix

Mirror what the dividends branch right above already does: drop the `currency` column when it is empty, then rename `amount` by name instead of assigning positionally.

```python
if 'currency' in capital_gains.columns and (capital_gains['currency'] == '').all():
    capital_gains = capital_gains.drop('currency', axis=1)
capital_gains = capital_gains.rename(columns={'amount': 'Capital Gains'})
```

Downstream reads `capital_gains['Capital Gains']` by name, so the result is unchanged for the normal single-column case and no longer crashes when `currency` shows up.

### Test

Added `TestParseActions.test_capital_gains_with_currency_field` in `tests/test_utils.py`, which feeds a `capitalGains` event dict containing `currency` and asserts the parsed column. It fails on `dev` with the `Length mismatch` ValueError and passes with this change. Full `tests/test_utils.py` is green (21 passed, 1 xfailed), no network needed.
