### PR TITLE
Improve robustness of `YfData` when behind a SOCKS5 proxy

### DIFF
--- a/tests/test_cookie_crumb_degradation.py
+++ b/tests/test_cookie_crumb_degradation.py
@@ -1,0 +1,122 @@
+import unittest
+from unittest import mock
+
+from yfinance._http import requests
+from yfinance.data import SingletonMeta, YfData
+
+
+def _mock_response(status_code=200, text="", url="https://query1.finance.yahoo.com/v8/finance/chart/AAPL"):
+    resp = mock.MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.content = text.encode() or b"<html></html>"
+    resp.url = url
+    resp.json.return_value = {}
+    return resp
+
+
+class _DegradeTestBase(unittest.TestCase):
+    """YfData is a singleton: use throwaway instances so mocked state
+    cannot leak into other tests."""
+
+    def setUp(self):
+        SingletonMeta._instances.pop(YfData, None)
+        self.data = YfData()
+        self.data._cookie = None
+        self.data._crumb = None
+        self._no_persistent_cookie = mock.patch.object(
+            YfData, '_load_cookie_curlCffi', return_value=False)
+        self._no_persistent_cookie.start()
+
+    def tearDown(self):
+        self._no_persistent_cookie.stop()
+        SingletonMeta._instances.pop(YfData, None)
+
+
+class TestCookieFetchDegradation(_DegradeTestBase):
+    def test_fc_yahoo_timeout_is_not_fatal(self):
+        # fc.yahoo.com timing out behind a SOCKS5 proxy must degrade,
+        # not abort the eventual data request.
+        self.data._session.get = mock.MagicMock(
+            side_effect=requests.exceptions.Timeout("curl: (28) Connection timed out"))
+        self.assertFalse(self.data._get_cookie_basic())
+
+    def test_getcrumb_429_degrades_to_no_crumb_request(self):
+        # getcrumb returning 429 must not abort the request: chart API
+        # works without a crumb.
+        def fake_get(url=None, **kwargs):
+            if 'fc.yahoo.com' in url:
+                return _mock_response(200, url=url)
+            if 'getcrumb' in url:
+                return _mock_response(429, "Too Many Requests", url=url)
+            return _mock_response(200, "{}", url=url)
+
+        self.data._session.get = mock.MagicMock(side_effect=fake_get)
+        with mock.patch.object(YfData, '_load_cookie_curlCffi', return_value=False):
+            resp = self.data.get('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')
+        self.assertEqual(resp.status_code, 200)
+        sent_kwargs = self.data._session.get.call_args
+        self.assertNotIn('crumb', str(sent_kwargs))
+    def test_transient_crumb_failure_degrades(self):
+        # A timeout on getcrumb must not abort the chart request either.
+        def fake_get(url=None, **kwargs):
+            if 'fc.yahoo.com' in url:
+                return _mock_response(200, url=url)
+            if 'getcrumb' in url:
+                raise requests.exceptions.Timeout("timed out")
+            return _mock_response(200, '{"chart": {}}', url=url)
+
+        self.data._session.get = mock.MagicMock(side_effect=fake_get)
+        with mock.patch.object(YfData, '_load_cookie_curlCffi', return_value=False):
+            resp = self.data.get('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')
+        self.assertEqual(resp.status_code, 200)
+
+    def test_target_429_still_raises_rate_limit(self):
+        # Degrading cookie/crumb must not hide genuine Yahoo rate limiting:
+        # when the target endpoint itself 429s, YFRateLimitError is raised.
+        def fake_get(url=None, **kwargs):
+            if 'fc.yahoo.com' in url:
+                raise requests.exceptions.ConnectionError("proxy down")
+            if 'getcrumb' in url:
+                raise requests.exceptions.Timeout("timed out")
+            return _mock_response(429, "Too Many Requests", url=url)
+
+        from yfinance.exceptions import YFRateLimitError
+        self.data._session.get = mock.MagicMock(side_effect=fake_get)
+        try:
+            self.data.get('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')
+            self.fail("expected YFRateLimitError")
+        except YFRateLimitError:
+            pass
+
+    def test_custom_proxies_not_overwritten(self):
+        # A user-supplied SOCKS5 proxy mapping must survive being passed
+        # to yfinance.
+        proxy_map = {"http": "socks5h://127.0.0.1:1080",
+                     "https": "socks5h://127.0.0.1:1080"}
+        session = requests.Session()
+        session.proxies = dict(proxy_map)
+        try:
+            data = YfData(session=session)
+            self.assertEqual(data._session.proxies, proxy_map)
+        finally:
+            SingletonMeta._instances.pop(YfData, None)
+
+    def test_make_request_does_not_wipe_session_proxies(self):
+        # Regression: _make_request() used to reset session proxies to the
+        # global config value (None by default), silently disabling a
+        # SOCKS5 proxy configured directly on the session.
+        proxy_map = {"http": "socks5h://127.0.0.1:1080",
+                     "https": "socks5h://127.0.0.1:1080"}
+        self.data._session.proxies = dict(proxy_map)
+        self.data._session.get = mock.MagicMock(
+            return_value=_mock_response(200, '{"chart": {}}'))
+        with mock.patch.object(YfData, '_load_cookie_curlCffi', return_value=False), \
+             mock.patch.object(YfData, '_get_cookie_and_crumb',
+                               return_value=(None, 'basic')):
+            self.data.get('https://query1.finance.yahoo.com/v8/finance/chart/AAPL')
+        self.assertEqual(self.data._session.proxies, proxy_map)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yfinance/data.py
+++ b/yfinance/data.py
@@ -243,6 +243,15 @@ class YfData(metaclass=SingletonMeta):
             # Can ignore because have second strategy.
             utils.get_yf_logger().debug("Handling DNS error on cookie fetch: " + str(e))
             return False
