### PR TITLE
Fix generic timedelta warning in FastInfo

### DIFF
--- a/tests/test_quote.py
+++ b/tests/test_quote.py
@@ -1,0 +1,31 @@
+import datetime
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+
+from yfinance.scrapers.quote import FastInfo
+
+
+class TestFastInfo(unittest.TestCase):
+    def test_shares_does_not_use_pandas_timedelta(self):
+        ticker = MagicMock()
+        ticker.get_shares_full.return_value = pd.Series([100])
+
+        with patch(
+            "yfinance.scrapers.quote.pd.Timedelta",
+            side_effect=AssertionError(
+                "FastInfo.shares must not use pandas Timedelta with a Python date"
+            ),
+        ):
+            shares = FastInfo(ticker).shares
+
+        self.assertEqual(shares, 100)
+        ticker.get_shares_full.assert_called_once()
+
+        start = ticker.get_shares_full.call_args.kwargs["start"]
+        self.assertIsInstance(start, datetime.date)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -309,7 +309,7 @@ class TestTickerHistory(unittest.TestCase):
         self.assertTrue(md['YF repair?'])
 
     def test_download(self):
-        tomorrow = pd.Timestamp.now().date() + pd.Timedelta(days=1)  # helps with caching
+        tomorrow = pd.Timestamp.now().date() + timedelta(days=1)  # helps with caching
         for threads in [False, True]:
             for ignore_tz in [False, True]:
                 for mli in [False, True]:

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -251,7 +251,9 @@ class FastInfo:
         if self._shares is not None:
             return self._shares
 
-        shares = self._tkr.get_shares_full(start=pd.Timestamp.now('UTC').date()-pd.Timedelta(days=548))
+        shares = self._tkr.get_shares_full(
+            start=pd.Timestamp.now('UTC').date() - datetime.timedelta(days=548)
+        )
         # if shares is None:
         #     # Requesting 18 months failed, so fallback to shares which should include last year
         #     shares = self._tkr.get_shares()


### PR DESCRIPTION
## Summary

Replace pandas `Timedelta` arithmetic on a Python `date` with the standard-library `datetime.timedelta`.

This avoids the generic NumPy timedelta deprecation warning in `FastInfo.shares` while preserving the existing 548-day lookback period.

The equivalent deprecated date arithmetic in `tests/test_ticker.py` is also updated.

## Changes

* Use `datetime.timedelta(days=548)` in `FastInfo.shares`.
* Replace `pd.Timedelta(days=1)` with the standard-library `timedelta` in `test_download`.
* Add a deterministic regression test ensuring `FastInfo.shares` does not use pandas `Timedelta` with a Python `date`.

## Testing

```text
python -m unittest \
  tests.test_quote.TestFastInfo.test_shares_does_not_use_pandas_timedelta \
  tests.test_ticker.TestTickerHistory.test_download \
  -v

python -m compileall -q yfinance
git diff --check
```

Result:

```text
Ran 2 tests in 14.484s

OK
```

Addresses the remaining `FastInfo.shares` warning reported in #2914.
