### PR TITLE
Fix IntCastingNaNError when repairing Volume with NaN in sudden-change ranges

### DIFF
--- a/tests/test_price_repair.py
+++ b/tests/test_price_repair.py
@@ -752,6 +752,54 @@ class TestPriceRepair(unittest.TestCase):
                     raise
 
 
+class TestFixPricesSuddenChangeVolumeNaN(unittest.TestCase):
+    """Network-free regression test for a NaN Volume crashing repair with
+    IntCastingNaNError (Cannot convert non-finite values (NA or inf) to integer).
+
+    Reuses the checked-in '4063.T' bad-stock-split fixture: this ticker/date range
+    is already known (see TestPriceRepairAssumptions.test_repair_bad_stock_splits)
+    to trigger a Volume-correcting repair range in _fix_bad_stock_splits(), so
+    injecting a NaN into one of the affected rows exercises the exact code path
+    that previously raised.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.dp = os.path.dirname(__file__)
+        fp_bad = os.path.join(cls.dp, "data", "4063-T-1d-bad-stock-split.csv")
+        fp_fixed = os.path.join(cls.dp, "data", "4063-T-1d-bad-stock-split-fixed.csv")
+        cls.df_bad = _pd.read_csv(fp_bad, index_col="Date")
+        cls.df_bad.index = _pd.to_datetime(cls.df_bad.index, utc=True)
+        cls.df_fixed = _pd.read_csv(fp_fixed, index_col="Date")
+        cls.df_fixed.index = _pd.to_datetime(cls.df_fixed.index, utc=True)
+        # Row known (from the fixture pair) to fall inside a corrected range.
+        cls.target_date = _pd.Timestamp('2023-03-15 15:00:00+0000', tz='UTC')
+
+    def _make_hist(self):
+        # Construct PriceHistory directly (no network): _fix_bad_stock_splits() and
+        # _fix_prices_sudden_change() only operate on the DataFrame passed in.
+        from yfinance.scrapers.history import PriceHistory
+        return PriceHistory(data=None, ticker="4063.T", tz="Asia/Tokyo")
+
+    def test_nan_volume_in_corrected_range_does_not_raise(self):
+        hist = self._make_hist()
+        df_bad_nan = self.df_bad.copy()
+        df_bad_nan.loc[self.target_date, 'Volume'] = _np.nan
+
+        repaired = hist._fix_bad_stock_splits(df_bad_nan, "1d", "Asia/Tokyo")
+
+        # NaN must be preserved, not silently coerced into a wrong integer.
+        self.assertTrue(_pd.isna(repaired.loc[self.target_date, 'Volume']))
+
+    def test_clean_data_repair_unaffected_by_the_fix(self):
+        # Regression guard: rows without NaN must still repair exactly as before,
+        # matching the pre-existing known-good fixture.
+        hist = self._make_hist()
+        repaired = hist._fix_bad_stock_splits(self.df_bad.copy(), "1d", "Asia/Tokyo")
+        repaired = repaired.sort_index()
+        df_fixed = self.df_fixed.sort_index()
+        self.assertTrue(_np.isclose(repaired['Volume'], df_fixed['Volume'], rtol=5e-6).all())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_price_repair.py
+++ b/tests/test_price_repair.py
@@ -788,8 +788,12 @@ class TestFixPricesSuddenChangeVolumeNaN(unittest.TestCase):
 
         repaired = hist._fix_bad_stock_splits(df_bad_nan, "1d", "Asia/Tokyo")
 
-        # NaN must be preserved, not silently coerced into a wrong integer.
+        # NaN must be preserved (as NA), not silently coerced into a wrong
+        # integer. Note: the repaired range itself is nullable Int64, but the
+        # final dtype here is Float64 because the NaN-injected *input* column is
+        # necessarily float64 and unrepaired rows keep it.
         self.assertTrue(_pd.isna(repaired.loc[self.target_date, 'Volume']))
+        self.assertEqual(repaired['Volume'].isna().sum(), 1)
 
     def test_clean_data_repair_unaffected_by_the_fix(self):
         # Regression guard: rows without NaN must still repair exactly as before,
@@ -798,7 +802,10 @@ class TestFixPricesSuddenChangeVolumeNaN(unittest.TestCase):
         repaired = hist._fix_bad_stock_splits(self.df_bad.copy(), "1d", "Asia/Tokyo")
         repaired = repaired.sort_index()
         df_fixed = self.df_fixed.sort_index()
-        self.assertTrue(_np.isclose(repaired['Volume'], df_fixed['Volume'], rtol=5e-6).all())
+        volume = repaired['Volume'].astype('float64').to_numpy()
+        self.assertTrue(_np.isclose(volume, df_fixed['Volume'], rtol=5e-6).all())
+        # Volume is migrated to nullable Int64 by the repair (int64 input).
+        self.assertEqual(repaired['Volume'].dtype, 'Int64')
 
 
 if __name__ == '__main__':

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -2700,6 +2700,17 @@ class PriceHistory:
                     df = pd.concat([df_pre_split_repaired.sort_index(), df_post_cutoff])
         return df
 
+    def _round_volume_nansafe(self, s):
+        # Round a Volume-like Series to int, same as plain '.round().astype(int)' when
+        # no NaN is present. But a NaN Volume can occur within a repaired range, and
+        # 'int' cannot represent NaN, so leave the Series as rounded floats in that case
+        # (matches the NaN-tolerant handling already applied to 'Volume' at the end of
+        # _fix_prices_sudden_change()) instead of raising IntCastingNaNError.
+        rounded = s.round()
+        if rounded.isna().any():
+            return rounded
+        return rounded.astype('int')
+
     @utils.log_indent_decorator
     def _fix_prices_sudden_change(self, df, interval, tz_exchange, change, unit_switch=False, correct_volume=False, correct_dividend=False):
         if df.empty:
@@ -3288,9 +3299,9 @@ class PriceHistory:
                 f_open_and_closed_fixed = f_open_fixed & f_close_fixed
                 f_open_xor_closed_fixed = np.logical_xor(f_open_fixed, f_close_fixed)
                 if f_open_and_closed_fixed.any():
-                    df2.loc[f_open_and_closed_fixed, "Volume"] = (df2.loc[f_open_and_closed_fixed, "Volume"] * m_rcp).round().astype('int')
+                    df2.loc[f_open_and_closed_fixed, "Volume"] = self._round_volume_nansafe(df2.loc[f_open_and_closed_fixed, "Volume"] * m_rcp)
                 if f_open_xor_closed_fixed.any():
-                    df2.loc[f_open_xor_closed_fixed, "Volume"] = (df2.loc[f_open_xor_closed_fixed, "Volume"] * 0.5 * m_rcp).round().astype('int')
+                    df2.loc[f_open_xor_closed_fixed, "Volume"] = self._round_volume_nansafe(df2.loc[f_open_xor_closed_fixed, "Volume"] * 0.5 * m_rcp)
 
             sudden_change_repaired[f_corrected] = True
 
@@ -3348,7 +3359,7 @@ class PriceHistory:
                     df2.iloc[r[0]:r[1], df2.columns.get_loc('Dividends')] *= m
                 if correct_volume:
                     col_loc = df2.columns.get_loc("Volume")
-                    df2.iloc[r[0]:r[1], col_loc] = (df2.iloc[r[0]:r[1], col_loc] * m_rcp).round().astype('int')
+                    df2.iloc[r[0]:r[1], col_loc] = self._round_volume_nansafe(df2.iloc[r[0]:r[1], col_loc] * m_rcp)
                 sudden_change_repaired[r[0]:r[1]] = True
                 if r[0] == r[1] - 1:
                     if interday:
@@ -3388,7 +3399,7 @@ class PriceHistory:
                 if correct_dividend:
                     df2['Dividends'] *= m
                 if correct_volume:
-                    df2['Volume'] = (df2['Volume'] * m_rcp).round().astype('int')
+                    df2['Volume'] = self._round_volume_nansafe(df2['Volume'] * m_rcp)
                 sudden_change_repaired = ~sudden_change_repaired
 
         if 'Repaired?' not in df2.columns:

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -2700,17 +2700,6 @@ class PriceHistory:
                     df = pd.concat([df_pre_split_repaired.sort_index(), df_post_cutoff])
         return df
 
-    def _round_volume_nansafe(self, s):
-        # Round a Volume-like Series to int, same as plain '.round().astype(int)' when
-        # no NaN is present. But a NaN Volume can occur within a repaired range, and
-        # 'int' cannot represent NaN, so leave the Series as rounded floats in that case
-        # (matches the NaN-tolerant handling already applied to 'Volume' at the end of
-        # _fix_prices_sudden_change()) instead of raising IntCastingNaNError.
-        rounded = s.round()
-        if rounded.isna().any():
-            return rounded
-        return rounded.astype('int')
-
     @utils.log_indent_decorator
     def _fix_prices_sudden_change(self, df, interval, tz_exchange, change, unit_switch=False, correct_volume=False, correct_dividend=False):
         if df.empty:
@@ -3184,6 +3173,13 @@ class PriceHistory:
         if idx_latest_active is not None:
             idx_rev_latest_active = df.shape[0] - 1 - idx_latest_active
             logger.debug(f'idx_latest_active={idx_latest_active}, idx_rev_latest_active={idx_rev_latest_active}', extra=log_extras)
+        if correct_volume:
+            # Migrate Volume to nullable Int64: a NaN Volume can occur within a
+            # repaired range, and the corrections below partially assign scaled
+            # values back into the column - with plain 'int' that raises
+            # IntCastingNaNError, and partial assignment of NA into an 'int'/'float'
+            # column raises TypeError on pandas 3.
+            df2['Volume'] = df2['Volume'].round().astype('Int64')
         if correct_columns_individually:
             f_corrected = np.full(n, False)
             if correct_volume:
@@ -3299,9 +3295,9 @@ class PriceHistory:
                 f_open_and_closed_fixed = f_open_fixed & f_close_fixed
                 f_open_xor_closed_fixed = np.logical_xor(f_open_fixed, f_close_fixed)
                 if f_open_and_closed_fixed.any():
-                    df2.loc[f_open_and_closed_fixed, "Volume"] = self._round_volume_nansafe(df2.loc[f_open_and_closed_fixed, "Volume"] * m_rcp)
+                    df2.loc[f_open_and_closed_fixed, "Volume"] = (df2.loc[f_open_and_closed_fixed, "Volume"] * m_rcp).round().astype('Int64')
                 if f_open_xor_closed_fixed.any():
-                    df2.loc[f_open_xor_closed_fixed, "Volume"] = self._round_volume_nansafe(df2.loc[f_open_xor_closed_fixed, "Volume"] * 0.5 * m_rcp)
+                    df2.loc[f_open_xor_closed_fixed, "Volume"] = (df2.loc[f_open_xor_closed_fixed, "Volume"] * 0.5 * m_rcp).round().astype('Int64')
 
             sudden_change_repaired[f_corrected] = True
 
@@ -3359,7 +3355,9 @@ class PriceHistory:
                     df2.iloc[r[0]:r[1], df2.columns.get_loc('Dividends')] *= m
                 if correct_volume:
                     col_loc = df2.columns.get_loc("Volume")
-                    df2.iloc[r[0]:r[1], col_loc] = self._round_volume_nansafe(df2.iloc[r[0]:r[1], col_loc] * m_rcp)
+                    # '.array' because on pandas 3.0, iloc-assigning an Int64 *Series*
+                    # containing NA raises KeyError (positional lookup on the value's index)
+                    df2.iloc[r[0]:r[1], col_loc] = (df2.iloc[r[0]:r[1], col_loc] * m_rcp).round().astype('Int64').array
                 sudden_change_repaired[r[0]:r[1]] = True
                 if r[0] == r[1] - 1:
                     if interday:
@@ -3399,18 +3397,11 @@ class PriceHistory:
                 if correct_dividend:
                     df2['Dividends'] *= m
                 if correct_volume:
-                    df2['Volume'] = self._round_volume_nansafe(df2['Volume'] * m_rcp)
+                    df2['Volume'] = (df2['Volume'] * m_rcp).round().astype('Int64')
                 sudden_change_repaired = ~sudden_change_repaired
 
         if 'Repaired?' not in df2.columns:
             df2['Repaired?'] = False
         df2['Repaired?'] = df2['Repaired?'].to_numpy() | sudden_change_repaired
-
-        if correct_volume:
-            f_na = df2['Volume'].isna()
-            if f_na.any():
-                df2.loc[~f_na,'Volume'] = df2['Volume'][~f_na].round(0).astype('int')
-            else:
-                df2['Volume'] = df2['Volume'].round(0).astype('int')
 
         return df2.sort_index()


### PR DESCRIPTION
Fixes #2855.

### Problem
`_fix_prices_sudden_change()` rounds and casts corrected `Volume` values to `int` in four places. Only the last of the four (at the end of the function) guards against NaN:

```python
if correct_volume:
    f_na = df2['Volume'].isna()
    if f_na.any():
        df2.loc[~f_na,'Volume'] = df2['Volume'][~f_na].round(0).astype('int')
    else:
        df2['Volume'] = df2['Volume'].round(0).astype('int')
```

The other three call sites do `.round().astype('int')` directly with no such guard. If a `Volume` value inside a detected price-repair range (e.g. a bad stock split) is `NaN`, this raises `pandas.errors.IntCastingNaNError: Cannot convert non-finite values (NA or inf) to integer` and aborts the whole repair — matching the traceback in #2855.

### Fix
*(Updated after review — the first iteration kept NaN rows as rounded floats via a helper; per review, `Volume` is now migrated to nullable `Int64` instead.)*

At the start of the correction phase in `_fix_prices_sudden_change()`, the `Volume` column is converted to pandas nullable `Int64`. The four correction sites then round and cast their scaled values to `Int64`, which can hold `<NA>`, so a NaN inside a repaired range no longer raises. This also makes the NaN special-case at the end of the function unnecessary, so it is removed — a net simplification.

One pandas 3.0 quirk: `.iloc`-assigning an `Int64` *Series* containing `<NA>` raises `KeyError` (pandas positionally indexes the value's own index during setitem validation), so the ranges-loop site assigns the underlying `.array` — noted in a code comment.

### Verification
Reused the checked-in `4063.T` bad-stock-split fixture (`tests/data/4063-T-1d-bad-stock-split*.csv`), which is already known to trigger a Volume-correcting repair range (see `TestPriceRepairAssumptions.test_repair_bad_stock_splits`). Injecting a `NaN` into a row inside that corrected range:
- **Before this fix**: raises `IntCastingNaNError` (matches the reported bug, confirmed on current `dev`)
- **After this fix**: no longer raises; the `NaN` is preserved as `<NA>` rather than silently coerced into a wrong integer
- **Clean data (no NaN)**: repair output still matches the existing known-good fixture exactly, and the repaired frame's `Volume` comes back as `Int64` — asserted in the test

Adds two network-free tests to `tests/test_price_repair.py` (`TestFixPricesSuddenChangeVolumeNaN`) covering both cases. The bad-stock-split and 100x repair tests in `TestPriceRepair` still pass.
