### PR TITLE
Complementary info: guard against empty or missing timeseries result

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1248,6 +1248,46 @@ class TestTickerInfo(unittest.TestCase):
             q._fetch_complementary()
         self.assertEqual(q._info["trailingPegRatio"], 1.23)
 
+    def test_complementary_info_empty_result_timeseries(self):
+        # Companion to test_complementary_info_sparse_timeseries, one level up
+        # the same access chain. Yahoo can return the timeseries envelope with
+        # an empty/missing/null 'result' (or omit 'timeseries'/'finance'
+        # entirely). The previous code read json_result["error"] and
+        # json_result["result"][0] without guarding, raising
+        # TypeError/KeyError/IndexError and breaking .info for the whole
+        # ticker. It should degrade to None instead.
+        from yfinance.scrapers.quote import Quote
+
+        degrade_to_none = [
+            # 'result' is an empty list -> would raise IndexError
+            '{"timeseries": {"error": null, "result": []}}',
+            # 'result' key missing -> would raise KeyError
+            '{"timeseries": {"error": null}}',
+            # 'result' is null -> would raise TypeError
+            '{"timeseries": {"error": null, "result": null}}',
+            # neither 'timeseries' nor 'finance' present -> json_result is None
+            '{}',
+        ]
+        for payload in degrade_to_none:
+            data = MagicMock()
+            data.cache_get.return_value.text = payload
+            q = Quote(data, "TEST")
+            q._info = {}
+            with patch.object(Quote, "_fetch_info", return_value=None):
+                q._fetch_complementary()
+            self.assertIsNone(q._info["trailingPegRatio"],
+                              f"Expected None for payload: {payload}")
+
+        # Happy path still extracts the raw value
+        payload = '{"timeseries": {"error": null, "result": [{"trailingPegRatio": [{"reportedValue": {"raw": 1.23}}]}]}}'
+        data = MagicMock()
+        data.cache_get.return_value.text = payload
+        q = Quote(data, "TEST")
+        q._info = {}
+        with patch.object(Quote, "_fetch_info", return_value=None):
+            q._fetch_complementary()
+        self.assertEqual(q._info["trailingPegRatio"], 1.23)
+
     def test_isin_info(self):
         isin_list = {"ES0137650018": True,
                      "does_not_exist": True,  # Nonexistent but doesn't raise an error

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -872,11 +872,12 @@ class Quote:
 
             json_str = self._data.cache_get(url=url).text
             json_data = json.loads(json_str)
-            json_result = json_data.get("timeseries") or json_data.get("finance")
-            if json_result["error"] is not None:
-                raise YFException("Failed to parse json response from Yahoo Finance: " + str(json_result["error"]))
+            json_result = json_data.get("timeseries") or json_data.get("finance") or {}
+            if json_result.get("error") is not None:
+                raise YFException("Failed to parse json response from Yahoo Finance: " + str(json_result.get("error")))
+            result = json_result.get("result") or []
+            keydict = result[0] if result else {}
             for k in keys:
-                keydict = json_result["result"][0]
                 if k in keydict and keydict[k]:
                     self._info[k] = keydict[k][-1].get("reportedValue", {}).get("raw")
                 else:


### PR DESCRIPTION
## Summary

This is the direct companion to #2863, one level up the same access chain in `Quote._fetch_complementary`.

#2863 hardened the inner value access (`keydict[k][-1].get("reportedValue", {}).get("raw")`), but the outer access on the same lines is still unguarded:

```python
json_result = json_data.get("timeseries") or json_data.get("finance")
if json_result["error"] is not None:        # TypeError if json_result is None
...
    keydict = json_result["result"][0]       # IndexError if result == [],
                                             # KeyError if "result" missing,
                                             # TypeError if result is None
```

When Yahoo returns the timeseries envelope with an empty / missing / null `result` (or omits `timeseries`/`finance` entirely), this raises and breaks `Ticker.info` for the whole symbol, since `_fetch_complementary` populates `trailingPegRatio`.

The sibling `_fetch_valuation_measures` already guards this exact shape (`(data.get("timeseries") or {}).get("result") or []`, added in #2851), so this brings `_fetch_complementary` in line with the established pattern.

## What changed

- `yfinance/scrapers/quote.py`: default `json_result` to `{}`, read `error`/`result` via `.get()`, and degrade `keydict` to `{}` when `result` is empty. Each requested key then falls through to the existing `else` branch and is set to `None`, matching the commented reference logic directly above the live code.
- `tests/test_ticker.py`: added `test_complementary_info_empty_result_timeseries` (mock-based, no network) beside the #2863 test, covering empty / missing / null `result` and a missing `timeseries`/`finance` envelope, plus the happy path.

## Testing

- `pytest tests/test_ticker.py::TestTickerInfo::test_complementary_info_empty_result_timeseries` and `::test_complementary_info_sparse_timeseries`: both pass.
- New test fails on current `dev` (IndexError / KeyError / TypeError) and passes with the fix.
- `ruff check` on the changed files: clean.