### PR TITLE
Fix error messages showing internal 15m interval for 30m requests

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -483,6 +483,19 @@ class TestPriceHistory(unittest.TestCase):
         with self.assertRaises(YFPricesMissingError):
             dat.history(period="1mo", raise_errors=True)
 
+    def test_30m_interval_error_mentions_requested_interval(self):
+        # Regression for #1029: yfinance fetches 15m data from Yahoo to build
+        # 30m bars, but the internal 15m interval leaked into error messages.
+        from yfinance.exceptions import YFPricesMissingError
+        dat = yf.Ticker("SPY", session=self.session)
+        start_d = _dt.date.today() - _dt.timedelta(days=120)
+        end_d = start_d + _dt.timedelta(days=7)
+        with self.assertRaises(YFPricesMissingError) as cm:
+            dat.history(start=start_d, end=end_d, interval="30m", raise_errors=True)
+        msg = str(cm.exception)
+        self.assertIn("(30m ", msg)
+        self.assertNotIn("(15m ", msg)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -69,6 +69,7 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
         interval : str
             Valid intervals: 1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo
             Intraday data cannot extend last 60 days
+            Note: 30m data is fetched from Yahoo as 15m then resampled, to work around a Yahoo API bug
         start: str
             Download start date string (YYYY-MM-DD) or _datetime, inclusive.
             Default is 99 years ago

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -49,6 +49,7 @@ class PriceHistory:
             interval : str
               | Valid intervals: 1m,2m,5m,15m,30m,60m,90m,1h,1d,5d,1wk,1mo,3mo
               | Intraday data cannot extend last 60 days
+              | Note: 30m data is fetched from Yahoo as 15m then resampled, to work around a Yahoo API bug
             start : str
               | Download start date string (YYYY-MM-DD) or _datetime, inclusive.
               | Default: 99 years ago
@@ -250,7 +251,7 @@ class PriceHistory:
         intraday = params["interval"][-1] in ("m", 'h')
         _price_data_debug = ''
         if start or period is None or period.lower() == "max":
-            _price_data_debug += f' ({params["interval"]} '
+            _price_data_debug += f' ({interval_user} '
             if start_user is not None:
                 _price_data_debug += f'{start_user}'
             elif not intraday:
@@ -277,6 +278,10 @@ class PriceHistory:
             fail = True
         elif "chart" in data and data["chart"] and data["chart"]["error"]:
             _price_data_debug += ' (Yahoo error = "' + data["chart"]["error"]["description"] + '")'
+            if params["interval"] != interval_user.lower():
+                # Yahoo's error names the fetched interval, which can differ from
+                # the user's request (e.g. 30m is fetched as 15m).
+                _price_data_debug += f' (note: yfinance fetched {params["interval"]} data to build {interval_user} bars)'
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)
             fail = True
         elif "chart" not in data or not data["chart"] or data["chart"]["result"] is None or not data["chart"]["result"] or not data["chart"]["result"][0]["indicators"]["quote"][0]:

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -281,7 +281,7 @@ class PriceHistory:
             if params["interval"] != interval_user.lower():
                 # Yahoo's error names the fetched interval, which can differ from
                 # the user's request (e.g. 30m is fetched as 15m).
-                _price_data_debug += f' (note: yfinance fetched {params["interval"]} data to build {interval_user} bars)'
+                _price_data_debug += f' ({interval_user} resampled from {params["interval"]})'
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)
             fail = True
         elif "chart" not in data or not data["chart"] or data["chart"]["result"] is None or not data["chart"]["result"] or not data["chart"]["result"][0]["indicators"]["quote"][0]:


### PR DESCRIPTION
yfinance works around a Yahoo API bug by fetching 15m data and resampling it into 30m bars. That internal 15m interval leaked into YFPricesMissingError messages: a failed 30m request reported '15m data not available', confusing users who never asked for 15m (reported 2022, still reproducible on 1.4.1).

- Build the error context from the interval the user requested.
- When Yahoo's quoted error names the internally fetched interval, append a note explaining the substitution.
- Document the 30m-to-15m mapping in history() and download() docstrings, which the docs website is generated from.
- Add live regression test that fails before this change.

Closes #1029