### PR TITLE
Fix TypeError in Quote._fetch_info when Yahoo returns no data (#2865)

### DIFF
--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,50 @@
+"""
+Unit tests for yfinance.scrapers.quote.Quote.
+
+These are offline tests (the network fetches are mocked), covering the
+no-data / partial-data paths of ``_fetch_info`` — see issue #2865.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from yfinance.scrapers.quote import Quote
+
+
+class TestQuoteFetchInfo(unittest.TestCase):
+    def _make_quote(self):
+        # _data is only used by the (mocked) fetch helpers, so a stub is fine.
+        return Quote(MagicMock(), "TEST")
+
+    def test_no_crash_when_both_fetches_return_none(self):
+        """Both Yahoo endpoints empty must not raise TypeError (#2865)."""
+        q = self._make_quote()
+        with patch.object(q, "_fetch", return_value=None), \
+             patch.object(q, "_fetch_additional_info", return_value=None):
+            q._fetch_info()  # previously: "argument of type 'NoneType' is not ..."
+        self.assertIsNone(q._info)
+
+    def test_valid_result_kept_when_additional_info_is_none(self):
+        """A valid primary result must not be discarded when there's no
+        additional info (the old ``else`` branch nulled it)."""
+        q = self._make_quote()
+        valid = {"quoteSummary": {"result": [{"symbol": "TEST", "shortName": "Test Co"}]}}
+        with patch.object(q, "_fetch", return_value=valid), \
+             patch.object(q, "_fetch_additional_info", return_value=None):
+            q._fetch_info()
+        self.assertIsNotNone(q._info)
+        self.assertEqual(q._info.get("shortName"), "Test Co")
+
+    def test_additional_info_used_when_primary_is_none(self):
+        """When only the additional-info endpoint responds, it is used."""
+        q = self._make_quote()
+        extra = {"quoteResponse": {"result": [{"symbol": "TEST", "longName": "Test Co"}]}}
+        with patch.object(q, "_fetch", return_value=None), \
+             patch.object(q, "_fetch_additional_info", return_value=extra):
+            q._fetch_info()
+        self.assertIsNotNone(q._info)
+        self.assertEqual(q._info.get("longName"), "Test Co")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -619,10 +619,19 @@ class Quote:
         modules = ['financialData', 'quoteType', 'defaultKeyStatistics', 'assetProfile', 'summaryDetail']
         result = self._fetch(modules=modules)
         additional_info = self._fetch_additional_info()
-        if additional_info is not None and result is not None:
-            result.update(additional_info)
-        else:
+        if result is None:
             result = additional_info
+        elif additional_info is not None:
+            result.update(additional_info)
+        # else: `result` is valid and there's no additional info to merge — keep it.
+
+        if result is None:
+            # Both Yahoo endpoints returned no data (e.g. an empty or blocked
+            # payload via a proxy/session). Leave info unset rather than raising
+            # "argument of type 'NoneType' is not ..." on the membership test
+            # below; callers already handle a missing `_info` (see the `info`
+            # property and `_fetch_complementary`).
+            return
 
         query1_info = {}
         for quote in ["quoteSummary", "quoteResponse"]:


### PR DESCRIPTION
### Summary

`Quote._fetch_info()` raises `TypeError: argument of type 'NoneType' is not iterable` when **both** `_fetch()` and `_fetch_additional_info()` return `None` — e.g. when Yahoo returns an empty/blocked payload through a proxy session (reported in #2865). The membership test `if quote in result` then runs on `None`.

While fixing this I noticed the same merge block also **silently discarded a valid primary result** whenever the additional-info fetch returned `None`: the old `else` branch set `result = additional_info` (`None`), throwing away good data.

### Changes

- Restructure the merge so a valid `result` is preserved when there's no additional info, and `additional_info` is used as a fallback when `result` is missing.
- Return early (leaving `_info` unset, which the `info` property and `_fetch_complementary` already handle) when **both** fetches yield no data, instead of crashing on the membership test below. This matches the `if result is None: return` guard used elsewhere in the file.
- Add offline regression tests (`tests/test_quote.py`) covering all three branches (both-None, valid-result-only, additional-only).

### Testing

```
pytest tests/test_quote.py   # 3 passed (network mocked)
```

Fixes #2865.

_Note: #2701 attempted the crash fix but has been conflicting/stale for ~2 months and has no test. This PR is rebased on current `main`, additionally fixes the data-loss path, and adds regression coverage. Happy to coordinate with the original author if preferred._
