### PR TITLE
Add missing balance sheet keys: FixedMaturityInvestments, EquityInves…

### DIFF
--- a/yfinance/const.py
+++ b/yfinance/const.py
@@ -82,7 +82,7 @@ fundamentals_keys = {
                       "LoansReceivable", "AccountsReceivable", "AllowanceForDoubtfulAccountsReceivable",
                       "GrossAccountsReceivable", "CashCashEquivalentsAndShortTermInvestments",
                       "OtherShortTermInvestments", "CashAndCashEquivalents", "CashEquivalents", "CashFinancial",
-                      "CashCashEquivalentsAndFederalFundsSold"],
+                      "CashCashEquivalentsAndFederalFundsSold", "FixedMaturityInvestments", "EquityInvestments", "NetLoan", "DeferredAssets"],
     'cash-flow': ["ForeignSales", "DomesticSales", "AdjustedGeographySegmentData", "FreeCashFlow",
                   "RepurchaseOfCapitalStock", "RepaymentOfDebt", "IssuanceOfDebt", "IssuanceOfCapitalStock",
                   "CapitalExpenditure", "InterestPaidSupplementalData", "IncomeTaxPaidSupplementalData",


### PR DESCRIPTION
Fixes #2605 

Yahoo Finance returns the data for the following fields but yfinance was not requesting them due to missing keys in const.py:
- FixedMaturityInvestments
- EquityInvestments  
- NetLoan
- DeferredAssets

Keys were verified by calling Yahoo timeseries API directly and confirming all four keys existence. Numbers matched Yahoo's balance sheet page exactly.