### PR TITLE
Don't claim 'possibly delisted' when Yahoo explains the missing data

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -496,6 +496,31 @@ class TestPriceHistory(unittest.TestCase):
         self.assertIn("(30m ", msg)
         self.assertNotIn("(15m ", msg)
 
+    def test_prices_missing_error_delisted_prefix(self):
+        # Offline check of YFPricesMissingError message formats: the
+        # 'possibly delisted' speculation must be suppressible when the
+        # real cause of missing data is known.
+        from yfinance.exceptions import YFPricesMissingError
+        e = YFPricesMissingError("AAA", "(1d 2020-01-01 -> 2020-01-02)")
+        self.assertEqual(str(e), "$AAA: possibly delisted; no price data found (1d 2020-01-01 -> 2020-01-02)")
+        e = YFPricesMissingError("AAA", "(1d 2020-01-01 -> 2020-01-02)", possibly_delisted=False)
+        self.assertEqual(str(e), "$AAA: no price data found (1d 2020-01-01 -> 2020-01-02)")
+
+    def test_range_error_does_not_claim_delisting(self):
+        # A request Yahoo rejects with an explicit range error is not
+        # delisting evidence, so the message must not speculate 'possibly
+        # delisted'. When a ticker really is dead, Yahoo's quoted error
+        # text still communicates it.
+        from yfinance.exceptions import YFPricesMissingError
+        dat = yf.Ticker("SPY", session=self.session)
+        start_d = _dt.date.today() - _dt.timedelta(days=120)
+        end_d = start_d + _dt.timedelta(days=7)
+        with self.assertRaises(YFPricesMissingError) as cm:
+            dat.history(start=start_d, end=end_d, interval="30m", raise_errors=True)
+        msg = str(cm.exception)
+        self.assertNotIn("possibly delisted", msg)
+        self.assertIn("no price data found", msg)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -496,21 +496,22 @@ class TestPriceHistory(unittest.TestCase):
         self.assertIn("(30m ", msg)
         self.assertNotIn("(15m ", msg)
 
-    def test_prices_missing_error_delisted_prefix(self):
-        # Offline check of YFPricesMissingError message formats: the
-        # 'possibly delisted' speculation must be suppressible when the
-        # real cause of missing data is known.
+    def test_prices_missing_error_message_formats(self):
+        # Offline check of YFPricesMissingError message formats. Without a
+        # Yahoo reason, the message speculates about delisting and reports
+        # the request context. With one, Yahoo's reason is the whole message.
         from yfinance.exceptions import YFPricesMissingError
         e = YFPricesMissingError("AAA", "(1d 2020-01-01 -> 2020-01-02)")
         self.assertEqual(str(e), "$AAA: possibly delisted; no price data found (1d 2020-01-01 -> 2020-01-02)")
-        e = YFPricesMissingError("AAA", "(1d 2020-01-01 -> 2020-01-02)", possibly_delisted=False)
-        self.assertEqual(str(e), "$AAA: no price data found (1d 2020-01-01 -> 2020-01-02)")
+        e = YFPricesMissingError("AAA", "(1d 2020-01-01 -> 2020-01-02)", yahoo_reason="No data found, symbol may be delisted")
+        self.assertEqual(str(e), "$AAA: No data found, symbol may be delisted")
 
-    def test_range_error_does_not_claim_delisting(self):
-        # A request Yahoo rejects with an explicit range error is not
-        # delisting evidence, so the message must not speculate 'possibly
-        # delisted'. When a ticker really is dead, Yahoo's quoted error
-        # text still communicates it.
+    def test_range_error_surfaces_yahoo_reason(self):
+        # A request Yahoo rejects with an explicit reason is not delisting
+        # evidence, so the message must not speculate 'possibly delisted' or
+        # bury Yahoo's reason under generic 'no price data found' text. The
+        # #2900 resample note must still append so 30m failures do not read
+        # as a 15m request.
         from yfinance.exceptions import YFPricesMissingError
         dat = yf.Ticker("SPY", session=self.session)
         start_d = _dt.date.today() - _dt.timedelta(days=120)
@@ -519,7 +520,9 @@ class TestPriceHistory(unittest.TestCase):
             dat.history(start=start_d, end=end_d, interval="30m", raise_errors=True)
         msg = str(cm.exception)
         self.assertNotIn("possibly delisted", msg)
-        self.assertIn("no price data found", msg)
+        self.assertNotIn("no price data found", msg)
+        self.assertIn("data not available", msg)
+        self.assertIn("(30m resampled from 15m)", msg)
 
 
 if __name__ == '__main__':

--- a/yfinance/exceptions.py
+++ b/yfinance/exceptions.py
@@ -34,15 +34,21 @@ class YFTzMissingError(YFTickerMissingError):
 class YFPricesMissingError(YFTickerMissingError):
     """Yahoo returned no price data for the requested range/interval.
 
-    possibly_delisted=False suppresses the delisting speculation, e.g. when
-    Yahoo's response contains an explicit reason for the missing data.
+    When Yahoo states an explicit reason, pass it as yahoo_reason: that
+    reason becomes the whole message and the speculative 'possibly delisted'
+    prefix and generic 'no price data found' text are dropped, because Yahoo
+    has already explained the absence. Otherwise the message reports the
+    request context (debug_info) and keeps the delisting speculation.
     """
