### PR TITLE
Document `back_adjust` and `progress` parameters in `download()`

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -84,6 +84,8 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             Default is False
         auto_adjust: bool
             Adjust all OHLC automatically? Default is True
+        back_adjust: bool
+            Back-adjust data to mimic true historical prices? Default is False
         repair: bool
             Detect currency unit 100x mixups and attempt repair
             Default is False
@@ -94,6 +96,8 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
             Download dividend + stock splits data. Default is False
         threads: bool / int
             How many threads to use for mass downloading. Default is True
+        progress: bool
+            Show progress bar during download? Default is True
         ignore_tz: bool
             When combining from different timezones, ignore that part of datetime.
             Default depends on interval. Intraday = False. Day+ = True.


### PR DESCRIPTION
## Summary

The `download()` docstring documents every keyword argument except two that are part of its public signature:

- `back_adjust` (defaults to `False`)
- `progress` (defaults to `True`)

Since the docs site is generated from these docstrings, both parameters are currently missing from the published API reference for `yf.download()`, even though users can and do pass them.

This PR adds entries for both, following the existing format and placement (`back_adjust` next to its sibling `auto_adjust`, `progress` alongside the other download-behaviour flags).

## Changes

- `yfinance/multi.py`: document `back_adjust` and `progress` in `download()`.

Docs-only change — no functional impact.