### PR TITLE
Guard get_shares_full against empty/missing share-count timeseries

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1288,6 +1288,47 @@ class TestTickerInfo(unittest.TestCase):
             q._fetch_complementary()
         self.assertEqual(q._info["trailingPegRatio"], 1.23)
 
+    def test_shares_full_empty_result_timeseries(self):
+        # get_shares_full reads json_data["timeseries"]["result"] and then
+        # shares_data[0] without guarding. Yahoo can return a 200 whose
+        # share-count timeseries envelope has an empty/missing/null 'result'
+        # (common for symbols with no share-count history, and for the
+        # 'finance' error envelope that omits 'timeseries'). The unguarded
+        # access raised IndexError/KeyError/TypeError, which also broke the
+        # 'shares' complementary field feeding .info. It should return None
+        # instead, matching the function's other graceful-degradation exits.
+        ticker = yf.Ticker("TEST", session=self.session)
+        ticker._tz = "America/New_York"  # avoid network tz lookup
+
+        return_none = [
+            # 'result' is an empty list -> would raise IndexError
+            {"timeseries": {"error": None, "result": []}},
+            # 'result' key missing -> would raise KeyError
+            {"timeseries": {"error": None}},
+            # 'result' is null -> would raise TypeError
+            {"timeseries": {"error": None, "result": None}},
+            # 'timeseries' absent (finance error envelope) -> would raise KeyError
+            {"finance": {"result": None, "error": {"code": "Not Found"}}},
+        ]
+        for payload in return_none:
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = payload
+            with patch.object(ticker._data, "cache_get", return_value=mock_resp):
+                self.assertIsNone(ticker.get_shares_full(),
+                                  f"Expected None for payload: {payload}")
+
+        # Happy path still returns a populated Series
+        ts = int(pd.Timestamp("2024-01-02", tz="UTC").timestamp())
+        payload = {"timeseries": {"error": None, "result": [
+            {"shares_out": [123456789], "timestamp": [ts]}
+        ]}}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = payload
+        with patch.object(ticker._data, "cache_get", return_value=mock_resp):
+            data = ticker.get_shares_full()
+        self.assertIsInstance(data, pd.Series)
+        self.assertEqual(data.iloc[0], 123456789)
+
     def test_isin_info(self):
         isin_list = {"ES0137650018": True,
                      "does_not_exist": True,  # Nonexistent but doesn't raise an error

--- a/yfinance/base.py
+++ b/yfinance/base.py
@@ -537,8 +537,8 @@ class TickerBase:
             logger.error(f"{self.ticker}: Yahoo web request for share count failed")
             return None
 
-        shares_data = json_data["timeseries"]["result"]
-        if "shares_out" not in shares_data[0]:
+        shares_data = (json_data.get("timeseries") or {}).get("result") or []
+        if not shares_data or "shares_out" not in shares_data[0]:
             return None
         try:
             df = pd.Series(shares_data[0]["shares_out"], index=pd.to_datetime(shares_data[0]["timestamp"], unit="s"))


### PR DESCRIPTION
## Summary

- `TickerBase.get_shares_full` reads `json_data["timeseries"]["result"]` and then indexes `shares_data[0]` with no guard. When Yahoo returns a 200 whose share-count timeseries envelope has an empty `result` (`[]`), a `null` `result`, or omits `timeseries` entirely (the `finance` error envelope), this raises a raw `IndexError` / `TypeError` / `KeyError` that leaks straight to the caller and ignores `hide_exceptions`.
- Empty `result` is the common case: symbols with no share-count history (a lot of non-US tickers, ETFs, indices) come back as `{"timeseries": {"error": null, "result": []}}`, so `shares_data[0]` hits `IndexError: list index out of range`.
- The break isn't limited to the public `get_shares_full()` call. `Quote.shares` calls `get_shares_full` internally to populate the `shares` complementary field, so the same exception can take down `.info` for the whole ticker.
- Fix is minimal and matches how the rest of the function already degrades: pull `result` defensively and return `None` when it's empty, exactly like the existing `if "shares_out" not in shares_data[0]: return None` exit right below it. Every other failure path in this function already returns `None`.

```python
shares_data = (json_data.get("timeseries") or {}).get("result") or []
if not shares_data or "shares_out" not in shares_data[0]:
    return None
```

This is the same class of empty/malformed-timeseries guard as #2877 (Complementary info: guard against empty or missing timeseries result), which fixed the identical `json_result["result"][0]` pattern in `quote.py`. This is the next-door site in `base.py` that reads the same share-count timeseries shape and was still unguarded.

## Testing

Ran in a fresh venv with an editable install:

```
python -m venv .venv && . .venv/bin/activate
pip install -e . pytest ruff
```

Red -> green on the new test:

```
# stock dev (fix reverted): FAILS with IndexError: list index out of range at base.py:541
python -m pytest tests/test_ticker.py::TestTickerInfo::test_shares_full_empty_result_timeseries -v
# with the fix: PASSES
python -m pytest tests/test_ticker.py::TestTickerInfo::test_shares_full_empty_result_timeseries -v
```

Adjacent complementary-info guard tests still pass:

```
python -m pytest tests/test_ticker.py::TestTickerInfo::test_complementary_info_sparse_timeseries tests/test_ticker.py::TestTickerInfo::test_complementary_info_empty_result_timeseries -v
```

Lint / compile clean on changed files:

```
ruff check yfinance/base.py tests/test_ticker.py    # All checks passed!
python -m py_compile yfinance/base.py tests/test_ticker.py
git diff --check
```

The new test is fully mock-based (patches `_data.cache_get`, sets `_tz` to skip the network tz lookup), so it needs no network. It covers the four failing shapes (empty list, missing `result`, null `result`, missing `timeseries`) plus a happy path that still returns a populated Series.