### PR TITLE
Remove dead hide_exceptions override in _download_one

### DIFF
--- a/tests/test_download_concurrency.py
+++ b/tests/test_download_concurrency.py
@@ -5,10 +5,48 @@ DataFrame containing exactly the tickers they requested — no contamination,
 no exceptions — and that ``download()`` no longer relies on module-level
 dicts in ``yfinance.shared`` as scratch space.
 """
+import json
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
 
 from tests.context import yfinance as yf
+from yfinance.config import YfConfig
+from yfinance.data import YfData
+
+
+class TestDownloadGlobalConfig(unittest.TestCase):
+    """``download()`` must leave the global config exactly as it found it.
+
+    Runs offline: the fetch is stubbed out so every ticker fails, which is
+    the path that used to override the exception-hiding setting.
+    """
+
+    @staticmethod
+    def _boom(*args, **kwargs):
+        raise RuntimeError("simulated network failure")
+
+    def _download_offline(self):
+        with patch.object(YfData, "get", self._boom), \
+                patch.object(YfData, "cache_get", self._boom):
+            yf.download(["ZZZFAKE"], period="5d", threads=False, progress=False)
+
+    def test_download_leaves_network_config_untouched(self):
+        before = json.loads(repr(YfConfig.network))
+        self._download_offline()
+        self.assertEqual(json.loads(repr(YfConfig.network)), before)
+
+    def test_download_restores_hide_exceptions(self):
+        # Whatever the user set must survive a download, including the
+        # non-default value.
+        backup = YfConfig.debug.hide_exceptions
+        try:
+            for value in (True, False):
+                YfConfig.debug.hide_exceptions = value
+                self._download_offline()
+                self.assertEqual(YfConfig.debug.hide_exceptions, value)
+        finally:
+            YfConfig.debug.hide_exceptions = backup
 
 
 class TestDownloadConcurrency(unittest.TestCase):

--- a/yfinance/multi.py
+++ b/yfinance/multi.py
@@ -34,7 +34,6 @@ from ._http import new_session
 
 from . import Ticker, utils
 from .data import YfData
-from .config import YfConfig
 from .const import period_default
 
 
@@ -277,8 +276,6 @@ def _download_one(ctx, ticker, start=None, end=None,
     data = None
     sym = ticker.upper()
 
-    backup = YfConfig.network.hide_exceptions
-    YfConfig.network.hide_exceptions = False
     try:
         tkr = Ticker(ticker)
         data = tkr.history(
@@ -300,7 +297,5 @@ def _download_one(ctx, ticker, start=None, end=None,
             ctx.dfs[sym] = utils.empty_df()
             ctx.errors[sym] = repr(e)
             ctx.tracebacks[sym] = traceback.format_exc()
-
-    YfConfig.network.hide_exceptions = backup
 
     return data


### PR DESCRIPTION
## What

`_download_one()` (`yfinance/multi.py`) reads and writes `YfConfig.network.hide_exceptions` — but the flag lives in the **debug** section (`yfinance/config.py`), and all ~40 readers across the codebase check `YfConfig.debug.hide_exceptions`. Nothing anywhere reads `network.hide_exceptions`. The typo is silent because `NestedConfig.__getattr__` returns `None` for missing keys instead of raising.

Introduced in 4f38ecf ("Redesign YfConfig + small fixes", Dec 2025), which converted `history(raise_errors=True)` into this global override and typed `network` where every other conversion in the same commit correctly used `debug`. Two consequences:

1. The override has been a silent no-op since then — `download()`'s error-surfacing behaviour is actually provided by `PriceHistory._last_error`, which `_download_one` already consumes.
2. Every `yf.download()` call injects a bogus `"hide_exceptions": null` key into `yf.config.network` (the config dump documented in `doc/source/advanced/config.rst`).

## Why remove instead of retyping to `debug`

A naive `s/network/debug/` would introduce a real cross-thread race on the shared global: with `threads=True`, worker B can capture worker A's override (`False`) as its own "backup" and restore it, permanently flipping the user's `hide_exceptions=True` to `False` for all subsequent calls. I sequenced two threads deterministically and confirmed the user's setting is destroyed. Since `_last_error` already does the job the override was written for, removal is the safe fix. (Also removes the now-unused `YfConfig` import, which would otherwise fail ruff F401.)

Heads-up: open PR #2886 copies the `YfConfig.network.hide_exceptions` idiom into new code — not a competing fix, but worth catching in that review.

## Tests

New offline class `TestDownloadGlobalConfig` in `tests/test_download_concurrency.py` (module is already about download() not sharing global scratch state; `YfData.get`/`cache_get` stubbed to raise, no network):

- `test_download_leaves_network_config_untouched` — **red on dev** (`network` dict gains `'hide_exceptions': None`), green with the fix
- `test_download_restores_hide_exceptions` — forward guard pinning the user's `debug.hide_exceptions` across `download()`; passes on both sides today and would catch precisely the naive retype-to-debug fix

Offline suite: 26 passed, 1 xfailed. Ruff with the repo's exact CI invocation: all checks passed, identical before/after. Live smoke: `yf.download(['MSFT','AAPL'], threads=True)` returns shape (5, 10) with a clean `yf.config.network`.