### PR TITLE
Fix _fetch_info handling of None responses

### DIFF
--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -681,18 +681,21 @@ class Quote:
         modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
         result = self._fetch(modules=modules)
         additional_info = self._fetch_additional_info()
-        if additional_info is not None and result is not None:
+
+        if result is None:
+            result = {}
+
+        if additional_info is not None:
             result.update(additional_info)
-        else:
-            result = additional_info
 
         query1_info = {}
         for quote in ["quoteSummary", "quoteResponse"]:
-            if quote in result and len(result[quote]["result"]) > 0:
-                result[quote]["result"][0]["symbol"] = self._symbol
+            quote_result = result.get(quote, {}).get("result", [])
+
+            if len(quote_result) > 0:
+                quote_result[0]["symbol"] = self._symbol
                 query_info = next(
-                    (info for info in result.get(quote, {}).get("result", [])
-                    if info["symbol"] == self._symbol),
+                    (info for info in quote_result if info.get("symbol") == self._symbol),
                     None,
                 )
                 if query_info:


### PR DESCRIPTION
### Summary

Fixes a `TypeError` in `_fetch_info()` when Yahoo returns `None` from one or both internal fetch calls.

Previously, `_fetch_info()` used this merge logic:

```python
if additional_info is not None and result is not None:
    result.update(additional_info)
else:
    result = additional_info
```

This could cause two problems:

1. If both `_fetch()` and `_fetch_additional_info()` returned `None`, then `result` remained `None`.
2. If `_fetch()` returned valid data but `_fetch_additional_info()` returned `None`, the valid `result` could be overwritten with `None`.

Later, `_fetch_info()` performed:

```python
if quote in result and len(result[quote]["result"]) > 0:
```

When `result is None`, this raises:

```text
TypeError: argument of type 'NoneType' is not a container or iterable
```

### Fix

This PR normalizes `result` to an empty dictionary when `_fetch()` returns `None`:

```python
if result is None:
    result = {}
```

It also only merges `additional_info` when it is not `None`:

```python
if additional_info is not None:
    result.update(additional_info)
```

Additionally, the quote parsing logic now avoids direct indexing into `result[quote]["result"]` and instead uses safe `.get()` access:

```python
quote_result = result.get(quote, {}).get("result", [])
```

This prevents crashes when Yahoo returns an empty, blocked, or otherwise incomplete response.

### Testing

Verified normal behavior still works:

```bash
python -c "import yfinance as yf; print(yf.Ticker('NPCE').info.get('symbol'))"
```

Output:

```text
NPCE
```

Also tested the `None` response path by monkeypatching both internal fetch methods to return `None`:

```python
import yfinance as yf
from curl_cffi import requests as curlRequests

session = curlRequests.Session(impersonate="chrome")
ticker = yf.Ticker("NPCE", session=session)

ticker._quote._fetch = lambda modules: None
ticker._quote._fetch_additional_info = lambda: None

print(ticker.info)
```

Before this fix, this path crashed with:

```text
TypeError: argument of type 'NoneType' is not a container or iterable
```

After this fix, it no longer crashes.
