### PR TITLE
Fix pandas 3 timezone assertion in test_download_multi_small_interval

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -48,7 +48,8 @@ class TestPriceHistory(unittest.TestCase):
     def test_download_multi_small_interval(self):
         use_tkrs = ["AAPL", "0Q3.DE", "ATVI"]
         df = yf.download(use_tkrs, period="1d", interval="5m", auto_adjust=True)
-        self.assertEqual(df.index.tz, _tz.timezone("America/New_York"))
+        # Compare tz keys not objects: pandas 3 returns zoneinfo, pandas <3 pytz
+        self.assertEqual(str(df.index.tz), "America/New_York")
 
     def test_download_with_invalid_ticker(self):
         #Checks if using an invalid symbol gives the same output as not using an invalid symbol in combination with a valid symbol (AAPL)


### PR DESCRIPTION
pandas 3 attaches zoneinfo timezones to DatetimeIndex, so comparing against a pytz object fails on any pandas >= 3:

  AssertionError: zoneinfo.ZoneInfo(key='America/New_York')
                  != <DstTzInfo 'America/New_York' LMT-1 day, 19:04:00 STD>

Compare the timezone key string instead, which is identical for the zoneinfo (pandas 3) and pytz (pandas < 3) representations, matching the pandas floor of >= 1.3 in requirements.