### PR TITLE
Pin ruff ruleset for deterministic CI

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -18,4 +18,4 @@ jobs:
       # Verify: curl -s "https://api.github.com/repos/astral-sh/ruff-action/commits?sha=v3&until=$(date -u -d '7 days ago' '+%Y-%m-%dT%H:%M:%SZ')&per_page=1" | jq -r '.[0].sha'
       - uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
         with:
-          args: check --ignore E702 . --exclude yfinance/pricing_pb2.py
+          args: check .

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,6 @@
+# Pin ruleset so CI is deterministic across ruff versions.
+extend-exclude = ["yfinance/pricing_pb2.py"]
+
+[lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = ["E702"]


### PR DESCRIPTION
ruff 0.16.0 significantly expanded its default rule set. The lint job ran ruff with no config and an unpinned version, so CI started failing on hundreds of pre-existing violations across the repo (import order, pep604 annotations, datetime tz, etc.), unrelated to any change.

This pins the ruleset via ruff.toml (select E4,E7,E9,F; ignore E702; exclude the generated pricing_pb2.py) so linting is deterministic regardless of the installed ruff version, and simplifies the workflow args to `check .`. No code changes.