+        except Exception as e:
+            if _is_transient_error(e):
+                # fc.yahoo.com is non-critical: chart API works without its
+                # cookie. Degrade instead of aborting the data request
+                # (common behind SOCKS5 proxies where fc.yahoo.com times out).
+                utils.get_yf_logger().warning(
+                    f"Cookie fetch from fc.yahoo.com failed ({type(e).__name__}), continuing without it")
+                return False
+            raise
         self._save_cookie_curlCffi()
         return True
 
@@ -418,15 +427,31 @@ class YfData(metaclass=SingletonMeta):
             utils.get_yf_logger().debug(f'url={url}')
         utils.get_yf_logger().debug(f'params={params}')
 
-        # sync with config
-        self._session.proxies = _normalize_proxy(YfConfig.network.proxy)
+        # sync with config, but never wipe proxies set directly on a
+        # user-supplied session (e.g. SOCKS5 via curl_cffi)
+        if YfConfig.network.proxy is not None:
+            self._session.proxies = _normalize_proxy(YfConfig.network.proxy)
 
         if params is None:
             params = {}
         if 'crumb' in params:
             raise YFException("Don't manually add 'crumb' to params dict, let data.py handle it")
 
-        crumb, strategy = self._get_cookie_and_crumb()
+        try:
+            crumb, strategy = self._get_cookie_and_crumb()
+        except YFRateLimitError:
+            # getcrumb is rate-limited but the target endpoint may not need
+            # a crumb (e.g. chart API). Let the actual request decide.
+            utils.get_yf_logger().warning(
+                "Crumb fetch rate-limited (HTTP 429), continuing without crumb")
+            crumb, strategy = None, self._cookie_strategy
+        except Exception as e:
+            if _is_transient_error(e):
+                utils.get_yf_logger().warning(
+                    f"Cookie/crumb fetch failed ({type(e).__name__}), continuing without crumb")
+                crumb, strategy = None, self._cookie_strategy
+            else:
+                raise
         if crumb is not None:
             crumbs = {'crumb': crumb}
         else:
