### PR TITLE
fix: set business-day freq on daily price history

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -32,6 +32,20 @@ class TestPriceHistory(unittest.TestCase):
                 f = df.index.time == _dt.time(0)
                 self.assertTrue(f.all())
 
+    def test_daily_freq(self):
+        # Daily data should expose a business-day frequency so that
+        # downstream libraries (e.g. sktime) can rely on it (issue #1083).
+        tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
+        for tkr in tkrs:
+            dat = yf.Ticker(tkr, session=self.session)
+            df = dat.history(period="1mo", interval="1d")
+            if df.empty:
+                continue
+            self.assertIsNotNone(df.index.freq,
+                                 f"daily freq missing for {tkr}")
+            self.assertEqual(df.index.freq, _pd.offsets.BDay(),
+                             f"daily freq wrong for {tkr}: {df.index.freq}")
+
     def test_download_multi_large_interval(self):
         tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
         intervals = ["1d", "1wk", "1mo"]

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -635,6 +635,16 @@ class PriceHistory:
             msg = f'{self.ticker}: yfinance returning OHLC: {df.index[0]} -> {df.index[-1]}'
         logger.debug(msg)
 
+        # Set freq on daily data so downstream libraries (e.g. sktime) can
+        # rely on a meaningful frequency instead of None.
+        if interval_user == "1d" and not df.empty:
+            try:
+                df.index.freq = pd.offsets.BDay()
+            except ValueError:
+                # Index contains gaps (e.g. long trading halts, delisting) so
+                # a regular business-day frequency cannot be set.
+                pass
+
         # Don't care that Pandas hid this. If they do it to improve performance, we do it.
         df = df._consolidate()
 


### PR DESCRIPTION
Set index.freq to BusinessDay on daily (1d) price history so that
downstream libraries (e.g. sktime) can infer the frequency instead of
receiving None.

- Only applies to daily intervals; weekly/monthly/intraday untouched.
- Wrapped in try/except so indices with gaps (trading halts, delisting)
  degrade gracefully and keep returning data as before.
- Adds a regression test (`test_daily_freq`).

Fixes #1083