### PR TITLE
Fix NaN comparisons in stock split repair test

### DIFF
--- a/tests/test_price_repair.py
+++ b/tests/test_price_repair.py
@@ -523,14 +523,11 @@ class TestPriceRepair(unittest.TestCase):
                 df_good = df_good.sort_index()
                 repaired_df = repaired_df.sort_index()
                 for c in ["Open", "Low", "High", "Close", "Adj Close", "Volume"]:
-                    try:
-                        self.assertTrue((repaired_df[c].to_numpy() == df_good[c].to_numpy()).all())
-                    except Exception:
-                        print(f"tkr={tkr} interval={interval} COLUMN={c}")
-                        df_dbg = df_good[[c]].join(repaired_df[[c]], lsuffix='.good', rsuffix='.repaired')
-                        f_diff = repaired_df[c].to_numpy() != df_good[c].to_numpy()
-                        print(df_dbg[f_diff | _np.roll(f_diff, 1) | _np.roll(f_diff, -1)])
-                        raise
+                    _np.testing.assert_array_equal(
+                        repaired_df[c].to_numpy(),
+                        df_good[c].to_numpy(),
+                        err_msg=f"tkr={tkr} interval={interval} COLUMN={c}",
+                    )
 
         bad_tkrs = ['4063.T', 'AV.L', 'CNE.L', 'MOB.ST', 'SPM.MI']
         bad_tkrs.append('LA.V')  # special case - stock split error is 3 years ago! why not fixed?
@@ -590,14 +587,11 @@ class TestPriceRepair(unittest.TestCase):
             df_good = df_good.sort_index()
             repaired_df = repaired_df.sort_index()
             for c in ["Open", "Low", "High", "Close", "Adj Close", "Volume"]:
-                try:
-                    self.assertTrue((repaired_df[c].to_numpy() == df_good[c].to_numpy()).all())
-                except AssertionError:
-                    print(f"tkr={tkr} interval={interval} COLUMN={c}")
-                    df_dbg = df_good[[c]].join(repaired_df[[c]], lsuffix='.good', rsuffix='.repaired')
-                    f_diff = repaired_df[c].to_numpy() != df_good[c].to_numpy()
-                    print(df_dbg[f_diff | _np.roll(f_diff, 1) | _np.roll(f_diff, -1)])
-                    raise
+                _np.testing.assert_array_equal(
+                    repaired_df[c].to_numpy(),
+                    df_good[c].to_numpy(),
+                    err_msg=f"tkr={tkr} interval={interval} COLUMN={c}",
+                )
 
     def test_repair_bad_div_adjusts(self):
         bad_tkrs = []


### PR DESCRIPTION
## Summary

- compare unchanged repair output with NumPy's NaN-safe exact array assertion
- preserve exact shape and value checks while treating paired NaNs as equal
- apply the same comparison to both unchanged-data loops

Fixes #2926.

## Testing

- `ruff check tests/test_price_repair.py` — passed
- a focused exact comparison with paired NaNs — passed
- `python -m unittest tests.test_price_repair.TestPriceRepair.test_repair_bad_stock_splits` — the reported NaN comparison now passes; the live-data run later fails at the existing `4063.T` expected-repair assertion on line 557

## AI assistance

The change was developed with OpenAI Codex assistance, then reviewed and validated locally.