-    def __init__(self, ticker, debug_info, possibly_delisted=True):
+    def __init__(self, ticker, debug_info, yahoo_reason=None):
         self.debug_info = debug_info
-        if debug_info != '':
-            super().__init__(ticker, f"no price data found {debug_info}", possibly_delisted)
+        self.yahoo_reason = yahoo_reason
+        if yahoo_reason is not None:
+            super().__init__(ticker, yahoo_reason, possibly_delisted=False)
+        elif debug_info != '':
+            super().__init__(ticker, f"no price data found {debug_info}")
         else:
-            super().__init__(ticker, "no price data found", possibly_delisted)
+            super().__init__(ticker, "no price data found")
 
 
 class YFEarningsDateMissing(YFTickerMissingError):

--- a/yfinance/exceptions.py
+++ b/yfinance/exceptions.py
@@ -13,8 +13,15 @@ class YFNotImplementedError(NotImplementedError):
 
 
 class YFTickerMissingError(YFException):
-    def __init__(self, ticker, rationale):
-        super().__init__(f"${ticker}: possibly delisted; {rationale}")
+    """Expected ticker data is missing.
+
+    By default the message speculates the ticker is delisted, because Yahoo
+    rarely explains the absence. Pass possibly_delisted=False when the real
+    cause is known, so the message does not mislead.
+    """
+    def __init__(self, ticker, rationale, possibly_delisted=True):
+        prefix = "possibly delisted; " if possibly_delisted else ""
+        super().__init__(f"${ticker}: {prefix}{rationale}")
         self.rationale = rationale
         self.ticker = ticker
 
@@ -25,12 +32,17 @@ class YFTzMissingError(YFTickerMissingError):
 
 
 class YFPricesMissingError(YFTickerMissingError):
-    def __init__(self, ticker, debug_info):
+    """Yahoo returned no price data for the requested range/interval.
+
+    possibly_delisted=False suppresses the delisting speculation, e.g. when
+    Yahoo's response contains an explicit reason for the missing data.
+    """
+    def __init__(self, ticker, debug_info, possibly_delisted=True):
         self.debug_info = debug_info
         if debug_info != '':
-            super().__init__(ticker, f"no price data found {debug_info}")
+            super().__init__(ticker, f"no price data found {debug_info}", possibly_delisted)
         else:
-            super().__init__(ticker, "no price data found")
+            super().__init__(ticker, "no price data found", possibly_delisted)
 
 
 class YFEarningsDateMissing(YFTickerMissingError):

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -282,7 +282,8 @@ class PriceHistory:
                 # Yahoo's error names the fetched interval, which can differ from
                 # the user's request (e.g. 30m is fetched as 15m).
                 _price_data_debug += f' ({interval_user} resampled from {params["interval"]})'
-            _exception = YFPricesMissingError(self.ticker, _price_data_debug)
+            # Yahoo gave an explicit reason, so don't speculate about delisting.
+            _exception = YFPricesMissingError(self.ticker, _price_data_debug, possibly_delisted=False)
             fail = True
         elif "chart" not in data or not data["chart"] or data["chart"]["result"] is None or not data["chart"]["result"] or not data["chart"]["result"][0]["indicators"]["quote"][0]:
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -277,13 +277,14 @@ class PriceHistory:
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)
             fail = True
         elif "chart" in data and data["chart"] and data["chart"]["error"]:
-            _price_data_debug += ' (Yahoo error = "' + data["chart"]["error"]["description"] + '")'
+            # Yahoo explained why there's no data, so surface its reason directly
+            # instead of the generic "no price data found" plus request context.
+            yahoo_reason = data["chart"]["error"]["description"]
             if params["interval"] != interval_user.lower():
                 # Yahoo's error names the fetched interval, which can differ from
                 # the user's request (e.g. 30m is fetched as 15m).
-                _price_data_debug += f' ({interval_user} resampled from {params["interval"]})'
-            # Yahoo gave an explicit reason, so don't speculate about delisting.
-            _exception = YFPricesMissingError(self.ticker, _price_data_debug, possibly_delisted=False)
+                yahoo_reason += f' ({interval_user} resampled from {params["interval"]})'
+            _exception = YFPricesMissingError(self.ticker, _price_data_debug, yahoo_reason=yahoo_reason)
             fail = True
         elif "chart" not in data or not data["chart"] or data["chart"]["result"] is None or not data["chart"]["result"] or not data["chart"]["result"][0]["indicators"]["quote"][0]:
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)


### PR DESCRIPTION
Every YFPricesMissingError message speculates 'possibly delisted', even when Yahoo's response carries an explicit reason that has nothing to do with delisting, e.g. an intraday range outside the last 60 days. That speculation has misled users for years (see #1713, #1797, #2044, #2052). And when a ticker really is dead, Yahoo's quoted description already says 'No data found, symbol may be delisted', making the prefix redundant there too.

Add possibly_delisted=True parameter to YFTickerMissingError and YFPricesMissingError (default keeps every other callsite unchanged) and pass False in the one history() branch where Yahoo supplied an error description, letting Yahoo's stated reason stand.

Adds an offline test of both message formats and a live test that a range error no longer claims delisting.

Closes #2902 