### PR TITLE
Fix pandas Timedelta DeprecationWarning for interval strings (#2882)

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,12 +10,19 @@ Specific test class:
 """
 from datetime import datetime
 from unittest import TestSuite
+import warnings
 
 import pandas as pd
 
 import unittest
 
-from yfinance.utils import is_valid_period_format, _dts_in_same_interval, _parse_user_dt
+from yfinance.utils import (
+    is_valid_period_format,
+    _dts_in_same_interval,
+    _parse_user_dt,
+    _interval_to_timedelta,
+    _interval_to_pd_timedelta,
+)
 
 
 class TestPandas(unittest.TestCase):
@@ -179,6 +186,38 @@ class TestDateIntervalCheck(unittest.TestCase):
         
         dt3 = pd.Timestamp("2024-10-15 10:31:00")
         self.assertFalse(_dts_in_same_interval(dt1, dt3, "1min"))
+
+    def test_multi_day_interval(self):
+        # '5d' is a valid interval that falls through to the generic branch.
+        dt1 = pd.Timestamp("2024-10-15 10:00:00")
+        dt2 = pd.Timestamp("2024-10-18 10:00:00")  # 3 days later, same 5d window
+        self.assertTrue(_dts_in_same_interval(dt1, dt2, "5d"))
+
+        dt3 = pd.Timestamp("2024-10-22 10:00:00")  # 7 days later, next window
+        self.assertFalse(_dts_in_same_interval(dt1, dt3, "5d"))
+
+    def test_no_deprecation_warning_for_valid_intervals(self):
+        # Regression for #2882: interval strings were passed straight to
+        # pd.Timedelta, relying on pandas' single-letter unit aliases (e.g. 'd'),
+        # which raise a DeprecationWarning on pandas>=3.0 / numpy>=2.5 and are
+        # slated to error in a later release. '5d' in particular reaches the
+        # generic branch and warned. Assert every valid interval stays clean.
+        intervals = ["1m", "2m", "5m", "15m", "30m", "60m", "90m", "1h",
+                     "1d", "5d", "1wk", "1mo", "3mo"]
+        dt1 = pd.Timestamp("2024-01-02 10:00:00")
+        dt2 = pd.Timestamp("2024-01-05 10:00:00")
+        for interval in intervals:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                warnings.simplefilter("error", FutureWarning)
+                _dts_in_same_interval(dt1, dt2, interval)
+                _interval_to_timedelta(interval)
+
+    def test_interval_to_pd_timedelta_values(self):
+        self.assertEqual(_interval_to_pd_timedelta("90m"), pd.Timedelta(minutes=90))
+        self.assertEqual(_interval_to_pd_timedelta("1h"), pd.Timedelta(hours=1))
+        self.assertEqual(_interval_to_pd_timedelta("5d"), pd.Timedelta(days=5))
+        self.assertEqual(_interval_to_pd_timedelta("1wk"), pd.Timedelta(weeks=1))
 
     def test_parse_user_dt(self):
         exchange_tz = "US/Eastern"

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -471,6 +471,21 @@ def _parse_user_dt(dt, exchange_tz=_tz.utc):
     return dt
 
 
+def _interval_to_pd_timedelta(interval):
+    """Convert an intraday/day interval string (e.g. ``'90m'``, ``'1h'``, ``'5d'``)
+    to a ``pandas.Timedelta`` using explicit keyword units.
+
+    Passing these strings straight to ``pd.Timedelta`` relies on pandas' single
+    -letter unit aliases (``'d'``, ``'m'`` ...), which emit a ``DeprecationWarning``
+    on pandas>=3.0 / numpy>=2.5 and are slated to raise in a future release
+    (see GH #2882). Building with keyword units avoids that entirely.
+    """
+    for suffix, unit in (("wk", "weeks"), ("m", "minutes"), ("h", "hours"), ("d", "days")):
+        if interval.endswith(suffix):
+            return _pd.Timedelta(**{unit: int(interval[:-len(suffix)])})
+    return _pd.Timedelta(interval)
+
+
 def _interval_to_timedelta(interval):
     if interval[-1] == "d":
         return relativedelta(days=int(interval[:-1]))
@@ -481,7 +496,7 @@ def _interval_to_timedelta(interval):
     elif interval[-1] == "y":
         return relativedelta(years=int(interval[:-1]))
     else:
-        return _pd.Timedelta(interval)
+        return _interval_to_pd_timedelta(interval)
 
 
 def is_valid_period_format(period):
@@ -664,7 +679,7 @@ def _dts_in_same_interval(dt1, dt2, interval):
         quarter_diff = q2 - q1 + 4*year_diff
         last_rows_same_interval = quarter_diff == 0
     else:
-        last_rows_same_interval = (dt2 - dt1) < _pd.Timedelta(interval)
+        last_rows_same_interval = (dt2 - dt1) < _interval_to_pd_timedelta(interval)
     return last_rows_same_interval
 
 


### PR DESCRIPTION
## Summary

Fixes #2882.

Interval strings such as `"5d"` were passed straight to `pd.Timedelta(interval)`, which relies on pandas' single-letter unit aliases (e.g. `'d'`). On **pandas >= 3.0 / numpy >= 2.5** these emit a `DeprecationWarning` (`Pandas4Warning: 'd' is deprecated ... use 'D'`) that is slated to become a hard error in a future release — which would break history fetching.

`"5d"` is a valid interval and reaches the generic `else` branch of `_dts_in_same_interval`, so it warns in normal use.

## Change

- Add `_interval_to_pd_timedelta()`, which builds the `Timedelta` from an interval string using **explicit keyword units** (`Timedelta(days=5)` etc.), avoiding the deprecated aliases entirely.
- Route the two affected call sites (`_interval_to_timedelta` and `_dts_in_same_interval`) through it. Values are unchanged.

## Tests

- `test_multi_day_interval` — functional check for the `5d` path.
- `test_no_deprecation_warning_for_valid_intervals` — asserts every valid interval (`1m`…`3mo`) is warning-free (with `DeprecationWarning`/`FutureWarning` promoted to errors). This fails on the current code and passes with the fix.
- `test_interval_to_pd_timedelta_values` — value checks for the helper.

Full `tests/test_utils.py` passes under `python -W error::DeprecationWarning` (24 tests).