### PR TITLE
Fix: repair=True should not permanently convert GBp/ZAc/ILA prices to main currency

### DIFF
--- a/tests/test_price_repair.py
+++ b/tests/test_price_repair.py
@@ -751,6 +751,28 @@ class TestPriceRepair(unittest.TestCase):
                     print(repaired_df[f2][c] - correct_df[f2][c])
                     raise
 
+    def test_repair_gbp_not_converted(self):
+        tkr = "XDEV.L"
+        dat = yf.Ticker(tkr, session=self.session)
+
+        df_no_repair = dat.history(period='1mo', interval='1d', auto_adjust=False, repair=False)
+        df_repair = dat.history(period='1mo', interval='1d', auto_adjust=False, repair=True)
+
+        if df_no_repair.empty or df_repair.empty:
+            self.skipTest("No data returned for XDEV.L")
+
+        close_no_repair = df_no_repair['Close'].iloc[:-1]
+        close_repair = df_repair['Close'].iloc[:-1]
+
+        try:
+            self.assertTrue(_np.isclose(close_no_repair, close_repair, rtol=1e-2).all())
+        except AssertionError:
+            print("Mismatch in Close prices for XDEV.L")
+            print("- df_no_repair['Close']:")
+            print(close_no_repair)
+            print("- df_repair['Close']:")
+            print(close_repair)
+            raise
 
 
 if __name__ == '__main__':

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -14,6 +14,8 @@ from yfinance.config import YfConfig
 from yfinance.const import _BASE_URL_, _PRICE_COLNAMES_, period_default, _SENTINEL_
 from yfinance.exceptions import YFDataException, YFInvalidPeriodError, YFPricesMissingError, YFRateLimitError, YFTzMissingError
 
+_CURRENCY_CONVERSIONS = {'GBp': 0.01, 'ZAc': 0.01, 'ILA': 0.01}  # GBp = pence, ZAc = South African cents, ILA = Israeli agorot
+
 class PriceHistory:
     def __init__(self, data, ticker, tz, session=None):
         self._data = data
@@ -472,10 +474,12 @@ class PriceHistory:
 
             df = df.sort_index()
 
+            original_currency = currency  # keeps track of original currency before any repairs that may change it
+
             # Must fix bad 'Adj Close' & dividends before 100x/split errors.
             # First make currency consistent. On some exchanges, dividends often in different currency
             # to prices, e.g. £ vs pence.
-            df, currency = self._standardise_currency(df, currency)
+            df, currency, div_scaled, prices_scaled = self._standardise_currency(df, currency)
             self._history_metadata['currency'] = currency
 
             f_na = df['Volume'].isna()
@@ -499,6 +503,18 @@ class PriceHistory:
 
             # New:
             df = self._repair_capital_gains(df)
+
+            # Revert currency conversion done by _standardise_currency(),
+            # so the returned data matches the ticker's actual quotation currency.
+            if prices_scaled:
+                m = _CURRENCY_CONVERSIONS[original_currency]
+                for c in _PRICE_COLNAMES_:
+                    df[c] /= m
+                if div_scaled:
+                    df['Dividends'] /= m
+                self._history_metadata['currency'] = original_currency
+                if 'currencyRepaired' in self._history_metadata:
+                    del self._history_metadata['currencyRepaired']
 
             df = df.sort_index()
 
@@ -1064,27 +1080,18 @@ class PriceHistory:
         return df_v2
 
     def _standardise_currency(self, df, currency):
-        if currency not in ["GBp", "ZAc", "ILA"]:
-            return df, currency
-        currency2 = currency
-        if currency == 'GBp':
-            # UK £/pence
-            currency2 = 'GBP'
-            m = 0.01
-        elif currency == 'ZAc':
-            # South Africa Rand/cents
-            currency2 = 'ZAR'
-            m = 0.01
-        elif currency == 'ILA':
-            # Israel Shekels/Agora
-            currency2 = 'ILS'
-            m = 0.01
-
+        div_scaled = False
+        prices_scaled = False
+        if currency not in _CURRENCY_CONVERSIONS:
+            return df, currency, div_scaled, prices_scaled
+        m = _CURRENCY_CONVERSIONS[currency]
+        currency2 = {'GBp': 'GBP', 'ZAc': 'ZAR', 'ILA': 'ILS'}[currency]
+        
         # Use latest row with actual volume, because volume=0 rows can be 0.01x the other rows.
         # _fix_unit_switch() will ensure all rows are on same scale.
         f_volume = df['Volume']>0
         if not f_volume.any():
-            return df, currency
+            return df, currency, div_scaled, prices_scaled
         last_row = df.iloc[np.where(f_volume)[0][-1]]
         prices_in_subunits = True  # usually is true
         if last_row.name > (pd.Timestamp.now('UTC') - _datetime.timedelta(days=30)):
@@ -1101,6 +1108,7 @@ class PriceHistory:
         if prices_in_subunits:
             for c in _PRICE_COLNAMES_:
                 df[c] *= m
+            prices_scaled = True
         self._history_metadata["currency"] = currency2
         self._history_metadata["currencyRepaired"] = True
 
@@ -1118,8 +1126,9 @@ class PriceHistory:
             div_pcts = (divs['Dividends'] / divs['Close']).to_numpy()
             if len(div_pcts) > 0 and np.average(div_pcts) > 1:
                 df['Dividends'] *= m
+                div_scaled = True
 
-        return df, currency2
+        return df, currency2, div_scaled, prices_scaled
 
     def _dividends_convert_fx(self, dividends, fx, repair=False):
         bad_div_currencies = [c for c in dividends['currency'].unique() if c != fx]


### PR DESCRIPTION
_standardise_currency() converts pence, cents, and agora to main currency internally to help repair dividend-adjustment math, but this conversion was leaking into the final returned data and metadata, even when no actual repair was needed. Now reverts prices/dividends/currency back to original units before returning to the user.

## Before / after (XDEV.L)

**dev (unmodified):** Open=62.15, Close=62.01, currency=GBP

**this branch:** Open=6215.0, Close=6201.0, currency=GBp

Fixed values match the un-repaired data exactly, confirming no unnecessary "repair" occurs when nothing is broken.

Verified against XDEV.L, HSBA.L (incl. auto_adjust), NPN.JO, and AAPL. Confirmed bug reproduces on unmodified dev and is fixed on this branch. Ran tests/test_price_repair.py: 2 pre-existing failures (test_resampling, test_repair_zeroes_daily) reproduce identically on unmodified dev, unrelated to this change.

Fixes #2866 