### PR TITLE
Fix: NaN equality comparison 

### DIFF
--- a/tests/test_price_repair.py
+++ b/tests/test_price_repair.py
@@ -487,7 +487,7 @@ class TestPriceRepair(unittest.TestCase):
                 repaired_df = repaired_df.sort_index()
                 for c in ["Open", "Low", "High", "Close", "Adj Close", "Volume"]:
                     try:
-                        self.assertTrue((repaired_df[c].to_numpy() == df_good[c].to_numpy()).all())
+                        self.assertTrue(_np.isclose(repaired_df[c].to_numpy(), df_good[c].to_numpy(), equal_nan=True).all())
                     except Exception:
                         print(f"tkr={tkr} interval={interval} COLUMN={c}")
                         df_dbg = df_good[[c]].join(repaired_df[[c]], lsuffix='.good', rsuffix='.repaired')
@@ -554,7 +554,7 @@ class TestPriceRepair(unittest.TestCase):
             repaired_df = repaired_df.sort_index()
             for c in ["Open", "Low", "High", "Close", "Adj Close", "Volume"]:
                 try:
-                    self.assertTrue((repaired_df[c].to_numpy() == df_good[c].to_numpy()).all())
+                    self.assertTrue(_np.isclose(repaired_df[c].to_numpy(), df_good[c].to_numpy(), equal_nan=True).all())
                 except AssertionError:
                     print(f"tkr={tkr} interval={interval} COLUMN={c}")
                     df_dbg = df_good[[c]].join(repaired_df[[c]], lsuffix='.good', rsuffix='.repaired')


### PR DESCRIPTION
`test_repair_bad_stock_splits` was using `==` to compare numpy arrays which doesn't work when both arrays 
contains NaN values, since `NaN != NaN` in floating point. Replaced with 
`np.isclose(..., equal_nan=True)` in both comparison locations within the function.

**Before:**
```python
self.assertTrue((repaired_df[c].to_numpy() == df_good[c].to_numpy()).all())
```

**After:**
```python
self.assertTrue(_np.isclose(repaired_df[c].to_numpy(), df_good[c].to_numpy(), equal_nan=True).all())
```

Fixes #2926