### PR TITLE
Fix: Screener: add dividendyield and dividendpershare.lasttwelvemonths

### DIFF
--- a/yfinance/const.py
+++ b/yfinance/const.py
@@ -693,6 +693,8 @@ EQUITY_SCREENER_FIELDS = {
         "lastclosepriceearnings.lasttwelvemonths",
         "pegratio_5y"},
     "profitability":{
+        "dividendyield",
+        "dividendpershare.lasttwelvemonths",
         "consecutive_years_of_dividend_growth_count",
         "returnonassets.lasttwelvemonths",
         "returnonequity.lasttwelvemonths",


### PR DESCRIPTION
Added two missing Yahoo Finance screener fields to `EQUITY_SCREENER_FIELDS`:

- **`dividendyield`** — trailing dividend yield percentage
- **`dividendpershare.lasttwelvemonths`** — trailing dividend per share

Both are queryable/sortable fields supported by the Yahoo Finance screener API and used by the official Yahoo stock screener. They were missing from the `profitability` category, alongside the existing forward equivalents (`forward_dividend_yield`, `forward_dividend_per_share`), causing `EquityQuery` to reject queries referencing them.

The existing regression test `test_no_screener_field_is_two_fields_concatenated` auto-covers new fields since it iterates over all `EQUITY_SCREENER_FIELDS`.