### PR TITLE
Fix: don't treat curl_cffi>=0.16 sessions as caching (presence of .cache != active cache)

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -2,7 +2,9 @@
 import unittest
 from functools import lru_cache
 
+from yfinance._http import new_session
 from yfinance.data import SingletonMeta, YfData, _normalize_proxy, lru_cache_freezeargs
+from yfinance.exceptions import YFDataException
 from yfinance.utils import frozendict
 
 
@@ -139,6 +141,32 @@ class TestCookieStrategyLoginPreservation(unittest.TestCase):
         self.data._set_cookie_strategy('basic')
         self.assertEqual(self.data._session.cookies.get("T"), "T-opt")
         self.assertEqual(self.data._session.cookies.get("Y"), "Y-opt")
+
+
+class TestSetSessionCacheDetection(unittest.TestCase):
+    """A session is caching only when a cache is active, not when `.cache` merely exists.
+
+    curl_cffi >= 0.16 Sessions always expose `.cache` (None when disabled).
+    """
+
+    def setUp(self):
+        SingletonMeta._instances.pop(YfData, None)
+        self.data = YfData()
+
+    def tearDown(self):
+        SingletonMeta._instances.pop(YfData, None)
+
+    def test_session_with_disabled_cache_is_accepted(self):
+        session = new_session()
+        session.cache = None
+        self.data._set_session(session)
+        self.assertIs(self.data._session, session)
+
+    def test_session_with_active_cache_is_rejected(self):
+        session = new_session()
+        session.cache = object()
+        with self.assertRaises(YFDataException):
+            self.data._set_session(session)
 
 
 if __name__ == "__main__":

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -137,18 +137,9 @@ class YfData(metaclass=SingletonMeta):
         if session is None:
             return
 
-        try:
-            session.cache
-        except AttributeError:
-            # Not caching
-            self._session_is_caching = False
-        else:
-            # Is caching. This is annoying.
-            # Can't simply use a non-caching session to fetch cookie & crumb,
-            # because then the caching-session won't have cookie.
-            self._session_is_caching = True
-            # requests_cache wraps the stdlib Session; it doesn't work with
-            # curl_cffi and tends to miss anyway because the Yahoo crumb rotates.
+        # Test for an active cache, not the attribute's presence: curl_cffi >= 0.16
+        # Sessions always expose `.cache` (None when disabled).
+        if getattr(session, "cache", None) is not None:
             raise YFDataException("Caching sessions (e.g. requests_cache) are not supported. Solution: stop setting session, let yfinance handle.")
 
         if not is_supported_session(session):
@@ -269,11 +260,7 @@ class YfData(metaclass=SingletonMeta):
             'timeout': timeout,
             'allow_redirects': True
         }
-        if self._session_is_caching:
-            get_args['expire_after'] = self._expire_after
-            crumb_response = self._session.get(**get_args)
-        else:
-            crumb_response = self._session.get(**get_args)
+        crumb_response = self._session.get(**get_args)
         self._crumb = crumb_response.text
         if crumb_response.status_code == 429 or "Too Many Requests" in self._crumb:
             utils.get_yf_logger().debug(f"Didn't receive crumb {self._crumb}")
@@ -308,11 +295,7 @@ class YfData(metaclass=SingletonMeta):
 
         get_args = {**base_args, 'url': 'https://guce.yahoo.com/consent'}
         try:
-            if self._session_is_caching:
-                get_args['expire_after'] = self._expire_after
-                response = self._session.get(**get_args)
-            else:
-                response = self._session.get(**get_args)
+            response = self._session.get(**get_args)
         except requests.exceptions.ChunkedEncodingError:
             # No idea why happens, but handle nicely so can switch to other cookie method.
             utils.get_yf_logger().debug('_get_cookie_csrf() encountering requests.exceptions.ChunkedEncodingError, aborting')
@@ -346,14 +329,8 @@ class YfData(metaclass=SingletonMeta):
             'url': f'https://guce.yahoo.com/copyConsent?sessionId={sessionId}',
             'data': data}
         try:
-            if self._session_is_caching:
-                post_args['expire_after'] = self._expire_after
-                get_args['expire_after'] = self._expire_after
-                self._session.post(**post_args)
-                self._session.get(**get_args)
-            else:
-                self._session.post(**post_args)
-                self._session.get(**get_args)
+            self._session.post(**post_args)
+            self._session.get(**get_args)
         except requests.exceptions.ChunkedEncodingError:
             # No idea why happens, but handle nicely so can switch to other cookie method.
             utils.get_yf_logger().debug('_get_cookie_csrf() encountering requests.exceptions.ChunkedEncodingError, aborting')
@@ -376,11 +353,7 @@ class YfData(metaclass=SingletonMeta):
         get_args = {
             'url': 'https://query2.finance.yahoo.com/v1/test/getcrumb',
             'timeout': timeout}
-        if self._session_is_caching:
-            get_args['expire_after'] = self._expire_after
-            r = self._session.get(**get_args)
-        else:
-            r = self._session.get(**get_args)
+        r = self._session.get(**get_args)
         self._crumb = r.text
 
         if r.status_code == 429 or "Too Many Requests" in self._crumb:


### PR DESCRIPTION
## Summary

`_set_session` flagged a session as "caching" (and refused it) based on the mere *presence* of a `.cache` attribute. curl_cffi >= 0.16 always exposes `.cache` (`None` when disabled), so yfinance's own `new_session()` tripped the check and raised `YFDataException` on **every** call, even with no session passed. curl_cffi 0.15.x lacks the attribute, so the break only shows on 0.16+.

0.16 is currently in beta (`0.16.0b1`), but yfinance pins `curl_cffi>=0.15` with no upper bound: the moment 0.16 final ships, every fresh install breaks. Verified against 0.16.0b1: on `dev`, plain `YfData()` raises; with this fix it works, and a `requests_cache.CachedSession` is still rejected (its `.cache` is a non-None backend).

## Fix

Test for an *active* cache instead: `getattr(session, "cache", None) is not None`. Still rejects `requests_cache` and curl_cffi with caching enabled; accepts a normal session whose `.cache` is `None`.

Also removed the dead `_session_is_caching` machinery: since `_set_session` raises on any active cache, the flag could never be `True`, so the four `expire_after` branches were unreachable (and referenced `self._expire_after`, which is never defined). Worse, setting the flag before the raise left a live singleton in a broken state if a caching session was passed after init.

## Tests

`tests/test_data.py::TestSetSessionCacheDetection` (offline, version-independent): `.cache = None` accepted, active cache rejected. Red on the base branch, green here. Also validated end-to-end in a downstream project pinned to `curl_cffi==0.16.0b1` running this branch.
