### PR TITLE
Fix generic-unit timedelta DeprecationWarning for sub-day intervals (#2882)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,11 +11,18 @@ Specific test class:
 from datetime import datetime
 from unittest import TestSuite
 
+import warnings
+
 import pandas as pd
 
 import unittest
 
-from yfinance.utils import is_valid_period_format, _dts_in_same_interval, _parse_user_dt
+from yfinance.utils import (
+    is_valid_period_format,
+    _dts_in_same_interval,
+    _parse_user_dt,
+    _interval_to_timedelta,
+)
 
 
 class TestPandas(unittest.TestCase):
@@ -179,6 +186,27 @@ class TestDateIntervalCheck(unittest.TestCase):
         
         dt3 = pd.Timestamp("2024-10-15 10:31:00")
         self.assertFalse(_dts_in_same_interval(dt1, dt3, "1min"))
+
+    def test_no_generic_timedelta_deprecation_warning(self):
+        # Regression for #2882: sub-day intervals must not trigger numpy's
+        # "'generic' unit for NumPy timedelta is deprecated" DeprecationWarning.
+        intervals = ["1m", "2m", "5m", "15m", "30m", "60m", "90m", "1h"]
+        for interval in intervals:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _interval_to_timedelta(interval)
+            generic = [w for w in caught
+                       if issubclass(w.category, DeprecationWarning)
+                       and "generic" in str(w.message)]
+            self.assertEqual(generic, [], f"generic-unit warning for {interval!r}")
+
+    def test_interval_to_timedelta_values(self):
+        # Lock the sub-day interval parsing behaviour.
+        self.assertEqual(_interval_to_timedelta("1m"), pd.Timedelta(minutes=1))
+        self.assertEqual(_interval_to_timedelta("30m"), pd.Timedelta(minutes=30))
+        self.assertEqual(_interval_to_timedelta("90m"), pd.Timedelta(minutes=90))
+        self.assertEqual(_interval_to_timedelta("1h"), pd.Timedelta(hours=1))
+        self.assertEqual(_interval_to_timedelta("4h"), pd.Timedelta(hours=4))
 
     def test_parse_user_dt(self):
         exchange_tz = "US/Eastern"

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -480,6 +480,13 @@ def _interval_to_timedelta(interval):
         return relativedelta(months=int(interval[:-2]))
     elif interval[-1] == "y":
         return relativedelta(years=int(interval[:-1]))
+    elif interval[-1] == "m":
+        # Minute intervals e.g. "1m", "30m", "90m". Pass an explicit unit
+        # instead of a bare string so numpy>=2.5 does not emit the
+        # "'generic' unit for NumPy timedelta is deprecated" warning.
+        return _pd.Timedelta(minutes=int(interval[:-1]))
+    elif interval[-1] == "h":
+        return _pd.Timedelta(hours=int(interval[:-1]))
     else:
         return _pd.Timedelta(interval)
 
@@ -664,7 +671,7 @@ def _dts_in_same_interval(dt1, dt2, interval):
         quarter_diff = q2 - q1 + 4*year_diff
         last_rows_same_interval = quarter_diff == 0
     else:
-        last_rows_same_interval = (dt2 - dt1) < _pd.Timedelta(interval)
+        last_rows_same_interval = (dt2 - dt1) < _interval_to_timedelta(interval)
     return last_rows_same_interval
 
 


### PR DESCRIPTION
@
## Summary

Fixes #2882.

`_interval_to_timedelta` fell through to `_pd.Timedelta(interval)` for sub-day intervals (`"1m"`, `"30m"`, `"1h"`, …). Passing a bare interval string makes numpy >= 2.5 emit:

```
DeprecationWarning: The generic unit for NumPy timedelta is deprecated, and will raise an error in the future.
```

flooding the console on any intraday download and set to become a hard error in a future numpy/pandas release.

## Changes

- `yfinance/utils.py`: parse minute intervals as `Timedelta(minutes=...)` and hour intervals as `Timedelta(hours=...)` with explicit units in `_interval_to_timedelta`.
- Route the second warning site, `_dts_in_same_interval` (was calling `_pd.Timedelta(interval)` inline), through `_interval_to_timedelta` so both reported lines (484 and 667 in the issue) are covered by one fix.
- Values are unchanged (`pd.Timedelta("1m")` already parsed as 1 minute); only the code path changes.

## Tests

Added to `tests/test_utils.py`:
- `test_no_generic_timedelta_deprecation_warning` - asserts no generic-unit `DeprecationWarning` for `1m/2m/5m/15m/30m/60m/90m/1h`.
- `test_interval_to_timedelta_values` - locks the parsed values.

`python -m pytest tests/test_utils.py` → 22 passed, 1 xfailed (pre-existing).

Note: my local env has numpy 2.4.6 (< 2.5), so the warning does not fire there; the fix removes the bare-string path that warns on numpy >= 2.5 and the new test is version-agnostic.
@