### PR TITLE
Fix multi-day interval TypeError and actually silence the numpy>=2.5 Timedelta warning

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -221,6 +221,32 @@ class TestDateIntervalCheck(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.assertEqual(_parse_user_dt(float(epoch), exchange_tz), expected)
 
+
+class TestMultiDayInterval(unittest.TestCase):
+    def test_multiday_interval_does_not_raise(self):
+        # _interval_to_timedelta returns a relativedelta for day intervals,
+        # which cannot be compared against the Timedelta (dt2 - dt1), so a
+        # multi-day interval used to raise TypeError here.
+        dt1 = pd.Timestamp("2024-01-01")
+        dt2 = pd.Timestamp("2024-01-08")
+        self.assertTrue(_dts_in_same_interval(dt1, dt2, "10d"))
+        self.assertFalse(_dts_in_same_interval(dt1, dt2, "5d"))
+
+    def test_multiday_interval_does_not_warn(self):
+        # Building the comparison Timedelta must not trigger numpy's
+        # "generic unit" DeprecationWarning on pandas 2.x + numpy>=2.5.
+        dt1 = pd.Timestamp("2024-01-01")
+        dt2 = pd.Timestamp("2024-01-04")
+        for interval in ("3d", "5d", "10d"):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                _dts_in_same_interval(dt1, dt2, interval)
+            generic = [w for w in caught
+                       if issubclass(w.category, DeprecationWarning)
+                       and "generic" in str(w.message)]
+            self.assertEqual(generic, [], f"generic-unit warning for {interval!r}")
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -251,7 +251,9 @@ class FastInfo:
         if self._shares is not None:
             return self._shares
 
-        shares = self._tkr.get_shares_full(start=pd.Timestamp.now('UTC').date()-pd.Timedelta(days=548))
+        # unit="D" rather than days=... so pandas does not emit the numpy>=2.5
+        # "generic unit" deprecation warning when constructing the Timedelta.
+        shares = self._tkr.get_shares_full(start=pd.Timestamp.now('UTC').date() - pd.Timedelta(548, unit="D"))
         # if shares is None:
         #     # Requesting 18 months failed, so fallback to shares which should include last year
         #     shares = self._tkr.get_shares()

--- a/yfinance/utils.py
+++ b/yfinance/utils.py
@@ -481,12 +481,14 @@ def _interval_to_timedelta(interval):
     elif interval[-1] == "y":
         return relativedelta(years=int(interval[:-1]))
     elif interval[-1] == "m":
-        # Minute intervals e.g. "1m", "30m", "90m". Pass an explicit unit
-        # instead of a bare string so numpy>=2.5 does not emit the
-        # "'generic' unit for NumPy timedelta is deprecated" warning.
-        return _pd.Timedelta(minutes=int(interval[:-1]))
+        # Minute intervals e.g. "1m", "30m", "90m". Pass the value and an
+        # explicit unit rather than a keyword like minutes=, because on
+        # pandas 2.x + numpy>=2.5 even the keyword form emits the
+        # "'generic' unit for NumPy timedelta is deprecated" warning; only
+        # the (value, unit=...) form is silent.
+        return _pd.Timedelta(int(interval[:-1]), unit="m")
     elif interval[-1] == "h":
-        return _pd.Timedelta(hours=int(interval[:-1]))
+        return _pd.Timedelta(int(interval[:-1]), unit="h")
     else:
         return _pd.Timedelta(interval)
 
@@ -670,6 +672,13 @@ def _dts_in_same_interval(dt1, dt2, interval):
         year_diff = dt2.year - dt1.year
         quarter_diff = q2 - q1 + 4*year_diff
         last_rows_same_interval = quarter_diff == 0
+    elif interval[-1] == "d":
+        # Multi-day intervals e.g. "5d". _interval_to_timedelta() returns a
+        # relativedelta for day intervals, which cannot be compared with the
+        # Timedelta (dt2 - dt1) and raises TypeError, so build a Timedelta
+        # directly. unit="D" rather than days=... keeps the numpy>=2.5
+        # "generic unit" deprecation warning silent.
+        last_rows_same_interval = (dt2 - dt1) < _pd.Timedelta(int(interval[:-1]), unit="D")
     else:
         last_rows_same_interval = (dt2 - dt1) < _interval_to_timedelta(interval)
     return last_rows_same_interval


### PR DESCRIPTION
Two related fixes in the interval/date-arithmetic code. This supersedes the earlier version of this PR, which reordered the `Quote.shares` arithmetic on a rationale that turns out to be wrong — I verified the reordering silenced nothing.

### 1. The numpy>=2.5 "generic unit" warning is not actually being silenced

Issue #2914 reports the `'generic' unit for NumPy timedelta is deprecated` `DeprecationWarning`. #2882 added a workaround in `_interval_to_timedelta` that passes `minutes=` / `hours=` keywords "so numpy>=2.5 does not emit the warning" — but on pandas 2.x + numpy>=2.5 **the keyword form still warns**. Measured on numpy 2.5.1 / pandas 2.3.3:

| construction | warns? |
|---|---|
| `pd.Timedelta("5d")` (bare string) | yes |
| `pd.Timedelta(days=548)` (keyword) | **yes** |
| `pd.Timedelta(minutes=90)` (keyword) | **yes** |
| `pd.Timedelta(90, unit="m")` | no |
| `pd.Timedelta(548, unit="D")` | no |

Only the `(value, unit=...)` form is silent. So this switches `_interval_to_timedelta`'s sub-day branches and `Quote.shares` to that form.

Concretely: **`tests/test_utils.py::TestDateIntervalCheck::test_no_generic_timedelta_deprecation_warning` — the regression test #2882 added — currently fails on numpy 2.5.1 / pandas 2.3.3**, because the keyword workaround doesn't hold. This change makes it pass. (It presumably passes in CI on a numpy<2.5 or pandas-3.0 runner, where the warning doesn't fire at all.)

### 2. TypeError on multi-day intervals

`_interval_to_timedelta` returns a `relativedelta` for day intervals, and `relativedelta` can't be compared with the `Timedelta` `(dt2 - dt1)`, so `_dts_in_same_interval` raises for a multi-day interval:

```python
>>> _dts_in_same_interval(pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-08"), "5d")
TypeError: '<' not supported between instances of 'Timedelta' and 'relativedelta'
```

Still reproduces on current `dev`. The new `d` branch builds a `Timedelta` directly (with `unit="D"`, so it doesn't reintroduce the warning).

### Verification

Built the exact stack from #2914 (Python 3.14, numpy 2.5.1, pandas 2.3.3):

- every `_interval_to_timedelta` / `_dts_in_same_interval` construction is now clean, with values unchanged (`90m` → 90 min, `1h` → 1 hour, `5d` compares correctly);
- `Timedelta(n, unit=...)` is also clean and correct on numpy 2.4.6 and on pandas 3.0.3, so this doesn't trade one deprecation for another;
- added `TestMultiDayInterval` covering the TypeError case and the multi-day warning. Reverting only the source while keeping the tests fails those two **and** the existing `test_no_generic_timedelta_deprecation_warning`;
- `ruff check` clean on the changed files.

I did **not** touch the pandas-internal side: a user constructing their own `Timedelta(days=...)` will still see the warning until they move to pandas 3.0 (which fixes it at source). This only stops yfinance's own internal constructions from emitting it — which is what the two linked issues are about.

Rebased onto `dev` (`f20d53e`, before the ruff-CI pin) so the branch carries no workflow-file change.