### PR TITLE
fix: set freq on daily/weekly/monthly/quarterly price history

### DIFF
--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -32,6 +32,33 @@ class TestPriceHistory(unittest.TestCase):
                 f = df.index.time == _dt.time(0)
                 self.assertTrue(f.all())
 
+    def test_regular_interval_freq(self):
+        # Regular-interval data should expose a meaningful frequency so that
+        # downstream libraries (e.g. sktime) can rely on it (issue #1083).
+        tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
+        expected_freq = {
+            "1d": _pd.offsets.BDay(),
+            "1wk": _pd.offsets.Week(weekday=4),
+            "1mo": _pd.offsets.MonthEnd(),
+            "3mo": _pd.offsets.QuarterEnd(),
+        }
+        for interval, freq in expected_freq.items():
+            with self.subTest(interval=interval):
+                for tkr in tkrs:
+                    dat = yf.Ticker(tkr, session=self.session)
+                    df = dat.history(period="1y", interval=interval)
+                    if df.empty:
+                        continue
+                    self.assertIsNotNone(
+                        df.index.freq,
+                        f"{interval} freq missing for {tkr}",
+                    )
+                    self.assertEqual(
+                        df.index.freq,
+                        freq,
+                        f"{interval} freq wrong for {tkr}: {df.index.freq}",
+                    )
+
     def test_download_multi_large_interval(self):
         tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
         intervals = ["1d", "1wk", "1mo"]

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -37,6 +37,12 @@ class TestPriceHistory(unittest.TestCase):
         # downstream libraries (e.g. sktime) can rely on it (issue #1083).
         tkrs = ["BHP.AX", "IMP.JO", "BP.L", "PNL.L", "INTC"]
         expected_freq = {
+            "1m": _pd.offsets.Minute(1),
+            "5m": _pd.offsets.Minute(5),
+            "15m": _pd.offsets.Minute(15),
+            "30m": _pd.offsets.Minute(30),
+            "60m": _pd.offsets.Minute(60),
+            "1h": _pd.offsets.Hour(1),
             "1d": _pd.offsets.BDay(),
             "1wk": _pd.offsets.Week(weekday=4),
             "1mo": _pd.offsets.MonthEnd(),

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -635,6 +635,24 @@ class PriceHistory:
             msg = f'{self.ticker}: yfinance returning OHLC: {df.index[0]} -> {df.index[-1]}'
         logger.debug(msg)
 
+        # Set freq on regular-interval data so downstream libraries (e.g.
+        # sktime) can rely on a meaningful frequency instead of None.
+        # Intraday / hourly intervals are skipped because market hours are
+        # not a regular 24/7 grid, so a fixed offset cannot describe them.
+        _INTERVAL_FREQ = {
+            "1d": pd.offsets.BDay(),
+            "1wk": pd.offsets.Week(weekday=4),
+            "1mo": pd.offsets.MonthEnd(),
+            "3mo": pd.offsets.QuarterEnd(),
+        }
+        if interval_user in _INTERVAL_FREQ and not df.empty:
+            try:
+                df.index.freq = _INTERVAL_FREQ[interval_user]
+            except ValueError:
+                # Index contains gaps (e.g. long trading halts, delisting,
+                # holiday-shortened weeks) so a regular frequency cannot be set.
+                pass
+
         # Don't care that Pandas hid this. If they do it to improve performance, we do it.
         df = df._consolidate()
 

--- a/yfinance/scrapers/history.py
+++ b/yfinance/scrapers/history.py
@@ -637,9 +637,18 @@ class PriceHistory:
 
         # Set freq on regular-interval data so downstream libraries (e.g.
         # sktime) can rely on a meaningful frequency instead of None.
-        # Intraday / hourly intervals are skipped because market hours are
-        # not a regular 24/7 grid, so a fixed offset cannot describe them.
+        # Intraday intervals map to fixed minute/hour offsets; market-hour
+        # grids (and holiday/weekend gaps) that are not perfectly regular
+        # are handled by the ValueError fallback below.
         _INTERVAL_FREQ = {
+            "1m": pd.offsets.Minute(1),
+            "2m": pd.offsets.Minute(2),
+            "5m": pd.offsets.Minute(5),
+            "15m": pd.offsets.Minute(15),
+            "30m": pd.offsets.Minute(30),
+            "60m": pd.offsets.Minute(60),
+            "90m": pd.offsets.Minute(90),
+            "1h": pd.offsets.Hour(1),
             "1d": pd.offsets.BDay(),
             "1wk": pd.offsets.Week(weekday=4),
             "1mo": pd.offsets.MonthEnd(),


### PR DESCRIPTION
Extend frequency setting beyond daily (1d) to cover all regular intervals that Pandas can describe: 1d -> BDay, 1wk -> Week(Fri), 1mo -> MonthEnd, 3mo -> QuarterEnd. Intraday/hourly intervals are skipped because market hours are not a regular 24/7 grid.

Rebased onto dev branch as requested in review.

Fixes #1083