### PR TITLE
Fix custom-period window start timezone (use exchange tz, bound events)

### DIFF
--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -1045,6 +1045,89 @@ class TestTickerMiscFinancials(unittest.TestCase):
         data_cached = self.ticker.calendar
         self.assertIs(data, data_cached, "data not cached")
 
+    def test_custom_period_start_uses_exchange_tz(self):
+        # Regression: _custom_period_start() must compute the window start as a
+        # date in the *exchange* timezone, independent of the machine's local
+        # timezone. The old code used datetime.date.fromtimestamp(ts) (local tz),
+        # which could shift the start by a day on non-UTC machines.
+        import datetime as _dt
+        import yfinance.scrapers.history as hist
+        from yfinance import utils
+
+        # Pick a timestamp where the exchange (NY, UTC-5) date differs from the
+        # UTC date, so the test still fails on a UTC CI runner if the code ever
+        # reverts to using local/UTC time.
+        end_ts = 1704074400  # 2024-01-01 02:00:00 UTC == 2023-12-31 21:00 NY
+        expected = (pd.Timestamp(end_ts, unit='s', tz='UTC')
+                     .tz_convert('America/New_York').date()
+                     - utils._interval_to_timedelta('10d')
+                     - _dt.timedelta(days=4))
+
+        got = hist._custom_period_start(end_ts, '10d', 'America/New_York')
+        self.assertEqual(got, expected)
+
+    def test_custom_period_binds_events_to_window(self):
+        # Regression: for a custom (non-standard) period, the returned
+        # dividends must be trimmed to the requested window start (exchange
+        # timezone) instead of to the first price row. The old code only used
+        # ``start`` as a non-None sentinel and trimmed from quotes.index[0],
+        # so an event between the first price row and the true window start was
+        # incorrectly kept.
+        import time as _time_mod
+        from unittest.mock import patch
+
+        end_ts = 1704110400  # 2024-01-01 12:00:00 UTC
+        tz_name = 'America/New_York'
+        day = 86400
+        n = 20
+        timestamps = [end_ts - (n - 1 - i) * day for i in range(n)]
+        closes = [float(100 + i) for i in range(n)]
+        indicators = {"quote": [{
+            "open": closes, "high": closes, "low": closes,
+            "close": closes, "volume": [1000] * n,
+        }]}
+        # Window start ~= end_ts - 14d (10d period + 4d buffer).
+        # div_between: after the first price row but before the window start ->
+        #   old code keeps it, fixed code drops it.
+        # div_inside: inside the window -> both keep it.
+        div_between = end_ts - 17 * day
+        div_inside = end_ts - 5 * day
+        events = {"dividends": {
+            str(div_between): {"date": div_between, "amount": 0.5},
+            str(div_inside): {"date": div_inside, "amount": 0.7},
+        }}
+        payload = {"chart": {"result": [{
+            "meta": {
+                "exchangeTimezoneName": tz_name,
+                "priceHint": 2,
+                "currency": "USD",
+                "instrumentType": "EQUITY",
+                "validRanges": ["1d", "5d", "1mo", "3mo", "1y", "max"],
+            },
+            "timestamp": timestamps,
+            "indicators": indicators,
+            "events": events,
+        }], "error": None}}
+
+        class _Resp:
+            text = "{}"
+
+            def json(self):
+                return payload
+
+        with patch("time.time", return_value=end_ts):
+            with patch("yfinance.data.YfData.get", return_value=_Resp()):
+                df = self.ticker.history(period="10d", interval="1d",
+                                         repair=False, actions=True,
+                                         auto_adjust=False)
+        # The returned frame's Dividends column reflects the (trimmed) events.
+        # div_inside is inside the window -> must be present (amount 0.7).
+        # div_between is between the first price row and the true window start
+        # -> the old code kept it, the fix drops it (amount 0.5).
+        divs = df['Dividends']
+        self.assertTrue((divs == 0.7).any(), "in-window dividend was dropped")
+        self.assertFalse((divs == 0.5).any(), "out-of-window dividend was kept")
+
     # # sustainability stopped working
     # def test_sustainability(self):
     #     data = self.ticker.sustainability

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -18,6 +18,20 @@ from yfinance.exceptions import YFDataException, YFInvalidPeriodError, YFPricesM
 
 _CURRENCY_CONVERSIONS = {'GBp': 0.01, 'ZAc': 0.01, 'ILA': 0.01}  # GBp = pence, ZAc = South African cents, ILA = Israeli agorot
 
