### PR TITLE
docs: state download()'s actual returned index timezone contract

### DIFF
--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -98,6 +98,10 @@ def download(tickers, start=None, end=None, actions=False, threads=True,
         ignore_tz: bool
             When combining from different timezones, ignore that part of datetime.
             Default depends on interval. Intraday = False. Day+ = True.
+            Also controls the returned index's timezone: if True, the index is
+            tz-naive. If False (the intraday default), the index is converted
+            to the most common exchange timezone among the requested tickers
+            (before 1.4.0, this case always returned UTC instead; see CHANGELOG).
         rounding: bool
             Optional. Round values to 2 decimal places?
         timeout: None or float


### PR DESCRIPTION
## Summary

`download()`'s `ignore_tz` docstring explains the parameter's effect on combining timezones across tickers, but never states what timezone the returned index actually carries in either case.

This is a real gap I hit myself: since 1.4.0 (#2825, "Fix localized intraday download() always returning UTC"), `ignore_tz=False` (the intraday default) tz-converts to the most common exchange timezone among the requested tickers, instead of always UTC as before. That change is correct and in the changelog, but the docstring itself never said what to expect either before or after, so a caller relying on the old always-UTC behavior (e.g. asserting an exact timezone in their own tests) would only discover the change by diffing actual output against an unpinned upgrade, not from the docs.

## Change

Docstring only, no behavior change. Verified the exact contract against `reindex_dfs()`: `tz_localize(None)` when `ignore_tz=True` (tz-naive), `tz_convert(tz_mode)` (mode of each ticker's `index.tz`) when `ignore_tz=False`.

I did look into #2926 and #2924 first (both looked like open, unclaimed issues in this area) - #2926 turned out to already be fixed on `dev` via #2933 (just not yet released to `main`, left a comment there), and #2924 already has an accepted PR (#2927) from another contributor. This docstring gap is what was actually still open once I'd ruled those out.