### PR TITLE
fix: drop 'possibly delisted' speculation when Yahoo explains the error

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -483,6 +483,23 @@ class TestPriceHistory(unittest.TestCase):
         with self.assertRaises(YFPricesMissingError):
             dat.history(period="1mo", raise_errors=True)
 
+    def test_prices_missing_delisted_hint(self):
+        # Regression for #2902: when Yahoo explains the real cause,
+        # the "possibly delisted" speculation must be suppressed.
+        from yfinance.exceptions import YFPricesMissingError
+
+        msg_with_hint = str(YFPricesMissingError("SPY", ""))
+        self.assertTrue(msg_with_hint.startswith("$SPY: possibly delisted;"))
+
+        debug = ' (30m 2026-03-16 -> 2026-03-23) (Yahoo error = "The requested range must be within the last 60 days.")'
+        msg_no_hint = str(YFPricesMissingError("SPY", debug, delisted_hint=False))
+        self.assertTrue(msg_no_hint.startswith("$SPY: no price data found"))
+        self.assertNotIn("possibly delisted", msg_no_hint)
+        self.assertIn("The requested range must be within the last 60 days.", msg_no_hint)
+
+        # Default keeps the hint (backwards compatible)
+        self.assertIn("possibly delisted", str(YFPricesMissingError("SPY", debug)))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/yfinance/exceptions.py
+++ b/yfinance/exceptions.py
@@ -13,8 +13,11 @@ class YFNotImplementedError(NotImplementedError):
 
 
 class YFTickerMissingError(YFException):
-    def __init__(self, ticker, rationale):
-        super().__init__(f"${ticker}: possibly delisted; {rationale}")
+    def __init__(self, ticker, rationale, delisted_hint=True):
+        if delisted_hint:
+            super().__init__(f"${ticker}: possibly delisted; {rationale}")
+        else:
+            super().__init__(f"${ticker}: {rationale}")
         self.rationale = rationale
         self.ticker = ticker
 
@@ -25,12 +28,12 @@ class YFTzMissingError(YFTickerMissingError):
 
 
 class YFPricesMissingError(YFTickerMissingError):
-    def __init__(self, ticker, debug_info):
+    def __init__(self, ticker, debug_info, delisted_hint=True):
         self.debug_info = debug_info
         if debug_info != '':
-            super().__init__(ticker, f"no price data found {debug_info}")
+            super().__init__(ticker, f"no price data found {debug_info}", delisted_hint)
         else:
-            super().__init__(ticker, "no price data found")
+            super().__init__(ticker, "no price data found", delisted_hint)
 
 
 class YFEarningsDateMissing(YFTickerMissingError):

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -277,7 +277,7 @@ class PriceHistory:
             fail = True
         elif "chart" in data and data["chart"] and data["chart"]["error"]:
             _price_data_debug += ' (Yahoo error = "' + data["chart"]["error"]["description"] + '")'
-            _exception = YFPricesMissingError(self.ticker, _price_data_debug)
+            _exception = YFPricesMissingError(self.ticker, _price_data_debug, delisted_hint=False)
             fail = True
         elif "chart" not in data or not data["chart"] or data["chart"]["result"] is None or not data["chart"]["result"] or not data["chart"]["result"][0]["indicators"]["quote"][0]:
             _exception = YFPricesMissingError(self.ticker, _price_data_debug)


### PR DESCRIPTION
Closes #2902

## Problem

Every `YFPricesMissingError` message starts with `$TICKER: possibly delisted;` — even when Yahoo's chart response contains an explicit error description that states the real cause. Example from the issue:

```
$SPY: possibly delisted; no price data found  (30m 2026-03-16 -> 2026-03-23) (Yahoo error = "15m data not available for startTime=... The requested range must be within the last 60 days.")
```

SPY is not delisted; the request was outside the allowed range and Yahoo said so. The speculation sends users down the wrong path (see #1713, #1797, #2044, #2052). And when a ticker really is dead, Yahoo's own description already says "No data found, symbol may be delisted", so the prefix adds nothing there either.

## Change

- `YFTickerMissingError.__init__` and `YFPricesMissingError.__init__` gain a `delisted_hint` parameter (default `True`, so all existing callers and subclasses are unaffected).
- `history()` passes `delisted_hint=False` **only** in the branch where Yahoo returned an explicit `chart.error.description` (`yfinance/scrapers/history.py`).
- The hint is retained where Yahoo returns no data at all (e.g. `{"chart": null}` for a genuinely unknown ticker), per the issue's suggested fix.

```python
# before
$SPY: possibly delisted; no price data found  (30m ...) (Yahoo error = "The requested range must be within the last 60 days.")

# after
$SPY: no price data found  (30m ...) (Yahoo error = "The requested range must be within the last 60 days.")
```

## Verification

- `tests/test_prices.py::test_prices_missing_delisted_hint` — new unit test covering both message forms and backward compatibility of the default.
- Full `tests/test_prices.py` run: 22 passed, 2 skipped, 1 xfailed.