### PR TITLE
fix: add missing @property to FundsData.quote_type

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1402,6 +1402,16 @@ class TestTickerFundsData(unittest.TestCase):
             ticker = yf.Ticker("AAPL", session=self.session) # stock, not funds
             ticker.funds_data._fetch_and_parse()
 
+    def test_quote_type_is_property(self):
+        # quote_type was the only FundsData accessor missing @property, so
+        # `funds_data.quote_type` returned the bound method instead of the
+        # parsed string. Pre-set the cache to keep this offline/deterministic.
+        from yfinance.scrapers.funds import FundsData
+        funds = FundsData(MagicMock(), "TEST")
+        funds._quote_type = "ETF"
+        self.assertIsInstance(funds.quote_type, str)
+        self.assertEqual(funds.quote_type, "ETF")
+
     def test_description(self):
         for ticker in self.test_tickers:
             description = ticker.funds_data.description

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -44,6 +44,7 @@ class FundsData:
         self._bond_ratings = None
         self._sector_weightings = None
 
+    @property
     def quote_type(self) -> str:
         """
         Returns the quote type of the fund.


### PR DESCRIPTION
### Problem

`FundsData.quote_type` is the only accessor on the class that isn't a `@property`. Every sibling (`description`, `fund_overview`, `fund_operations`, `asset_classes`, `top_holdings`, `equity_holdings`, `bond_holdings`, `bond_ratings`, `sector_weightings`) is decorated, but `quote_type` was left as a plain method.

Because of that, the documented attribute access returns the bound method object rather than the parsed string:

```python
import yfinance as yf

fd = yf.Ticker("SPY").funds_data
fd.description   # 'SPDR S&P 500 ETF Trust ...'   -> str
fd.quote_type    # <bound method FundsData.quote_type ...>  -> not the value
fd.quote_type()  # 'ETF'   (have to call it, unlike every sibling)
```

So `quote_type` is both inconsistent with the rest of the API and doesn't match the docstring, which says it returns the quote type string.

### Fix

Add the missing `@property` decorator. One line in `yfinance/scrapers/funds.py`.

### Test

Added `TestTickerFundsData.test_quote_type_is_property`. It pre-seeds the cache so it stays offline/deterministic (no Yahoo call) and asserts `quote_type` resolves to the string. It fails on `dev` before the fix:

```
AssertionError: <bound method FundsData.quote_type ...> is not an instance of <class 'str'>
```

and passes after.
