### PR TITLE
Preserve cached history metadata when the tradingPeriods enrichment fetch fails (#2745)

### DIFF
--- a/tests/test_history_metadata.py
+++ b/tests/test_history_metadata.py
@@ -1,0 +1,52 @@
+"""
+Regression tests for PriceHistory.get_history_metadata().
+
+These do not hit the network: the secondary intraday request that
+get_history_metadata() makes to populate 'tradingPeriods' is mocked.
+"""
+import unittest
+from unittest.mock import patch
+
+from yfinance.scrapers.history import PriceHistory
+from yfinance.exceptions import YFPricesMissingError
+
+
+def _make_price_history():
+    # PriceHistory only needs (data, ticker, tz) for these code paths;
+    # _data is never touched because _get_history_cache is mocked.
+    return PriceHistory(data=None, ticker="TEST", tz="UTC")
+
+
+class TestGetHistoryMetadata(unittest.TestCase):
+    def test_metadata_preserved_when_tradingperiods_fetch_fails(self):
+        """A failing 'tradingPeriods' enrichment fetch must not discard or
+        raise over metadata already populated by a prior history() call."""
+        ph = _make_price_history()
+        good = {"currency": "CHF", "exchangeName": "EBS", "YF repair?": False}
+        ph._history_metadata = dict(good)
+        ph._history_metadata_formatted = True  # skip network-free formatting step
+
+        def _raise(*args, **kwargs):
+            raise YFPricesMissingError("TEST", "")
+
+        with patch.object(PriceHistory, "_get_history_cache", side_effect=_raise):
+            md = ph.get_history_metadata()
+
+        self.assertEqual(md.get("currency"), "CHF")
+        self.assertEqual(md.get("exchangeName"), "EBS")
+
+    def test_raises_when_no_prior_metadata(self):
+        """If there is no prior metadata at all, the error must still surface."""
+        ph = _make_price_history()
+        ph._history_metadata = None
+
+        def _raise(*args, **kwargs):
+            raise YFPricesMissingError("TEST", "")
+
+        with patch.object(PriceHistory, "_get_history_cache", side_effect=_raise):
+            with self.assertRaises(YFPricesMissingError):
+                ph.get_history_metadata()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -572,7 +572,19 @@ class PriceHistory:
                 else:
                     # default
                     repair = False
-            self._get_history_cache(period="5d", interval="1h", repair=repair)['prices']
+            # 'tradingPeriods' is optional enrichment fetched via a secondary
+            # intraday request. For some valid (non-delisted) tickers/exchanges
+            # that request returns no prices and raises YFPricesMissingError -
+            # and on the way it overwrites self._history_metadata with {}. Don't
+            # let that discard metadata already populated by a prior history()
+            # call: restore and return what we already have instead of raising.
+            _prev_metadata = self._history_metadata
+            try:
+                self._get_history_cache(period="5d", interval="1h", repair=repair)['prices']
+            except YFPricesMissingError:
+                if _prev_metadata is None:
+                    raise
+                self._history_metadata = _prev_metadata
 
         if self._history_metadata_formatted is False:
             self._history_metadata = utils.format_history_metadata(self._history_metadata)


### PR DESCRIPTION
Fixes #2745.

### Problem
`get_history_metadata()` makes a secondary intraday request (`period="5d", interval="1h"`) to populate `tradingPeriods`. For some valid, non-delisted tickers/exchanges (e.g. `ROG.SW`) that request returns no prices and raises `YFPricesMissingError` — and before raising, `_get_history_cache` overwrites `self._history_metadata` with `{}`.

As a result, even though metadata (`currency`, `exchangeName`, `timezone`, …) was already populated by a prior `history()` call, the method both **raises** and **destroys** that cached metadata.

### Fix
In `get_history_metadata()`, snapshot the existing metadata before the optional enrichment fetch. If that fetch raises `YFPricesMissingError`, restore the snapshot and return it instead of propagating — `tradingPeriods` is optional enrichment. When there was no prior metadata at all, the error is still raised (unchanged behaviour). The shared `_get_history_cache` is left untouched to keep the change minimal.

### Tests
Adds `tests/test_history_metadata.py` (network-free, mocks the secondary fetch):
- metadata already populated → preserved & returned when the enrichment fetch fails
- no prior metadata → `YFPricesMissingError` still raised

Verified red→green: the first test fails on `dev` without the fix and passes with it.