### PR TITLE
Fix AttributeError in Lookup error handling (self.ticker -> self.query)

### DIFF
--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -3,6 +3,7 @@ import unittest
 import pandas as pd
 
 from tests.context import yfinance as yf, session_gbl
+from yfinance.exceptions import YFDataException
 
 
 class TestLookup(unittest.TestCase):
@@ -63,6 +64,38 @@ class TestLookup(unittest.TestCase):
 
         self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(len(result), 1000)
+
+
+class TestLookupErrorHandling(unittest.TestCase):
+    """Offline tests for Lookup error handling (no network access)."""
+
+    def test_error_response_raises_yfdataexception(self):
+        # When Yahoo returns a 'finance.error' payload, Lookup should raise
+        # YFDataException with the query in the message, not crash with an
+        # AttributeError from referencing a non-existent 'self.ticker'.
+        query = "INVALID-QUERY"
+        lookup = yf.Lookup(query=query)
+
+        class _FakeResponse:
+            text = '{"finance": {"error": {"code": "Bad Request"}}}'
+
+            @staticmethod
+            def json():
+                return {"finance": {"result": None,
+                                    "error": {"code": "Bad Request",
+                                              "description": "Invalid input"}}}
+
+        class _FakeData:
+            @staticmethod
+            def get(*args, **kwargs):
+                return _FakeResponse()
+
+        # Bypass the network layer entirely.
+        lookup._data = _FakeData()
+
+        with self.assertRaises(YFDataException) as cm:
+            lookup.get_all(count=5)
+        self.assertIn(query, str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/yfinance/lookup.py
+++ b/yfinance/lookup.py
@@ -82,13 +82,13 @@ class Lookup:
         except _json.JSONDecodeError:
             if not YfConfig.debug.hide_exceptions:
                 raise
-            self._logger.error(f"{self.ticker}: 'lookup' fetch received faulty data")
+            self._logger.error(f"{self.query}: 'lookup' fetch received faulty data")
             data = {}
 
         # Error returned
         if data.get("finance", {}).get("error", {}):
             error = data.get("finance", {}).get("error", {})
-            raise YFDataException(f"{self.ticker}: 'lookup' fetch returned error: {error}")
+            raise YFDataException(f"{self.query}: 'lookup' fetch returned error: {error}")
 
         self._cache[cache_key] = data
         return data


### PR DESCRIPTION
### Problem

`Lookup` stores the search term as `self.query`, but two error-handling paths in `Lookup._fetch_lookup` reference `self.ticker`, which the class never defines:

```python
# yfinance/lookup.py
self._logger.error(f"{self.ticker}: 'lookup' fetch received faulty data")   # faulty-JSON path
...
raise YFDataException(f"{self.ticker}: 'lookup' fetch returned error: {error}")  # Yahoo error path
```

When Yahoo returns a `finance.error` payload (e.g. bad request / rate limit) or non-JSON body, the intended `YFDataException` / error log is never produced. Instead the interpreter raises a confusing `AttributeError: 'Lookup' object has no attribute 'ticker'`, masking the real cause.

### Root cause

Copy/paste of the `self.ticker` pattern used elsewhere in the library (e.g. `TickerBase`) into `Lookup`, which exposes the term as `self.query` (see the debug log on the line just above, which already correctly uses `self.query`).

### Fix

Replace both `self.ticker` references with `self.query`. Two-character change per line, no behavior change beyond producing the intended error.

### Test

Added an offline unit test (`tests/test_lookup.py::TestLookupErrorHandling`) that mocks the HTTP layer to return a `finance.error` payload and asserts `YFDataException` is raised with the query in the message.

- On current `dev` (before the source fix): the test fails with `AttributeError: 'Lookup' object has no attribute 'ticker'`.
- With the fix: `YFDataException` is raised as intended and the test passes.

Verified `ruff check` and `pyright --level error` pass on the changed files.
