### PR TITLE
fix(funds): log raw response instead of unbound `data` in FundsData error handler

### DIFF
--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -1,0 +1,37 @@
+"""Tests for yfinance.scrapers.funds error handling."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from yfinance.config import YfConfig
+from yfinance.scrapers.funds import FundsData
+
+
+class TestFundsDataErrorHandling(unittest.TestCase):
+    def setUp(self):
+        self._orig_hide = YfConfig.debug.hide_exceptions
+        YfConfig.debug.hide_exceptions = True
+
+    def tearDown(self):
+        YfConfig.debug.hide_exceptions = self._orig_hide
+
+    def test_no_fund_data_does_not_raise_unbound_local(self):
+        # Yahoo's quoteSummary endpoint returns {"quoteSummary": {"result": None}}
+        # for symbols that carry no fund data (e.g. a plain equity ticker).
+        # Indexing result["quoteSummary"]["result"][0] then raises TypeError,
+        # not KeyError, so it lands in the broad `except Exception` handler.
+        # That handler logged `data`, a name that is never bound when the
+        # indexing itself fails, so it raised UnboundLocalError and masked the
+        # original error instead of logging the response.
+        fd = FundsData(MagicMock(), "AAPL")
+        no_fund_response = {"quoteSummary": {"result": None}}
+
+        with patch.object(fd, "_fetch", return_value=no_fund_response):
+            # Should swallow-and-log the parse failure, never leak
+            # UnboundLocalError out of the error handler.
+            fd._fetch_and_parse()
+
+        self.assertIsNone(fd._quote_type)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/scrapers/funds.py
+++ b/yfinance/scrapers/funds.py
@@ -200,7 +200,7 @@ class FundsData:
             logger.error(f"Failed to get fund data for '{self._symbol}' reason: {e}")
             logger.debug("Got response: ")
             logger.debug("-------------")
-            logger.debug(f" {data}")
+            logger.debug(f" {result}")
             logger.debug("-------------")
 
     @staticmethod


### PR DESCRIPTION
### Bug

`FundsData._fetch_and_parse()` binds `data` inside the `try` block and then logs it from the broad `except Exception` handler:

```python
result = self._fetch()
try:
    data = result["quoteSummary"]["result"][0]
    ...
except Exception as e:
    ...
    logger.debug(f" {data}")   # data may be unbound here
```

When the failure happens on that first statement, `data` is never assigned, so the handler raises `UnboundLocalError` and hides the real error.

This is reachable in normal use, not a malformed-input edge case: for a symbol that has no fund data, Yahoo's quoteSummary endpoint returns `{"quoteSummary": {"result": None, "error": {...}}}`. Then `result["quoteSummary"]["result"]` is `None`, `None[0]` raises `TypeError` (not `KeyError`, so it skips the `except KeyError` branch), and with the default `hide_exceptions=True` the code reaches the `data` log line and blows up with:

```
UnboundLocalError: cannot access local variable 'data' where it is not associated with a value
```

masking the underlying `'NoneType' object is not subscriptable`.

### Fix

Log `result` instead of `data`. `result` is assigned before the `try` block, so it's always bound, and it's the raw response the debug line was meant to show anyway.

### Testing

Added `tests/test_funds.py` reproducing the case (`_fetch` returns a no-data response). It fails on `dev` with `UnboundLocalError` and passes with the fix. Ran locally:

- `pytest tests/test_funds.py` — passes with the fix, fails before it
- `pyright . --level error` — clean
- `ruff check` — clean

(The pytest workflow is currently disabled in CI, so the new test won't run there, but it documents the regression and is ready if pytest is re-enabled.)