@@ -457,12 +482,22 @@ class YfData(metaclass=SingletonMeta):
         utils.get_yf_logger().debug(f'response code={response.status_code}')
         if response.status_code >= 400:
             # Retry with other cookie strategy
-            if strategy == 'basic':
-                self._set_cookie_strategy('csrf')
-            else:
-                self._set_cookie_strategy('basic')
-            crumb, strategy = self._get_cookie_and_crumb(timeout)
-            request_args['params']['crumb'] = crumb
+            try:
+                if strategy == 'basic':
+                    self._set_cookie_strategy('csrf')
+                else:
+                    self._set_cookie_strategy('basic')
+                crumb, strategy = self._get_cookie_and_crumb(timeout)
+            except YFRateLimitError:
+                crumb = None
+            except Exception as e:
+                if not _is_transient_error(e):
+                    raise
+                crumb = None
+            if 'crumb' in request_args['params']:
+                del request_args['params']['crumb']
+            if crumb is not None:
+                request_args['params']['crumb'] = crumb
             response = request_method(**request_args)
             utils.get_yf_logger().debug(f'response code={response.status_code}')
 


### PR DESCRIPTION
## Summary

Fixes four related robustness problems in `YfData` that break `history()` behind SOCKS5 proxies, even when the chart API itself is reachable:

1. **Proxy wipe (the critical bug).** `_make_request()` unconditionally ran
   `self._session.proxies = _normalize_proxy(YfConfig.network.proxy)`. With no global proxy configured (the default), this reset `proxies=None`, silently disabling any SOCKS5 proxy the user set directly on their `curl_cffi` session → all data requests timed out (`curl: (28)`), while direct use of the same session worked.
   Now proxies are only overwritten when `YfConfig.network.proxy is not None`.

2. **`fc.yahoo.com` timeouts were fatal.** `_get_cookie_basic()` caught only `DNSError`; a curl error 28 (common for `fc.yahoo.com` through proxies) aborted the entire data request. Transient errors are now handled like DNS errors: log a warning and continue without the cookie (the chart API doesn't need it).

3. **Crumb fetch 429/timeouts were fatal.** `_get_crumb_basic()` raised `YFRateLimitError` on 429 and transient network errors propagated out of `_get_cookie_and_crumb()`, aborting requests to endpoints (e.g. chart API) that work without a crumb. `_make_request()` now degrades to a crumb-less request. Endpoints that do require a crumb still surface their own failure and trigger the existing cookie-strategy-toggle retry; a genuine 429 from the target endpoint still raises `YFRateLimitError`.

4. **`'crumb': None` written into params.** In the >=400 retry branch, a failed secondary crumb fetch put `crumb=None` into the request params. Now a failed refetch simply omits the parameter.

No public API changes. Cookie/crumb reuse and both cookie strategies are untouched.

## Testing

New test module `tests/test_cookie_crumb_degradation.py`:

- `test_fc_yahoo_timeout_is_not_fatal` — timeout degrades instead of raising
- `test_getcrumb_429_degrades_to_no_crumb_request` — 429 on getcrumb, chart still 200
- `test_transient_crumb_failure_degrades` — getcrumb timeout, chart still 200
- `test_target_429_still_raises_rate_limit` — real rate limiting still surfaces
- `test_custom_proxies_not_overwritten` / `test_make_request_does_not_wipe_session_proxies` — regression tests for the proxy wipe

All pass locally alongside existing `tests/test_data.py` (21 passed); `ruff check` clean.

Real-world verification with `socks5h://` + `curl_cffi` (firefox impersonation, HTTP/2):

```
✅ proxy check: HTTP 200, HTTP/3
✅ crumb check: HTTP 200, HTTP/3
Fetching 005930.KS history...
✅ got 14 rows
```
