### PR TITLE
Fix: handle null result from Yahoo API in _fetch_info

### DIFF
--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -690,7 +690,7 @@ class Quote:
 
         query1_info = {}
         for quote in ["quoteSummary", "quoteResponse"]:
-            quote_result = result.get(quote, {}).get("result", [])
+            quote_result = result.get(quote, {}).get("result") or []
 
             if len(quote_result) > 0:
                 quote_result[0]["symbol"] = self._symbol


### PR DESCRIPTION
When Yahoo Finance returns `"result": null` in the quoteSummary response, `_fetch_info` crashes with: 

TypeError: object of type 'NoneType' has no len()

This is because the line `.get("result, [])` only uses `[]` when the key is missing, disregarding the fact that the key could exist with a null value.

Fix - Use 'or []' to handle both missing and null case.

Closes #2905 