+
+def _custom_period_start(end_ts, period, tz_name):
+    # Window start for a custom (non-standard) period, as a ``date`` in the
+    # exchange timezone. Convert the UTC epoch explicitly so the result is
+    # independent of the machine's local timezone -- the previous code used
+    # ``datetime.date.fromtimestamp()`` which is local-timezone dependent.
+    # Mirrors the convention used by the normal-period branch ("Convert period
+    # to start -> end").
+    start = pd.Timestamp(end_ts, unit='s', tz='UTC').tz_convert(tz_name).date()
+    start -= utils._interval_to_timedelta(period)
+    start -= _datetime.timedelta(days=4)
+    return start
+
+
 class HistoryMetadata(Mapping):
     """
     Dict-like lazy wrapper for PriceHistory metadata.
@@ -384,9 +398,10 @@ class PriceHistory:
         if period and period not in self._history_metadata.get("validRanges", []):
             end = int(_time.time())
             end_dt = pd.Timestamp(end, unit='s').tz_localize("UTC")
-            start = _datetime.date.fromtimestamp(end)
-            start -= utils._interval_to_timedelta(period)
-            start -= _datetime.timedelta(days=4)
+            # Window start in the exchange timezone (see _custom_period_start).
+            # Previously this used date.fromtimestamp(end) which is local-timezone
+            # dependent and could shift the start by a day on non-UTC machines.
+            start = _custom_period_start(end, period, tz_exchange)
 
         # parse quotes
         quotes = utils.parse_quotes(data["chart"]["result"][0])
@@ -472,7 +487,14 @@ class PriceHistory:
             self._capital_gains = pd.Series()
         if start is not None:
             if not quotes.empty:
-                start_d = quotes.index[0].floor('D')
+                if isinstance(start, _datetime.date):
+                    # Custom-period request: ``start`` is the window start as a date
+                    # in the exchange timezone (computed above). Bound the returned
+                    # events to it instead of to the first price row, so events
+                    # outside the requested window are dropped.
+                    start_d = pd.Timestamp(start, tz=tz_exchange)
+                else:
+                    start_d = quotes.index[0].floor('D')
                 if dividends is not None:
                     dividends = dividends.loc[start_d:]
                 if capital_gains is not None:


### PR DESCRIPTION
## Summary
For custom (non-standard) periods, `PriceHistory.history()` computed the window start with `datetime.date.fromtimestamp(end)`, which is **local-timezone dependent**, and then only used the value as a non-`None` sentinel — the actual trimming of dividends/splits/capital-gains used the first price row instead.

This PR makes the start computation correct **and** actually uses it:
- Compute the window start in the **exchange timezone** via the UTC epoch, independent of the machine's local timezone (consistent with the normal-period branch, e.g. `pd.Timestamp.now('UTC').tz_convert(tz).date()`).
- Use that start date to trim the returned events to the requested window, instead of only gating on `start` being set.

The start computation was extracted into `_custom_period_start()` for clarity.

## Why this matters
On a non-UTC machine (e.g. UTC+8) the old `fromtimestamp(end)` could shift the window start by a day. More importantly, the old code never bounded events by the custom period at all, so dividend/split/capital-gains rows that fell before the first price row but outside the requested window were incorrectly kept.

## Tests
- `test_custom_period_start_uses_exchange_tz` — asserts the helper returns the exchange-timezone date (fails if it ever reverts to local/UTC time).
- `test_custom_period_binds_events_to_window` — end-to-end (mocked fetch): a dividend between the first price row and the true window start is dropped by the fix, but was kept before.

## Scope / risk
Minimal: only the custom-period branch is touched. The `isinstance(start, date)` guard ensures the normal / `max` / user-start paths (where `start` is an int epoch) are unchanged.
