### PR TITLE
Guard _fetch_sec_filings and _fetch_calendar against null/empty Yahoo results

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1411,6 +1411,61 @@ class TestTickerInfo(unittest.TestCase):
     #                     else:
     #                         raise
 
+    def test_sec_filings_null_result(self):
+        # _fetch_sec_filings must not crash when Yahoo returns a null or empty
+        # 'result' inside quoteSummary; it should degrade gracefully to None.
+        from yfinance.scrapers.quote import Quote
+
+        bad_payloads = [
+            {"quoteSummary": {"result": None}},
+            {"quoteSummary": {"result": []}},
+            {"quoteSummary": {}},
+            {},
+        ]
+        for payload in bad_payloads:
+            data = MagicMock()
+            q = Quote(data, "TEST")
+            with patch.object(Quote, "_fetch", return_value=payload):
+                result = q._fetch_sec_filings()
+            self.assertIsNone(result, f"Expected None for payload: {payload}")
+
+    def test_sec_filings_happy_path(self):
+        # Ensure valid data is still parsed correctly after the null guard.
+        from yfinance.scrapers.quote import Quote
+
+        payload = {
+            "quoteSummary": {
+                "result": [{
+                    "secFilings": {
+                        "filings": [
+                            {"date": "2024-01-15", "type": "10-K", "exhibits": []},
+                        ]
+                    }
+                }]
+            }
+        }
+        data = MagicMock()
+        q = Quote(data, "TEST")
+        with patch.object(Quote, "_fetch", return_value=payload):
+            result = q._fetch_sec_filings()
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "10-K")
+
+    def test_calendar_null_result(self):
+        # _fetch_calendar must not crash with TypeError when quoteSummary.result
+        # is null; it should raise YFDataException (the existing error path).
+        from yfinance.scrapers.quote import Quote
+        from yfinance.exceptions import YFDataException
+
+        payload = {"quoteSummary": {"result": None}}
+        data = MagicMock()
+        q = Quote(data, "TEST")
+        with patch.object(Quote, "_fetch", return_value=payload):
+            with self.assertRaises(YFDataException):
+                q._fetch_calendar()
+
+
 class TestTickerFundsData(unittest.TestCase):
     session = None
 

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -907,7 +907,7 @@ class Quote:
                 self._calendar['Revenue High'] = earnings.get('revenueHigh', None)
                 self._calendar['Revenue Low'] = earnings.get('revenueLow', None)
                 self._calendar['Revenue Average'] = earnings.get('revenueAverage', None)
-        except (KeyError, IndexError):
+        except (KeyError, IndexError, TypeError):
             if not YfConfig.debug.hide_exceptions:
                 raise
             raise YFDataException(f"Failed to parse json response from Yahoo Finance: {result}")
@@ -918,7 +918,10 @@ class Quote:
         if result is None:
             return None
 
-        filings = result["quoteSummary"]["result"][0]["secFilings"]["filings"]
+        try:
+            filings = result["quoteSummary"]["result"][0]["secFilings"]["filings"]
+        except (KeyError, IndexError, TypeError):
+            return None
 
         # Improve structure
         for f in filings:


### PR DESCRIPTION
### Problem
`_fetch_sec_filings` runs `filings = result["quoteSummary"]["result"][0]["secFilings"]["filings"]` immediately after the `if result is None: return None` guard. When Yahoo returns a **non-None** payload whose `quoteSummary.result` is `null`/empty (or is missing the `secFilings` key), this crashes with `TypeError: 'NoneType' object is not subscriptable` (or `KeyError`/`IndexError`).

`_fetch_calendar` has the same class of gap: its parse block only catches `(KeyError, IndexError)`, so a `null` nested structure raises an uncaught `TypeError`.

### Fix
- `_fetch_sec_filings`: wrap the nested lookup in `try/except (KeyError, IndexError, TypeError)` and return `None` — graceful degradation, consistent with the existing `result is None` guard.
- `_fetch_calendar`: add `TypeError` to the existing `except` tuple.

### Tests
Adds network-free regression tests (mocking `Quote._fetch`) in `tests/test_ticker.py`:
- `test_sec_filings_null_result` — a `null` result degrades to `None` instead of crashing
- `test_sec_filings_happy_path` — a valid payload still parses correctly
- `test_calendar_null_result` — a `null` result raises a clean `YFDataException`

Verified red→green: `test_sec_filings_null_result` fails on current `dev` with `TypeError: 'NoneType' object is not subscriptable` and passes with this change.