### PR TITLE
Fix _fetch_calendar using local timezone instead of UTC for event dates

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1045,6 +1045,48 @@ class TestTickerMiscFinancials(unittest.TestCase):
         data_cached = self.ticker.calendar
         self.assertIs(data, data_cached, "data not cached")
 
+    def test_calendar_dates_use_utc_not_local(self):
+        # Regression: _fetch_calendar must interpret Yahoo's calendar-event
+        # epoch (always UTC) as a UTC calendar date, not a local-timezone date.
+        # On a non-UTC machine the buggy code returned a date off by one day.
+        # We simulate a local timezone of UTC+13 (by swapping the datetime
+        # class for a wrapper) so the test fails even on UTC CI runners if the
+        # bug ever returns.
+        import datetime as _dt
+        from datetime import timezone, timedelta
+        from unittest.mock import patch
+
+        # 2024-01-01 12:00:00 UTC -> with a UTC+13 local tz the buggy code
+        # would render 2024-01-02.
+        ts = 1704110400
+        real_dt = _dt.datetime
+        expected = real_dt.fromtimestamp(ts, tz=timezone.utc).date()
+
+        fake_events = {
+            "quoteSummary": {"result": [{"calendarEvents": {
+                "dividendDate": ts,
+                "exDividendDate": ts,
+                "earnings": {"earningsDate": [ts]},
+            }}]}
+        }
+
+        class _LocalTzDatetime(real_dt):
+            @staticmethod
+            def fromtimestamp(ts_, tz=None):
+                if tz is not None:
+                    return real_dt.fromtimestamp(ts_, tz=tz)
+                # simulate a machine running in UTC+13
+                return real_dt.fromtimestamp(ts_, tz=timezone.utc) + timedelta(hours=13)
+
+        quote = self.ticker._quote
+        with patch.object(quote, "_fetch", return_value=fake_events):
+            with patch.object(_dt, "datetime", _LocalTzDatetime):
+                quote._fetch_calendar()
+
+        self.assertEqual(quote._calendar.get("Dividend Date"), expected)
+        self.assertEqual(quote._calendar.get("Ex-Dividend Date"), expected)
+        self.assertEqual(quote._calendar.get("Earnings Date"), [expected])
+
     # # sustainability stopped working
     # def test_sustainability(self):
     #     data = self.ticker.sustainability

--- a/yfinance/scrapers/quote.py
+++ b/yfinance/scrapers/quote.py
@@ -896,13 +896,13 @@ class Quote:
             self._calendar = dict()
             _events = result["quoteSummary"]["result"][0]["calendarEvents"]
             if 'dividendDate' in _events:
-                self._calendar['Dividend Date'] = datetime.datetime.fromtimestamp(_events['dividendDate']).date()
+                self._calendar['Dividend Date'] = datetime.datetime.fromtimestamp(_events['dividendDate'], tz=datetime.timezone.utc).date()
             if 'exDividendDate' in _events:
-                self._calendar['Ex-Dividend Date'] = datetime.datetime.fromtimestamp(_events['exDividendDate']).date()
+                self._calendar['Ex-Dividend Date'] = datetime.datetime.fromtimestamp(_events['exDividendDate'], tz=datetime.timezone.utc).date()
             # splits = _events.get('splitDate')  # need to check later, i will add code for this if found data
             earnings = _events.get('earnings')
             if earnings is not None:
-                self._calendar['Earnings Date'] = [datetime.datetime.fromtimestamp(d).date() for d in earnings.get('earningsDate', [])]
+                self._calendar['Earnings Date'] = [datetime.datetime.fromtimestamp(d, tz=datetime.timezone.utc).date() for d in earnings.get('earningsDate', [])]
                 self._calendar['Earnings High'] = earnings.get('earningsHigh', None)
                 self._calendar['Earnings Low'] = earnings.get('earningsLow', None)
                 self._calendar['Earnings Average'] = earnings.get('earningsAverage', None)


### PR DESCRIPTION
## Summary

`_fetch_calendar` converts Yahoo's calendar-event epochs (always **UTC** timestamps: `dividendDate`, `exDividendDate`, `earningsDate`) with `datetime.datetime.fromtimestamp(ts)` **without a timezone**. On any machine not running in UTC the resulting `.date()` was off by one day — e.g. a `2024-01-01 12:00 UTC` event rendered as `2024-01-02` in UTC+13.

This is related to the open issue #1726 (which refactors `calendar` but does not fix the timezone handling of these three date lines).

### Changes
- **yfinance/scrapers/quote.py** — the 3 `fromtimestamp(...)` calls in `_fetch_calendar` now pass `tz=datetime.timezone.utc`, consistent with the existing `fromtimestamp(..., tz=timezone.utc)` usage in `data.py`.
- **tests/test_ticker.py** — adds a deterministic regression test `test_calendar_dates_use_utc_not_local`: it swaps `datetime.datetime` for a UTC+13 wrapper (only the no-`tz` path is shifted) and asserts the returned Dividend / Ex-Dividend / Earnings dates equal the UTC date. The test **fails on the buggy code** and **passes after the fix** (verified locally).

### Validation
- Environment: Python 3.13 + numpy 2.5.1 + pandas 2.3.3.
- New test `tests.test_ticker.TestTickerMiscFinancials.test_calendar_dates_use_utc_not_local` passes; a negative control (reverting the 3 lines to the buggy form) makes it fail as expected.

### Checklist
- [x] Targets the `dev` branch (not `main`)
- [x] Self-contained, minimal change
- [x] Includes a regression test